### PR TITLE
Add optional recipient field for intent outputs

### DIFF
--- a/src/lib/libraries/intentFactory.ts
+++ b/src/lib/libraries/intentFactory.ts
@@ -59,6 +59,7 @@ function toCoreCreateIntentOptions(opts: AppCreateIntentOptions): CreateIntentOp
 			outputTokens: opts.outputTokens.map(toCoreTokenContext),
 			verifier: opts.verifier,
 			account,
+			outputRecipient: opts.outputRecipient,
 			lock: {
 				type: "compact",
 				resetPeriod: opts.lock.resetPeriod,
@@ -73,6 +74,7 @@ function toCoreCreateIntentOptions(opts: AppCreateIntentOptions): CreateIntentOp
 		outputTokens: opts.outputTokens.map(toCoreTokenContext),
 		verifier: opts.verifier,
 		account,
+		outputRecipient: opts.outputRecipient,
 		lock: {
 			type: "escrow"
 		}

--- a/src/lib/screens/IssueIntent.svelte
+++ b/src/lib/screens/IssueIntent.svelte
@@ -34,12 +34,16 @@
 	const resolveExclusiveFor = (value: string): `0x${string}` | undefined =>
 		isAddress(value, { strict: false }) ? value : undefined;
 
+	const resolveRecipient = (value: string): `0x${string}` | undefined =>
+		isAddress(value, { strict: false }) ? value : undefined;
+
 	const intentOptions = $derived.by(
 		(): AppCreateIntentOptions => ({
 			exclusiveFor: resolveExclusiveFor(store.exclusiveFor),
 			inputTokens: store.inputTokens,
 			outputTokens: store.outputTokens,
 			verifier: store.verifier,
+			outputRecipient: resolveRecipient(store.recipient),
 			lock:
 				store.intentType === "compact"
 					? {
@@ -276,6 +280,19 @@
 
 		<SectionCard compact>
 			<div class="flex flex-col gap-2">
+				<div class="flex min-w-0 items-center gap-1">
+					<span class="text-[11px] font-semibold whitespace-nowrap text-gray-500">Recipient</span>
+					<FormControl
+						type="text"
+						size="sm"
+						className="flex-1"
+						placeholder="0x... (optional)"
+						state={store.recipient.length > 0 && !resolveRecipient(store.recipient)
+							? "error"
+							: "default"}
+						bind:value={store.recipient}
+					/>
+				</div>
 				<div class="flex items-center gap-1">
 					<span class="text-[11px] font-semibold text-gray-500">Verifier</span>
 					{#if sameChain}
@@ -313,15 +330,7 @@
 		</SectionCard>
 
 		<div class="mt-2 flex justify-center">
-			{#if !true}
-				<button
-					type="button"
-					class="h-8 rounded border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-400"
-					disabled
-				>
-					Input must be exactly raw 100 USDC
-				</button>
-			{:else if !allowanceCheck}
+			{#if !allowanceCheck}
 				<AwaitButton buttonFunction={approveFunction}>
 					{#snippet name()}
 						Set allowance

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -273,6 +273,7 @@ class Store {
 	allocatorId = $state<availableAllocators>(ALWAYS_OK_ALLOCATOR);
 	verifier = $state<Verifier>("polymer");
 	exclusiveFor: string = $state("");
+	recipient: string = $state("");
 	useExclusiveForQuoteRequest = $state(false);
 
 	invalidateWalletReadCache(scope: "all" | "balance" | "allowance" | "compact" = "all") {

--- a/tests/unit/recipientField.test.ts
+++ b/tests/unit/recipientField.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { isAddress } from "viem";
+
+// Mirrors the resolveRecipient helper in IssueIntent.svelte
+const resolveRecipient = (value: string): `0x${string}` | undefined =>
+	isAddress(value, { strict: false }) ? (value as `0x${string}`) : undefined;
+
+describe("resolveRecipient", () => {
+	it("returns the address for a valid checksummed EVM address", () => {
+		const addr = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+		expect(resolveRecipient(addr)).toBe(addr);
+	});
+
+	it("returns the address for a valid lowercase EVM address (strict: false)", () => {
+		const addr = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
+		expect(resolveRecipient(addr)).toBe(addr);
+	});
+
+	it("returns undefined for an empty string", () => {
+		expect(resolveRecipient("")).toBeUndefined();
+	});
+
+	it("returns undefined for a partial address", () => {
+		expect(resolveRecipient("0x1234")).toBeUndefined();
+	});
+
+	it("returns undefined for arbitrary non-address text", () => {
+		expect(resolveRecipient("alice.eth")).toBeUndefined();
+	});
+
+	it("returns undefined for a hex string that is too long", () => {
+		expect(resolveRecipient("0x" + "a".repeat(42))).toBeUndefined();
+	});
+});
+
+describe("outputRecipient in AppCreateIntentOptions", () => {
+	it("is undefined when recipient field is empty", () => {
+		const recipient = "";
+		const outputRecipient = resolveRecipient(recipient);
+		expect(outputRecipient).toBeUndefined();
+	});
+
+	it("is set when a valid address is provided", () => {
+		const recipient = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+		const outputRecipient = resolveRecipient(recipient);
+		expect(outputRecipient).toBe(recipient);
+	});
+
+	it("is undefined for an invalid address, so wallet default is used", () => {
+		const recipient = "not-an-address";
+		const outputRecipient = resolveRecipient(recipient);
+		expect(outputRecipient).toBeUndefined();
+	});
+});


### PR DESCRIPTION
**Linear:** https://linear.app/lifi-linear/issue/V2-116/add-recipient-field-on-lintentorg

## Summary

- Adds an optional `recipient` field to global store (`state.svelte.ts`)
- Surfaces a **Recipient** address input in the IssueIntent screen (accepts any EVM address, validates on-the-fly)
- Threads `outputRecipient` through `intentFactory.ts` to `toCoreCreateIntentOptions` for both compact and escrow paths

## Notes

- Stacked on `asem/V2-109/accommodate-intent.ts-solana-changes`
- Field is optional — leaving it blank uses the default recipient behaviour from the intent library

## Test plan

- [x] Open IssueIntent screen, verify Recipient input appears under the Verifier controls
- [x] Enter an invalid string — confirm the field turns red (error state)
- [x] Enter a valid EVM address — confirm error state clears
- [x] Submit an intent with a custom recipient and verify the order's output `recipient` reflects the input address

## Expected output

https://github.com/user-attachments/assets/e6da07fd-3b7d-4ef9-aac4-d35b32ad2154