### PR TITLE
feat: issue evm to solana orders

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Run checks
         run: bun run check
+        env:
+          PRIVATE_POLYMER_MAINNET_ZONE_API_KEY: ${{ secrets.PRIVATE_POLYMER_MAINNET_ZONE_API_KEY }}
+          PRIVATE_POLYMER_TESTNET_ZONE_API_KEY: ${{ secrets.PRIVATE_POLYMER_TESTNET_ZONE_API_KEY }}
+          PUBLIC_WALLET_CONNECT_PROJECT_ID: ${{ secrets.PUBLIC_WALLET_CONNECT_PROJECT_ID }}
       - name: Run unit tests
         run: bun run test:unit
       - name: Upload coverage artifact

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "cat-swapper",
       "dependencies": {
         "@electric-sql/pglite": "^0.3.15",
-        "@lifi/intent": "0.0.3-alpha.1",
+        "@lifi/intent": "0.0.4",
         "@metamask/sdk": "^0.34.0",
         "@sveltejs/adapter-cloudflare": "^7.0.3",
         "@wagmi/connectors": "^7.2.1",
@@ -219,7 +219,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.29", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="],
 
-    "@lifi/intent": ["@lifi/intent@0.0.3-alpha.1", "", { "dependencies": { "ky": "^1.12.0", "viem": "~2.45.1" } }, "sha512-dzEcS8U5buW7nLpkMmC0kj5R7EQC7l8l1mBd9IWr6R5/vSnSF3kO9zVaNQOmrbezSOS9TROrOpGDUWc847d/Uw=="],
+    "@lifi/intent": ["@lifi/intent@0.0.4", "", { "dependencies": { "borsh": "^2.0.0", "ky": "^1.12.0", "viem": "~2.45.1" } }, "sha512-T9wJGAY6sW6JcunEusXIvehxZcg2pRkaK0b+PUpSje2234yfZSmmcUPS1QTRxB6Iq6XROYopl6aUBIqzTHznew=="],
 
     "@metamask/json-rpc-engine": ["@metamask/json-rpc-engine@8.0.2", "", { "dependencies": { "@metamask/rpc-errors": "^6.2.1", "@metamask/safe-event-emitter": "^3.0.0", "@metamask/utils": "^8.3.0" } }, "sha512-IoQPmql8q7ABLruW7i4EYVHWUbF74yrp63bRuXV5Zf9BQwcn5H9Ww1eLtROYvI1bUXwOiHZ6qT5CWTrDc/t/AA=="],
 
@@ -440,6 +440,8 @@
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
+    "borsh": ["borsh@2.0.0", "", {}, "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
 		"vite": "^7.1.1"
 	},
 	"dependencies": {
-		"@lifi/intent": "0.0.3-alpha.1",
 		"@electric-sql/pglite": "^0.3.15",
+		"@lifi/intent": "0.0.4",
 		"@metamask/sdk": "^0.34.0",
 		"@sveltejs/adapter-cloudflare": "^7.0.3",
 		"@wagmi/connectors": "^7.2.1",

--- a/src/lib/components/InputTokenModal.svelte
+++ b/src/lib/components/InputTokenModal.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-	import { clientsById, coinList, getChainName, type Token } from "$lib/config";
-	const evmCoinList = (mainnet: boolean) =>
-		coinList(mainnet).filter((t) => !!clientsById[t.chainId]);
+	import { evmCoinList, getChainName, type Token } from "$lib/config";
 	import FieldRow from "$lib/components/ui/FieldRow.svelte";
 	import FormControl from "$lib/components/ui/FormControl.svelte";
 	import InlineMetaField from "$lib/components/ui/InlineMetaField.svelte";

--- a/src/lib/components/InputTokenModal.svelte
+++ b/src/lib/components/InputTokenModal.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-	import { coinList, getChainName, type Token } from "$lib/config";
+	import { clientsById, coinList, getChainName, type Token } from "$lib/config";
+	const evmCoinList = (mainnet: boolean) =>
+		coinList(mainnet).filter((t) => !!clientsById[t.chainId]);
 	import FieldRow from "$lib/components/ui/FieldRow.svelte";
 	import FormControl from "$lib/components/ui/FormControl.svelte";
 	import InlineMetaField from "$lib/components/ui/InlineMetaField.svelte";
@@ -80,7 +82,7 @@
 
 	const uniqueInputTokens = $derived([
 		...new Set(
-			coinList(store.mainnet)
+			evmCoinList(store.mainnet)
 				.map((v) => v.name)
 				.filter((v) => v !== "eth")
 		)
@@ -89,7 +91,9 @@
 	// svelte-ignore state_referenced_locally
 	let selectedTokenName = $state<string>(currentInputTokens[0].token.name);
 	const tokenSet = $derived(
-		coinList(store.mainnet).filter((v) => v.name.toLowerCase() === selectedTokenName.toLowerCase())
+		evmCoinList(store.mainnet).filter(
+			(v) => v.name.toLowerCase() === selectedTokenName.toLowerCase()
+		)
 	);
 
 	let circuitBreaker = false;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -62,9 +62,9 @@ export const solanaDevnet = defineChain({
 	testnet: true
 });
 
+// Source: PDA(seed: "polymer", program: SOLANA_POLYMER_ORACLE) — confirmed in default_orders.json
 const SOLANA_POLYMER_ORACLE_DEVNET =
 	"0xe48a6f95df84c28a030f60ba5b74e4a02922a4a5724c9633109f089b2287edfc" as const;
-// Source: PDA(seed: "polymer", program: SOLANA_POLYMER_ORACLE) — confirmed in default_orders.json
 export const WORMHOLE_ORACLE: Partial<Record<number, `0x${string}`>> = {
 	[ethereum.id]: "0x0000000000000000000000000000000000000000",
 	[arbitrum.id]: "0x0000000000000000000000000000000000000000",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -26,6 +26,10 @@ export const MULTICHAIN_INPUT_SETTLER_COMPACT =
 export const ALWAYS_OK_ALLOCATOR = "281773970620737143753120258" as const;
 export const POLYMER_ALLOCATOR = "116450367070547927622991121" as const; // 0x02ecC89C25A5DCB1206053530c58E002a737BD11 signing by 0x934244C8cd6BeBDBd0696A659D77C9BDfE86Efe6
 export const COIN_FILLER = "0x0000000000eC36B683C2E6AC89e9A75989C22a2e" as const;
+export const SOLANA_DEVNET_CHAIN_ID_NUM = 1151111081099712; // safe JS number (< 2^53)
+const SOLANA_POLYMER_ORACLE_DEVNET =
+	"0xe48a6f95df84c28a030f60ba5b74e4a02922a4a5724c9633109f089b2287edfc" as const;
+// Source: PDA(seed: "polymer", program: SOLANA_POLYMER_ORACLE) — confirmed in default_orders.json
 export const WORMHOLE_ORACLE: Partial<Record<number, `0x${string}`>> = {
 	[ethereum.id]: "0x0000000000000000000000000000000000000000",
 	[arbitrum.id]: "0x0000000000000000000000000000000000000000",
@@ -43,7 +47,8 @@ export const POLYMER_ORACLE: Partial<Record<number, `0x${string}`>> = {
 	[sepolia.id]: "0x00d5b500ECa100F7cdeDC800eC631Aca00BaAC00",
 	[baseSepolia.id]: "0x00d5b500ECa100F7cdeDC800eC631Aca00BaAC00",
 	[arbitrumSepolia.id]: "0x00d5b500ECa100F7cdeDC800eC631Aca00BaAC00",
-	[optimismSepolia.id]: "0x00d5b500ECa100F7cdeDC800eC631Aca00BaAC00"
+	[optimismSepolia.id]: "0x00d5b500ECa100F7cdeDC800eC631Aca00BaAC00",
+	[SOLANA_DEVNET_CHAIN_ID_NUM]: SOLANA_POLYMER_ORACLE_DEVNET
 };
 
 export type availableAllocators = typeof ALWAYS_OK_ALLOCATOR | typeof POLYMER_ALLOCATOR;
@@ -73,7 +78,9 @@ export const chainList = (mainnet: boolean) => {
 };
 
 export const chainIdList = (mainnet: boolean) => {
-	return chainList(mainnet).map((name) => chainMap[name].id);
+	const list = chainList(mainnet).map((name) => chainMap[name].id) as number[];
+	if (!mainnet) list.push(SOLANA_DEVNET_CHAIN_ID_NUM);
+	return list;
 };
 
 const chainEntries = chains.map((name) => [chainMap[name].id, chainMap[name]] as const);
@@ -267,6 +274,13 @@ export const coinList = (mainnet: boolean) => {
 				name: "weth",
 				chainId: arbitrumSepolia.id,
 				decimals: 18
+			},
+			// Solana devnet — token address is the SPL mint encoded as bytes32 (66 chars)
+			{
+				address: `0x3b442cb3912157f13a933d0134282d032b5ffecd01a2dbf1b7790608df002ea7`,
+				name: "usdc",
+				chainId: SOLANA_DEVNET_CHAIN_ID_NUM,
+				decimals: 6
 			}
 		] as const;
 };
@@ -324,9 +338,12 @@ export function getCoin(
 ) {
 	const { name = undefined, address = undefined } = args;
 	const chainId = normalizeChainId(args.chainId);
-	// ensure the address is ERC20-sized.
-	const concatedAddress =
-		"0x" + address?.replace("0x", "")?.slice(address.length - 42, address.length);
+	// For Solana chains, the token address is a full 32-byte pubkey (66-char hex) — compare directly.
+	// For EVM chains, the address may arrive as a bytes32 left-padded with zeros — slice to 20 bytes.
+	const isSolanaChain = chainId === SOLANA_DEVNET_CHAIN_ID_NUM;
+	const concatedAddress = isSolanaChain
+		? address?.toLowerCase()
+		: "0x" + address?.replace("0x", "")?.slice(address.length - 42, address.length);
 	for (const token of coinList(!isChainIdTestnet(chainId))) {
 		// check chain first.
 		if (token.chainId === chainId) {
@@ -353,6 +370,7 @@ function normalizeChainId(chainId: number | bigint | string) {
 
 export function isChainIdTestnet(chainId: number | bigint | string) {
 	const normalized = normalizeChainId(chainId);
+	if (normalized === SOLANA_DEVNET_CHAIN_ID_NUM) return true;
 	const chain = chainById[normalized];
 	if (!chain) throw new Error(`Chain is not known: ${normalized}`);
 	return chain.testnet;
@@ -360,6 +378,7 @@ export function isChainIdTestnet(chainId: number | bigint | string) {
 
 export function getChainName(chainId: number | bigint | string) {
 	const normalized = normalizeChainId(chainId);
+	if (normalized === SOLANA_DEVNET_CHAIN_ID_NUM) return "solana-devnet";
 	const name = chainNameById[normalized];
 	if (!name) throw new Error(`Chain is not known: ${normalized}`);
 	return name;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -139,8 +139,8 @@ export type Token = {
 	decimals: number;
 };
 
-export const coinList = (mainnet: boolean) => {
-	if (mainnet == true)
+export const coinList = (mainnet: boolean): Token[] => {
+	if (mainnet)
 		return [
 			{
 				address: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`,
@@ -243,6 +243,14 @@ export const coinList = (mainnet: boolean) => {
 				name: "usdc.e",
 				chainId: polygon.id,
 				decimals: 6
+			},
+			// Solana mainnet — SPL mint addresses encoded as bytes32 (66 chars); ADDRESS_ZERO = native SOL
+			{ address: ADDRESS_ZERO, name: "sol", chainId: SOLANA_MAINNET_CHAIN_ID_NUM, decimals: 9 },
+			{
+				address: `0xc6fa7af3bedbad3a3d65f36aabc97431b1bbe4c2d2f6e0e47ca60203452f5d61`,
+				name: "usdc",
+				chainId: SOLANA_MAINNET_CHAIN_ID_NUM,
+				decimals: 6
 			}
 		] as const;
 	else
@@ -319,15 +327,22 @@ export const coinList = (mainnet: boolean) => {
 				chainId: arbitrumSepolia.id,
 				decimals: 18
 			},
-			// Solana devnet — token address is the SPL mint encoded as bytes32 (66 chars)
+			// Solana devnet — SPL mint addresses encoded as bytes32 (66 chars); ADDRESS_ZERO = native SOL
+			{ address: ADDRESS_ZERO, name: "sol", chainId: SOLANA_DEVNET_CHAIN_ID_NUM, decimals: 9 },
 			{
 				address: `0x3b442cb3912157f13a933d0134282d032b5ffecd01a2dbf1b7790608df002ea7`,
 				name: "usdc",
 				chainId: SOLANA_DEVNET_CHAIN_ID_NUM,
 				decimals: 6
 			}
-		] as const;
+		];
 };
+
+export const evmCoinList = (mainnet: boolean) =>
+	coinList(mainnet).filter((t) => !!clientsById[t.chainId]);
+
+export const solanaCoinList = (mainnet: boolean) =>
+	coinList(mainnet).filter((t) => SOLANA_CHAIN_IDS.has(t.chainId));
 
 export function printToken(token: Token) {
 	return `${token.name.toUpperCase()}, ${getChainName(token.chainId)}`;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,9 @@
-import { createPublicClient, createWalletClient, custom, fallback, http } from "viem";
+import { createPublicClient, createWalletClient, custom, defineChain, fallback, http } from "viem";
+import {
+	SOLANA_MAINNET_CHAIN_ID,
+	SOLANA_TESTNET_CHAIN_ID,
+	SOLANA_DEVNET_CHAIN_ID
+} from "@lifi/intent";
 import {
 	arbitrum,
 	arbitrumSepolia,
@@ -26,7 +31,37 @@ export const MULTICHAIN_INPUT_SETTLER_COMPACT =
 export const ALWAYS_OK_ALLOCATOR = "281773970620737143753120258" as const;
 export const POLYMER_ALLOCATOR = "116450367070547927622991121" as const; // 0x02ecC89C25A5DCB1206053530c58E002a737BD11 signing by 0x934244C8cd6BeBDBd0696A659D77C9BDfE86Efe6
 export const COIN_FILLER = "0x0000000000eC36B683C2E6AC89e9A75989C22a2e" as const;
-export const SOLANA_DEVNET_CHAIN_ID_NUM = 1151111081099712; // safe JS number (< 2^53)
+// All three Solana chain IDs as numbers (all values are < 2^53, safe as JS numbers)
+export const SOLANA_MAINNET_CHAIN_ID_NUM = Number(SOLANA_MAINNET_CHAIN_ID);
+export const SOLANA_TESTNET_CHAIN_ID_NUM = Number(SOLANA_TESTNET_CHAIN_ID);
+export const SOLANA_DEVNET_CHAIN_ID_NUM = Number(SOLANA_DEVNET_CHAIN_ID);
+export const SOLANA_CHAIN_IDS = new Set([
+	SOLANA_MAINNET_CHAIN_ID_NUM,
+	SOLANA_TESTNET_CHAIN_ID_NUM,
+	SOLANA_DEVNET_CHAIN_ID_NUM
+]);
+
+export const solanaMainnet = defineChain({
+	id: SOLANA_MAINNET_CHAIN_ID_NUM,
+	name: "Solana",
+	nativeCurrency: { name: "SOL", symbol: "SOL", decimals: 9 },
+	rpcUrls: { default: { http: ["https://api.mainnet-beta.solana.com"] } }
+});
+export const solanaTestnet = defineChain({
+	id: SOLANA_TESTNET_CHAIN_ID_NUM,
+	name: "Solana Testnet",
+	nativeCurrency: { name: "SOL", symbol: "SOL", decimals: 9 },
+	rpcUrls: { default: { http: ["https://api.testnet.solana.com"] } },
+	testnet: true
+});
+export const solanaDevnet = defineChain({
+	id: SOLANA_DEVNET_CHAIN_ID_NUM,
+	name: "Solana Devnet",
+	nativeCurrency: { name: "SOL", symbol: "SOL", decimals: 9 },
+	rpcUrls: { default: { http: ["https://api.devnet.solana.com"] } },
+	testnet: true
+});
+
 const SOLANA_POLYMER_ORACLE_DEVNET =
 	"0xe48a6f95df84c28a030f60ba5b74e4a02922a4a5724c9633109f089b2287edfc" as const;
 // Source: PDA(seed: "polymer", program: SOLANA_POLYMER_ORACLE) — confirmed in default_orders.json
@@ -67,21 +102,30 @@ export const chainMap = {
 	katana,
 	megaeth,
 	bsc,
-	polygon
+	polygon,
+	solanaMainnet,
+	solanaTestnet,
+	solanaDevnet
 } as const;
 type ChainName = keyof typeof chainMap;
 export const chains = Object.keys(chainMap) as ChainName[];
-export const chainList = (mainnet: boolean) => {
-	if (mainnet == true) {
-		return ["ethereum", "base", "arbitrum", "megaeth", "katana", "polygon", "bsc"] as ChainName[];
-	} else return ["sepolia", "optimismSepolia", "baseSepolia", "arbitrumSepolia"] as ChainName[];
+export const chainList = (mainnet: boolean): ChainName[] => {
+	if (mainnet) {
+		return ["ethereum", "base", "arbitrum", "megaeth", "katana", "polygon", "bsc", "solanaMainnet"];
+	} else {
+		return [
+			"sepolia",
+			"optimismSepolia",
+			"baseSepolia",
+			"arbitrumSepolia",
+			"solanaTestnet",
+			"solanaDevnet"
+		];
+	}
 };
 
-export const chainIdList = (mainnet: boolean) => {
-	const list = chainList(mainnet).map((name) => chainMap[name].id) as number[];
-	if (!mainnet) list.push(SOLANA_DEVNET_CHAIN_ID_NUM);
-	return list;
-};
+export const chainIdList = (mainnet: boolean) =>
+	chainList(mainnet).map((name) => chainMap[name].id) as number[];
 
 const chainEntries = chains.map((name) => [chainMap[name].id, chainMap[name]] as const);
 const chainNameEntries = chains.map((name) => [chainMap[name].id, name] as const);
@@ -340,7 +384,7 @@ export function getCoin(
 	const chainId = normalizeChainId(args.chainId);
 	// For Solana chains, the token address is a full 32-byte pubkey (66-char hex) — compare directly.
 	// For EVM chains, the address may arrive as a bytes32 left-padded with zeros — slice to 20 bytes.
-	const isSolanaChain = chainId === SOLANA_DEVNET_CHAIN_ID_NUM;
+	const isSolanaChain = SOLANA_CHAIN_IDS.has(chainId);
 	const concatedAddress = isSolanaChain
 		? address?.toLowerCase()
 		: "0x" + address?.replace("0x", "")?.slice(address.length - 42, address.length);
@@ -370,15 +414,13 @@ function normalizeChainId(chainId: number | bigint | string) {
 
 export function isChainIdTestnet(chainId: number | bigint | string) {
 	const normalized = normalizeChainId(chainId);
-	if (normalized === SOLANA_DEVNET_CHAIN_ID_NUM) return true;
 	const chain = chainById[normalized];
 	if (!chain) throw new Error(`Chain is not known: ${normalized}`);
-	return chain.testnet;
+	return chain.testnet ?? false;
 }
 
 export function getChainName(chainId: number | bigint | string) {
 	const normalized = normalizeChainId(chainId);
-	if (normalized === SOLANA_DEVNET_CHAIN_ID_NUM) return "solana-devnet";
 	const name = chainNameById[normalized];
 	if (!name) throw new Error(`Chain is not known: ${normalized}`);
 	return name;
@@ -490,15 +532,25 @@ export const clients = {
 	})
 } as const;
 
-export const chainById = Object.fromEntries(chainEntries) as Record<
-	number,
-	(typeof chainMap)[keyof typeof chainMap]
->;
+export const chainById = {
+	...Object.fromEntries(chainEntries),
+	[solanaMainnet.id]: solanaMainnet,
+	[solanaTestnet.id]: solanaTestnet,
+	[solanaDevnet.id]: solanaDevnet
+} as Record<number, (typeof chainMap)[keyof typeof chainMap] | typeof solanaMainnet>;
 
-export const chainNameById = Object.fromEntries(chainNameEntries) as Record<number, ChainName>;
+export const chainNameById = {
+	...Object.fromEntries(chainNameEntries),
+	[solanaMainnet.id]: "solana",
+	[solanaTestnet.id]: "solana-testnet",
+	[solanaDevnet.id]: "solana-devnet"
+} as Record<number, string>;
 
 export const clientsById = Object.fromEntries(
-	chains.map((name) => [chainMap[name].id, clients[name]])
+	(Object.keys(clients) as (keyof typeof clients)[]).map((name) => [
+		chainMap[name].id,
+		clients[name]
+	])
 ) as Record<number, (typeof clients)[keyof typeof clients]>;
 
 export type WC = ReturnType<

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -339,7 +339,7 @@ export const coinList = (mainnet: boolean): Token[] => {
 };
 
 export const evmCoinList = (mainnet: boolean) =>
-	coinList(mainnet).filter((t) => !!clientsById[t.chainId]);
+	coinList(mainnet).filter((t) => !!evmClientsById[t.chainId]);
 
 export const solanaCoinList = (mainnet: boolean) =>
 	coinList(mainnet).filter((t) => SOLANA_CHAIN_IDS.has(t.chainId));
@@ -467,12 +467,12 @@ export function getChain(chainId: number | bigint | string) {
 
 export function getClient(chainId: number | bigint | string) {
 	const normalized = normalizeChainId(chainId);
-	const client = clientsById[normalized];
+	const client = evmClientsById[normalized];
 	if (!client) throw new Error(`Could not find client for chainId ${normalized}`);
 	return client;
 }
 
-export const clients = {
+export const evmClients = {
 	ethereum: createPublicClient({
 		chain: ethereum,
 		transport: fallback([
@@ -561,12 +561,12 @@ export const chainNameById = {
 	[solanaDevnet.id]: "solana-devnet"
 } as Record<number, string>;
 
-export const clientsById = Object.fromEntries(
-	(Object.keys(clients) as (keyof typeof clients)[]).map((name) => [
+export const evmClientsById = Object.fromEntries(
+	(Object.keys(evmClients) as (keyof typeof evmClients)[]).map((name) => [
 		chainMap[name].id,
-		clients[name]
+		evmClients[name]
 	])
-) as Record<number, (typeof clients)[keyof typeof clients]>;
+) as Record<number, (typeof evmClients)[keyof typeof evmClients]>;
 
 export type WC = ReturnType<
 	typeof createWalletClient<ReturnType<typeof custom>, undefined, undefined, undefined>

--- a/src/lib/libraries/coreDeps.ts
+++ b/src/lib/libraries/coreDeps.ts
@@ -5,7 +5,11 @@ import {
 	POLYMER_ORACLE,
 	WORMHOLE_ORACLE
 } from "$lib/config";
-import type { IntentDeps, OrderContainerValidationDeps } from "@lifi/intent";
+import {
+	SOLANA_OUTPUT_SETTLER_PDAS,
+	type IntentDeps,
+	type OrderContainerValidationDeps
+} from "@lifi/intent";
 
 function isNonZeroAddress(value: string | undefined): value is `0x${string}` {
 	return !!value && value.toLowerCase() !== "0x0000000000000000000000000000000000000000";
@@ -49,6 +53,9 @@ export const orderValidationDeps: OrderContainerValidationDeps = {
 		return allowed;
 	},
 	allowedOutputSettlers() {
-		return [COIN_FILLER];
+		const solanaSettlers = Object.values(SOLANA_OUTPUT_SETTLER_PDAS).filter(
+			(v): v is `0x${string}` => !!v
+		);
+		return [COIN_FILLER, ...solanaSettlers];
 	}
 };

--- a/src/lib/libraries/flowProgress.ts
+++ b/src/lib/libraries/flowProgress.ts
@@ -15,7 +15,7 @@ import { hashStruct, keccak256 } from "viem";
 import { compactTypes } from "@lifi/intent";
 import { getOutputHash, encodeMandateOutput } from "@lifi/intent";
 import { addressToBytes32, bytes32ToAddress } from "@lifi/intent";
-import { orderToIntent } from "@lifi/intent";
+import { containerToIntent } from "$lib/utils/intent";
 import { getOrFetchRpc } from "$lib/libraries/rpcCache";
 import type { MandateOutput, OrderContainer } from "@lifi/intent";
 import store from "$lib/state.svelte";
@@ -128,7 +128,7 @@ async function isOutputValidatedOnChain(
 async function isInputChainFinalised(chainId: bigint, container: OrderContainer) {
 	const { order, inputSettler } = container;
 	const inputChainClient = getClient(chainId);
-	const intent = orderToIntent(container);
+	const intent = containerToIntent(container);
 	const orderId = intent.orderId();
 
 	if (
@@ -185,7 +185,7 @@ export async function getOrderProgressChecks(
 	fillTransactions: Record<string, `0x${string}`>
 ): Promise<FlowCheckState> {
 	try {
-		const intent = orderToIntent(orderContainer);
+		const intent = containerToIntent(orderContainer);
 		const orderId = intent.orderId();
 		const inputChains = intent.inputChains();
 		const outputs = orderContainer.order.outputs;

--- a/src/lib/libraries/intentExecution.ts
+++ b/src/lib/libraries/intentExecution.ts
@@ -16,7 +16,7 @@ import {
 import { compact_type_hash } from "@lifi/intent";
 import { addressToBytes32 } from "@lifi/intent";
 import { signMultichainCompact, signStandardCompact } from "@lifi/intent";
-import { MultichainOrderIntent, StandardOrderIntent } from "@lifi/intent";
+import { MultichainOrderIntent, StandardEVMIntent as StandardOrderIntent } from "@lifi/intent";
 import type { NoSignature, Signature } from "@lifi/intent";
 import type { TypedDataSigner } from "@lifi/intent";
 import { switchWalletChain } from "$lib/utils/walletClientRuntime";

--- a/src/lib/libraries/intentFactory.ts
+++ b/src/lib/libraries/intentFactory.ts
@@ -59,6 +59,7 @@ function toCoreCreateIntentOptions(opts: AppCreateIntentOptions): CreateIntentOp
 			outputTokens: opts.outputTokens.map(toCoreTokenContext),
 			verifier: opts.verifier,
 			account,
+			outputRecipient: opts.outputRecipient,
 			lock: {
 				type: "compact",
 				resetPeriod: opts.lock.resetPeriod,
@@ -73,6 +74,7 @@ function toCoreCreateIntentOptions(opts: AppCreateIntentOptions): CreateIntentOp
 		outputTokens: opts.outputTokens.map(toCoreTokenContext),
 		verifier: opts.verifier,
 		account,
+		outputRecipient: opts.outputRecipient,
 		lock: {
 			type: "escrow"
 		}

--- a/src/lib/libraries/intentFactory.ts
+++ b/src/lib/libraries/intentFactory.ts
@@ -16,21 +16,35 @@ import type {
 	Signature,
 	StandardOrder
 } from "@lifi/intent";
+import {
+	Intent,
+	IntentApi,
+	StandardSolanaIntent,
+	SOLANA_MAINNET_CHAIN_ID,
+	SOLANA_TESTNET_CHAIN_ID,
+	SOLANA_DEVNET_CHAIN_ID
+} from "@lifi/intent";
 import type { AppCreateIntentOptions, AppTokenContext } from "$lib/appTypes";
 import { ERC20_ABI } from "$lib/abi/erc20";
-import { Intent } from "@lifi/intent";
-import { IntentApi } from "@lifi/intent";
 import { store } from "$lib/state.svelte";
 import { depositAndRegisterCompact, openEscrowIntent, signIntentCompact } from "./intentExecution";
 import { intentDeps } from "./coreDeps";
 
+const SOLANA_CHAIN_IDS = new Set([
+	SOLANA_MAINNET_CHAIN_ID,
+	SOLANA_TESTNET_CHAIN_ID,
+	SOLANA_DEVNET_CHAIN_ID
+]);
+
 function toCoreTokenContext(input: AppTokenContext): TokenContext {
+	const chainId = BigInt(input.token.chainId);
 	return {
 		token: {
 			address: input.token.address,
 			name: input.token.name,
-			chainId: BigInt(input.token.chainId),
-			decimals: input.token.decimals
+			chainId,
+			decimals: input.token.decimals,
+			chainNamespace: SOLANA_CHAIN_IDS.has(chainId) ? "solana" : "eip155"
 		},
 		amount: input.amount
 	};
@@ -127,6 +141,8 @@ export class IntentFactory {
 			const inputChain = inputTokens[0].token.chainId;
 			if (this.preHook) await this.preHook(inputChain);
 			const intent = new Intent(toCoreCreateIntentOptions(opts), intentDeps).order();
+			if (intent instanceof StandardSolanaIntent)
+				throw new Error("Compact signing is not supported for Solana intents.");
 
 			const sponsorSignature = await signIntentCompact(intent, account(), this.walletClient);
 
@@ -165,6 +181,8 @@ export class IntentFactory {
 		return async () => {
 			const { inputTokens, account } = opts;
 			const intent = new Intent(toCoreCreateIntentOptions(opts), intentDeps).singlechain();
+			if (intent instanceof StandardSolanaIntent)
+				throw new Error("Compact deposit and register is not supported for Solana intents.");
 
 			if (this.preHook) await this.preHook(inputTokens[0].token.chainId);
 
@@ -200,6 +218,8 @@ export class IntentFactory {
 		return async () => {
 			const { inputTokens, account } = opts;
 			const intent = new Intent(toCoreCreateIntentOptions(opts), intentDeps).order();
+			if (intent instanceof StandardSolanaIntent)
+				throw new Error("openEscrowIntent is not supported for Solana intents.");
 
 			const inputChain = inputTokens[0].token.chainId;
 			if (this.preHook) await this.preHook(inputChain);

--- a/src/lib/libraries/intentList.ts
+++ b/src/lib/libraries/intentList.ts
@@ -7,8 +7,8 @@ import {
 	MULTICHAIN_INPUT_SETTLER_ESCROW,
 	MULTICHAIN_INPUT_SETTLER_COMPACT
 } from "../config";
-import { orderToIntent } from "@lifi/intent";
 import { bytes32ToAddress, idToToken } from "@lifi/intent";
+import { containerToIntent } from "$lib/utils/intent";
 import type { OrderContainer, StandardOrder, MultichainOrder } from "@lifi/intent";
 import { validateOrderContainerWithReason } from "@lifi/intent";
 import { orderValidationDeps } from "./coreDeps";
@@ -201,7 +201,7 @@ function getContextDetails(orderContainer: OrderContainer): ContextDetails {
 
 export function buildBaseIntentRow(orderContainer: OrderContainer): BaseIntentRow {
 	const order = orderContainer.order;
-	const orderId = orderToIntent(orderContainer).orderId();
+	const orderId = containerToIntent(orderContainer).orderId();
 	const inputChipsRaw = getInputs(order);
 	const outputChipsRaw = getOutputs(order);
 	const chainScope = getChainScope(order);

--- a/src/lib/libraries/solver.ts
+++ b/src/lib/libraries/solver.ts
@@ -6,7 +6,7 @@ import axios from "axios";
 import { POLYMER_ORACLE_ABI } from "$lib/abi/polymeroracle";
 import { COIN_FILLER_ABI } from "$lib/abi/outputsettler";
 import { ERC20_ABI } from "$lib/abi/erc20";
-import { orderToIntent } from "@lifi/intent";
+import { containerToIntent } from "$lib/utils/intent";
 import { compactTypes } from "@lifi/intent";
 import store from "$lib/state.svelte";
 import { finaliseIntent } from "./intentExecution";
@@ -66,7 +66,7 @@ export class Solver {
 				orderContainer: { order, inputSettler },
 				outputs
 			} = args;
-			const orderId = orderToIntent({ order, inputSettler }).orderId();
+			const orderId = containerToIntent(args.orderContainer).orderId();
 
 			const outputChainId = Number(outputs[0].chainId);
 			const outputChain = getChain(outputChainId);
@@ -310,10 +310,7 @@ export class Solver {
 			const { preHook, postHook, account } = opts;
 			const { orderContainer, fillTransactionHashes, sourceChainId } = args;
 			const { order, inputSettler } = orderContainer;
-			const intent = orderToIntent({
-				inputSettler,
-				order
-			});
+			const intent = containerToIntent(orderContainer);
 			if (fillTransactionHashes.length !== order.outputs.length) {
 				throw new Error(
 					`Fill transaction hash count (${fillTransactionHashes.length}) does not match output count (${order.outputs.length}).`

--- a/src/lib/libraries/solver.ts
+++ b/src/lib/libraries/solver.ts
@@ -1,7 +1,7 @@
 import { BYTES32_ZERO, COIN_FILLER, getChain, getClient, getOracle, type WC } from "$lib/config";
 import { hashStruct, maxUint256, parseEventLogs } from "viem";
 import type { MandateOutput, OrderContainer } from "@lifi/intent";
-import { addressToBytes32, bytes32ToAddress } from "@lifi/intent";
+import { addressToBytes32, bytes32ToAddress, StandardSolanaIntent } from "@lifi/intent";
 import axios from "axios";
 import { POLYMER_ORACLE_ABI } from "$lib/abi/polymeroracle";
 import { COIN_FILLER_ABI } from "$lib/abi/outputsettler";
@@ -311,6 +311,8 @@ export class Solver {
 			const { orderContainer, fillTransactionHashes, sourceChainId } = args;
 			const { order, inputSettler } = orderContainer;
 			const intent = containerToIntent(orderContainer);
+			if (intent instanceof StandardSolanaIntent)
+				throw new Error("Finalise is not supported for Solana input intents.");
 			if (fillTransactionHashes.length !== order.outputs.length) {
 				throw new Error(
 					`Fill transaction hash count (${fillTransactionHashes.length}) does not match output count (${order.outputs.length}).`

--- a/src/lib/libraries/token.ts
+++ b/src/lib/libraries/token.ts
@@ -1,13 +1,13 @@
 import { maxUint256 } from "viem";
 import { COMPACT_ABI } from "../abi/compact";
 import { ERC20_ABI } from "../abi/erc20";
-import { ADDRESS_ZERO, clients, COMPACT } from "../config";
+import { ADDRESS_ZERO, evmClients, COMPACT } from "../config";
 import { ResetPeriod, toId } from "@lifi/intent";
 
 export async function getBalance(
 	user: `0x${string}` | undefined,
 	asset: `0x${string}`,
-	client: (typeof clients)[keyof typeof clients]
+	client: (typeof evmClients)[keyof typeof evmClients]
 ) {
 	if (!user) return 0n;
 	if (asset === ADDRESS_ZERO) {
@@ -29,7 +29,7 @@ export function getAllowance(contract: `0x${string}`) {
 	return async (
 		user: `0x${string}` | undefined,
 		asset: `0x${string}`,
-		client: (typeof clients)[keyof typeof clients]
+		client: (typeof evmClients)[keyof typeof evmClients]
 	) => {
 		if (!user) return 0n;
 		if (asset == ADDRESS_ZERO) return maxUint256;
@@ -45,7 +45,7 @@ export function getAllowance(contract: `0x${string}`) {
 export async function getCompactBalance(
 	user: `0x${string}` | undefined,
 	asset: `0x${string}`,
-	client: (typeof clients)[keyof typeof clients],
+	client: (typeof evmClients)[keyof typeof evmClients],
 	allocatorId: string
 ) {
 	if (!user) return 0n;

--- a/src/lib/screens/FillIntent.svelte
+++ b/src/lib/screens/FillIntent.svelte
@@ -11,7 +11,7 @@
 	import ChainActionRow from "$lib/components/ui/ChainActionRow.svelte";
 	import TokenAmountChip from "$lib/components/ui/TokenAmountChip.svelte";
 	import store from "$lib/state.svelte";
-	import { orderToIntent } from "@lifi/intent";
+	import { containerToIntent } from "$lib/utils/intent";
 	import { compactTypes } from "@lifi/intent";
 	import { hashStruct } from "viem";
 
@@ -77,7 +77,7 @@
 	$effect(() => {
 		refreshValidation;
 
-		const orderId = orderToIntent(orderContainer).orderId();
+		const orderId = containerToIntent(orderContainer).orderId();
 		if (autoScrolledOrderId === orderId) return;
 
 		const outputs = sortOutputsByChain(orderContainer).flatMap(([, chainOutputs]) => chainOutputs);

--- a/src/lib/screens/Finalise.svelte
+++ b/src/lib/screens/Finalise.svelte
@@ -22,7 +22,7 @@
 	import { SETTLER_ESCROW_ABI } from "$lib/abi/escrow";
 	import { idToToken } from "@lifi/intent";
 	import store from "$lib/state.svelte";
-	import { orderToIntent } from "@lifi/intent";
+	import { containerToIntent } from "$lib/utils/intent";
 	import { hashStruct } from "viem";
 	import { compactTypes } from "@lifi/intent";
 
@@ -41,7 +41,7 @@
 	let refreshClaimed = $state(0);
 	let claimedByChain = $state<Record<string, boolean>>({});
 	let claimStatusRun = 0;
-	const inputChains = $derived(orderToIntent(orderContainer).inputChains());
+	const inputChains = $derived(containerToIntent(orderContainer).inputChains());
 	const getInputsForChain = (container: OrderContainer, inputChain: bigint): [bigint, bigint][] => {
 		const { order } = container;
 		if ("originChainId" in order) {
@@ -89,7 +89,7 @@
 		const { order, inputSettler } = container;
 		const inputChainClient = getClient(chainId);
 
-		const intent = orderToIntent(container);
+		const intent = containerToIntent(container);
 		const orderId = intent.orderId();
 		// Determine the order type.
 		if (

--- a/src/lib/screens/IntentList.svelte
+++ b/src/lib/screens/IntentList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onDestroy } from "svelte";
 	import { tick } from "svelte";
-	import { orderToIntent } from "@lifi/intent";
+	import { containerToIntent } from "$lib/utils/intent";
 	import IntentListDetailRow from "$lib/components/IntentListDetailRow.svelte";
 	import {
 		buildBaseIntentRow,
@@ -104,7 +104,7 @@
 	);
 
 	const selectedOrderId = $derived(
-		selectedOrder ? orderToIntent(selectedOrder).orderId() : undefined
+		selectedOrder ? containerToIntent(selectedOrder).orderId() : undefined
 	);
 </script>
 

--- a/src/lib/screens/IssueIntent.svelte
+++ b/src/lib/screens/IssueIntent.svelte
@@ -14,7 +14,7 @@
 	import type { AppCreateIntentOptions } from "$lib/appTypes";
 	import { isAddress } from "viem";
 	import { isValidSolanaAddress, solanaAddressToBytes32 } from "$lib/utils/solana";
-	import { SOLANA_DEVNET_CHAIN_ID_NUM } from "$lib/config";
+	import { SOLANA_CHAIN_IDS } from "$lib/config";
 
 	const bigIntSum = (...nums: bigint[]) => nums.reduce((a, b) => a + b, 0n);
 
@@ -35,7 +35,6 @@
 	const resolveExclusiveFor = (value: string): `0x${string}` | undefined =>
 		isAddress(value, { strict: false }) ? value : undefined;
 
-	const SOLANA_CHAIN_IDS = new Set([SOLANA_DEVNET_CHAIN_ID_NUM]);
 	const resolveEvmRecipient = (value: string): `0x${string}` | undefined =>
 		isAddress(value, { strict: false }) ? (value as `0x${string}`) : undefined;
 	const resolveSolanaRecipient = (value: string): `0x${string}` | undefined =>

--- a/src/lib/screens/IssueIntent.svelte
+++ b/src/lib/screens/IssueIntent.svelte
@@ -47,10 +47,16 @@
 		store.outputTokens.some((t) => !SOLANA_CHAIN_IDS.has(t.token.chainId))
 	);
 
+	// When both Solana and EVM outputs are selected, Solana recipient takes priority since the
+	// library supports a single outputRecipient for all outputs. EVM recipient is only used when
+	// there are no Solana outputs.
 	const outputRecipient = $derived.by((): `0x${string}` | undefined => {
 		if (hasSolanaOutput) return resolveSolanaRecipient(store.solanaRecipient);
 		return resolveEvmRecipient(store.recipient);
 	});
+
+	// A valid Solana recipient is required to encode a usable cross-chain intent.
+	const solanaRecipientMissing = $derived(hasSolanaOutput && !outputRecipient);
 
 	const intentOptions = $derived.by(
 		(): AppCreateIntentOptions => ({
@@ -367,7 +373,15 @@
 		</SectionCard>
 
 		<div class="mt-2 flex justify-center">
-			{#if !allowanceCheck}
+			{#if solanaRecipientMissing}
+				<button
+					type="button"
+					class="h-8 rounded border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-400"
+					disabled
+				>
+					Solana Recipient Required
+				</button>
+			{:else if !allowanceCheck}
 				<AwaitButton buttonFunction={approveFunction}>
 					{#snippet name()}
 						Set allowance

--- a/src/lib/screens/IssueIntent.svelte
+++ b/src/lib/screens/IssueIntent.svelte
@@ -13,9 +13,10 @@
 	import { ResetPeriod } from "@lifi/intent";
 	import type { AppCreateIntentOptions } from "$lib/appTypes";
 	import { isAddress } from "viem";
+	import { isValidSolanaAddress, solanaAddressToBytes32 } from "$lib/utils/solana";
+	import { SOLANA_DEVNET_CHAIN_ID_NUM } from "$lib/config";
 
 	const bigIntSum = (...nums: bigint[]) => nums.reduce((a, b) => a + b, 0n);
-	const REQUIRED_INPUT_USDC_RAW = 100n;
 
 	let {
 		scroll,
@@ -34,8 +35,23 @@
 	const resolveExclusiveFor = (value: string): `0x${string}` | undefined =>
 		isAddress(value, { strict: false }) ? value : undefined;
 
-	const resolveRecipient = (value: string): `0x${string}` | undefined =>
-		isAddress(value, { strict: false }) ? value : undefined;
+	const SOLANA_CHAIN_IDS = new Set([SOLANA_DEVNET_CHAIN_ID_NUM]);
+	const resolveEvmRecipient = (value: string): `0x${string}` | undefined =>
+		isAddress(value, { strict: false }) ? (value as `0x${string}`) : undefined;
+	const resolveSolanaRecipient = (value: string): `0x${string}` | undefined =>
+		isValidSolanaAddress(value) ? solanaAddressToBytes32(value) : undefined;
+
+	const hasSolanaOutput = $derived(
+		store.outputTokens.some((t) => SOLANA_CHAIN_IDS.has(t.token.chainId))
+	);
+	const hasEvmOutput = $derived(
+		store.outputTokens.some((t) => !SOLANA_CHAIN_IDS.has(t.token.chainId))
+	);
+
+	const outputRecipient = $derived.by((): `0x${string}` | undefined => {
+		if (hasSolanaOutput) return resolveSolanaRecipient(store.solanaRecipient);
+		return resolveEvmRecipient(store.recipient);
+	});
 
 	const intentOptions = $derived.by(
 		(): AppCreateIntentOptions => ({
@@ -43,7 +59,7 @@
 			inputTokens: store.inputTokens,
 			outputTokens: store.outputTokens,
 			verifier: store.verifier,
-			outputRecipient: resolveRecipient(store.recipient),
+			outputRecipient,
 			lock:
 				store.intentType === "compact"
 					? {
@@ -280,19 +296,41 @@
 
 		<SectionCard compact>
 			<div class="flex flex-col gap-2">
-				<div class="flex min-w-0 items-center gap-1">
-					<span class="text-[11px] font-semibold whitespace-nowrap text-gray-500">Recipient</span>
-					<FormControl
-						type="text"
-						size="sm"
-						className="flex-1"
-						placeholder="0x... (optional)"
-						state={store.recipient.length > 0 && !resolveRecipient(store.recipient)
-							? "error"
-							: "default"}
-						bind:value={store.recipient}
-					/>
-				</div>
+				{#if hasEvmOutput}
+					<div class="flex min-w-0 items-center gap-1">
+						<span class="text-[11px] font-semibold whitespace-nowrap text-gray-500"
+							>EVM Recipient</span
+						>
+						<FormControl
+							type="text"
+							size="sm"
+							className="flex-1"
+							placeholder="0x... (optional)"
+							state={store.recipient.length > 0 && !resolveEvmRecipient(store.recipient)
+								? "error"
+								: "default"}
+							bind:value={store.recipient}
+						/>
+					</div>
+				{/if}
+				{#if hasSolanaOutput}
+					<div class="flex min-w-0 items-center gap-1">
+						<span class="text-[11px] font-semibold whitespace-nowrap text-gray-500"
+							>Solana Recipient</span
+						>
+						<FormControl
+							type="text"
+							size="sm"
+							className="flex-1"
+							placeholder="Base58... (required)"
+							state={store.solanaRecipient.length > 0 &&
+							!resolveSolanaRecipient(store.solanaRecipient)
+								? "error"
+								: "default"}
+							bind:value={store.solanaRecipient}
+						/>
+					</div>
+				{/if}
 				<div class="flex items-center gap-1">
 					<span class="text-[11px] font-semibold text-gray-500">Verifier</span>
 					{#if sameChain}

--- a/src/lib/screens/IssueIntent.svelte
+++ b/src/lib/screens/IssueIntent.svelte
@@ -34,12 +34,16 @@
 	const resolveExclusiveFor = (value: string): `0x${string}` | undefined =>
 		isAddress(value, { strict: false }) ? value : undefined;
 
+	const resolveRecipient = (value: string): `0x${string}` | undefined =>
+		isAddress(value, { strict: false }) ? value : undefined;
+
 	const intentOptions = $derived.by(
 		(): AppCreateIntentOptions => ({
 			exclusiveFor: resolveExclusiveFor(store.exclusiveFor),
 			inputTokens: store.inputTokens,
 			outputTokens: store.outputTokens,
 			verifier: store.verifier,
+			outputRecipient: resolveRecipient(store.recipient),
 			lock:
 				store.intentType === "compact"
 					? {
@@ -276,6 +280,19 @@
 
 		<SectionCard compact>
 			<div class="flex flex-col gap-2">
+				<div class="flex min-w-0 items-center gap-1">
+					<span class="text-[11px] font-semibold whitespace-nowrap text-gray-500">Recipient</span>
+					<FormControl
+						type="text"
+						size="sm"
+						className="flex-1"
+						placeholder="0x... (optional)"
+						state={store.recipient.length > 0 && !resolveRecipient(store.recipient)
+							? "error"
+							: "default"}
+						bind:value={store.recipient}
+					/>
+				</div>
 				<div class="flex items-center gap-1">
 					<span class="text-[11px] font-semibold text-gray-500">Verifier</span>
 					{#if sameChain}
@@ -313,15 +330,7 @@
 		</SectionCard>
 
 		<div class="mt-2 flex justify-center">
-			{#if !true}
-				<button
-					type="button"
-					class="h-8 rounded border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-400"
-					disabled
-				>
-					Input must be exactly raw 100 USDC
-				</button>
-			{:else if !allowanceCheck}
+			{#if !allowanceCheck}
 				<AwaitButton buttonFunction={approveFunction}>
 					{#snippet name()}
 						Set allowance

--- a/src/lib/screens/ReceiveMessage.svelte
+++ b/src/lib/screens/ReceiveMessage.svelte
@@ -12,7 +12,7 @@
 	import ChainActionRow from "$lib/components/ui/ChainActionRow.svelte";
 	import TokenAmountChip from "$lib/components/ui/TokenAmountChip.svelte";
 	import store from "$lib/state.svelte";
-	import { orderToIntent } from "@lifi/intent";
+	import { containerToIntent } from "$lib/utils/intent";
 	import { compactTypes } from "@lifi/intent";
 
 	// This script needs to be updated to be able to fetch the associated events of fills. Currently, this presents an issue since it can only fill single outputs.
@@ -110,7 +110,7 @@
 	$effect(() => {
 		refreshValidation;
 
-		const intent = orderToIntent(orderContainer);
+		const intent = containerToIntent(orderContainer);
 		const orderId = intent.orderId();
 		if (autoScrolledOrderId === orderId) return;
 
@@ -167,7 +167,7 @@
 	description="Click on each output and wait until they turn green. Polymer does not support batch validation. Continue to the right."
 >
 	<div class="space-y-2">
-		{#each orderToIntent(orderContainer).inputChains() as inputChain}
+		{#each containerToIntent(orderContainer).inputChains() as inputChain}
 			<SectionCard compact>
 				<ChainActionRow chainLabel={getChainName(inputChain)}>
 					{#snippet action()}

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -273,6 +273,7 @@ class Store {
 	allocatorId = $state<availableAllocators>(ALWAYS_OK_ALLOCATOR);
 	verifier = $state<Verifier>("polymer");
 	exclusiveFor: string = $state("");
+	recipient: string = $state("");
 	useExclusiveForQuoteRequest = $state(false);
 
 	invalidateWalletReadCache(scope: "all" | "balance" | "allowance" | "compact" = "all") {

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -274,6 +274,7 @@ class Store {
 	verifier = $state<Verifier>("polymer");
 	exclusiveFor: string = $state("");
 	recipient: string = $state("");
+	solanaRecipient: string = $state("");
 	useExclusiveForQuoteRequest = $state(false);
 
 	invalidateWalletReadCache(scope: "all" | "balance" | "allowance" | "compact" = "all") {
@@ -393,6 +394,7 @@ class Store {
 		const { bucket, ttlMs, isMainnet, scopeKey, fetcher } = opts;
 		const resolved: Record<number, Record<`0x${string}`, Promise<T>>> = {};
 		for (const token of coinList(isMainnet)) {
+			if (!clientsById[token.chainId]) continue; // skip non-EVM chains (e.g. Solana)
 			if (!resolved[token.chainId]) resolved[token.chainId] = {};
 			const key = `${bucket}:${isMainnet ? "mainnet" : "testnet"}:${token.chainId}:${token.address}:${scopeKey}`;
 			resolved[token.chainId][token.address] = getOrFetchRpc(

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -23,7 +23,7 @@ import {
 	transactionReceipts as transactionReceiptsTable
 } from "./schema";
 import { and, eq } from "drizzle-orm";
-import { orderToIntent } from "@lifi/intent";
+import { containerToIntent } from "./utils/intent";
 import { getOrFetchRpc, invalidateRpcPrefix } from "./libraries/rpcCache";
 import {
 	getCurrentConnection,
@@ -49,7 +49,7 @@ class Store {
 	async saveOrderToDb(order: OrderContainer) {
 		if (!browser) return;
 		if (!db) await initDb();
-		const orderId = orderToIntent(order).orderId();
+		const orderId = containerToIntent(order).orderId();
 		const now = Math.floor(Date.now() / 1000);
 		const id =
 			(order as any).id ?? (typeof crypto !== "undefined" ? crypto.randomUUID() : String(now));
@@ -89,7 +89,7 @@ class Store {
 				console.warn("saveOrderToDb db write failed", { orderId, error });
 			}
 		}
-		const idx = this.orders.findIndex((o) => orderToIntent(o).orderId() === orderId);
+		const idx = this.orders.findIndex((o) => containerToIntent(o).orderId() === orderId);
 		if (idx >= 0) this.orders[idx] = order;
 		else this.orders.push(order);
 	}

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -2,7 +2,7 @@ import type { OrderContainer } from "@lifi/intent";
 import type { AppTokenContext } from "./appTypes";
 import {
 	ALWAYS_OK_ALLOCATOR,
-	clientsById,
+	evmClientsById,
 	coinList,
 	COMPACT,
 	INPUT_SETTLER_COMPACT_LIFI,
@@ -388,18 +388,18 @@ class Store {
 		scopeKey: string;
 		fetcher: (
 			asset: `0x${string}`,
-			client: (typeof clientsById)[keyof typeof clientsById]
+			client: (typeof evmClientsById)[keyof typeof evmClientsById]
 		) => Promise<T>;
 	}) {
 		const { bucket, ttlMs, isMainnet, scopeKey, fetcher } = opts;
 		const resolved: Record<number, Record<`0x${string}`, Promise<T>>> = {};
 		for (const token of coinList(isMainnet)) {
-			if (!clientsById[token.chainId]) continue; // skip non-EVM chains (e.g. Solana)
+			if (!evmClientsById[token.chainId]) continue; // skip non-EVM chains (e.g. Solana)
 			if (!resolved[token.chainId]) resolved[token.chainId] = {};
 			const key = `${bucket}:${isMainnet ? "mainnet" : "testnet"}:${token.chainId}:${token.address}:${scopeKey}`;
 			resolved[token.chainId][token.address] = getOrFetchRpc(
 				key,
-				() => fetcher(token.address, clientsById[token.chainId]),
+				() => fetcher(token.address, evmClientsById[token.chainId]),
 				{ ttlMs }
 			);
 		}

--- a/src/lib/utils/intent.ts
+++ b/src/lib/utils/intent.ts
@@ -1,0 +1,26 @@
+import {
+	orderToIntent,
+	SOLANA_MAINNET_CHAIN_ID,
+	SOLANA_TESTNET_CHAIN_ID,
+	SOLANA_DEVNET_CHAIN_ID
+} from "@lifi/intent";
+import type { OrderContainer, OrderIntent } from "@lifi/intent";
+
+const SOLANA_CHAIN_IDS = new Set([
+	SOLANA_MAINNET_CHAIN_ID,
+	SOLANA_TESTNET_CHAIN_ID,
+	SOLANA_DEVNET_CHAIN_ID
+]);
+
+function isSolanaOrder(order: OrderContainer["order"]): boolean {
+	if (!("originChainId" in order)) return false;
+	return SOLANA_CHAIN_IDS.has(order.originChainId);
+}
+
+export function containerToIntent(container: OrderContainer): OrderIntent {
+	const { inputSettler, order } = container;
+	if (isSolanaOrder(order)) {
+		return orderToIntent({ namespace: "solana", inputSettler, order });
+	}
+	return orderToIntent({ namespace: "eip155", inputSettler, order });
+}

--- a/src/lib/utils/intent.ts
+++ b/src/lib/utils/intent.ts
@@ -2,9 +2,12 @@ import {
 	orderToIntent,
 	SOLANA_MAINNET_CHAIN_ID,
 	SOLANA_TESTNET_CHAIN_ID,
-	SOLANA_DEVNET_CHAIN_ID
+	SOLANA_DEVNET_CHAIN_ID,
+	StandardEVMIntent,
+	StandardSolanaIntent,
+	MultichainOrderIntent
 } from "@lifi/intent";
-import type { OrderContainer, OrderIntent } from "@lifi/intent";
+import type { OrderContainer } from "@lifi/intent";
 
 const SOLANA_CHAIN_IDS = new Set([
 	SOLANA_MAINNET_CHAIN_ID,
@@ -12,14 +15,14 @@ const SOLANA_CHAIN_IDS = new Set([
 	SOLANA_DEVNET_CHAIN_ID
 ]);
 
-function isSolanaOrder(order: OrderContainer["order"]): boolean {
-	if (!("originChainId" in order)) return false;
-	return SOLANA_CHAIN_IDS.has(order.originChainId);
-}
-
-export function containerToIntent(container: OrderContainer): OrderIntent {
+export function containerToIntent(
+	container: OrderContainer
+): StandardEVMIntent | StandardSolanaIntent | MultichainOrderIntent {
 	const { inputSettler, order } = container;
-	if (isSolanaOrder(order)) {
+	if (!("originChainId" in order)) {
+		return orderToIntent({ namespace: "eip155", inputSettler, order });
+	}
+	if (SOLANA_CHAIN_IDS.has(order.originChainId)) {
 		return orderToIntent({ namespace: "solana", inputSettler, order });
 	}
 	return orderToIntent({ namespace: "eip155", inputSettler, order });

--- a/src/lib/utils/solana.ts
+++ b/src/lib/utils/solana.ts
@@ -1,0 +1,18 @@
+import { base58 } from "@scure/base";
+
+export function isValidSolanaAddress(addr: string): boolean {
+	try {
+		const bytes = base58.decode(addr);
+		return bytes.length === 32;
+	} catch {
+		return false;
+	}
+}
+
+export function solanaAddressToBytes32(addr: string): `0x${string}` {
+	const bytes = base58.decode(addr);
+	if (bytes.length !== 32) throw new Error(`Invalid Solana address: ${addr}`);
+	return `0x${Array.from(bytes)
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("")}`;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,7 +13,7 @@
 	import ConnectWallet from "$lib/screens/ConnectWallet.svelte";
 	import FlowStepTracker from "$lib/components/ui/FlowStepTracker.svelte";
 	import store from "$lib/state.svelte";
-	import { orderToIntent } from "@lifi/intent";
+	import { containerToIntent } from "$lib/utils/intent";
 
 	// Fix bigint so we can json serialize it:
 	(BigInt.prototype as any).toJSON = function () {
@@ -67,8 +67,8 @@
 				const orderContainer = { ...order, allocatorSignature, sponsorSignature };
 
 				// Deduplicate: only add if not already present
-				const orderId = orderToIntent(orderContainer).orderId();
-				const alreadyExists = store.orders.some((o) => orderToIntent(o).orderId() === orderId);
+				const orderId = containerToIntent(orderContainer).orderId();
+				const alreadyExists = store.orders.some((o) => containerToIntent(o).orderId() === orderId);
 				if (alreadyExists) return;
 
 				store.orders.push(orderContainer);
@@ -100,18 +100,18 @@
 	let scrollStepProgress = $state(0);
 	async function importOrderById(orderId: `0x${string}`): Promise<"inserted" | "updated"> {
 		const importedOrder = await intentApi.getOrderByOnChainOrderId(orderId);
-		const importedOrderId = orderToIntent(importedOrder).orderId();
+		const importedOrderId = containerToIntent(importedOrder).orderId();
 		const existingIndex = store.orders.findIndex(
-			(o) => orderToIntent(o).orderId() === importedOrderId
+			(o) => containerToIntent(o).orderId() === importedOrderId
 		);
 		await store.saveOrderToDb(importedOrder);
 		selectedOrder =
-			store.orders.find((o) => orderToIntent(o).orderId() === importedOrderId) ?? importedOrder;
+			store.orders.find((o) => containerToIntent(o).orderId() === importedOrderId) ?? importedOrder;
 		return existingIndex >= 0 ? "updated" : "inserted";
 	}
 	async function deleteOrderById(orderId: `0x${string}`): Promise<void> {
 		await store.deleteOrderFromDb(orderId);
-		if (selectedOrder && orderToIntent(selectedOrder).orderId() === orderId) {
+		if (selectedOrder && containerToIntent(selectedOrder).orderId() === orderId) {
 			selectedOrder = undefined;
 		}
 	}

--- a/tests/unit/recipientField.test.ts
+++ b/tests/unit/recipientField.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { isAddress } from "viem";
+
+// Mirrors the resolveRecipient helper in IssueIntent.svelte
+const resolveRecipient = (value: string): `0x${string}` | undefined =>
+	isAddress(value, { strict: false }) ? (value as `0x${string}`) : undefined;
+
+describe("resolveRecipient", () => {
+	it("returns the address for a valid checksummed EVM address", () => {
+		const addr = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+		expect(resolveRecipient(addr)).toBe(addr);
+	});
+
+	it("returns the address for a valid lowercase EVM address (strict: false)", () => {
+		const addr = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
+		expect(resolveRecipient(addr)).toBe(addr);
+	});
+
+	it("returns undefined for an empty string", () => {
+		expect(resolveRecipient("")).toBeUndefined();
+	});
+
+	it("returns undefined for a partial address", () => {
+		expect(resolveRecipient("0x1234")).toBeUndefined();
+	});
+
+	it("returns undefined for arbitrary non-address text", () => {
+		expect(resolveRecipient("alice.eth")).toBeUndefined();
+	});
+
+	it("returns undefined for a hex string that is too long", () => {
+		expect(resolveRecipient("0x" + "a".repeat(42))).toBeUndefined();
+	});
+});
+
+describe("outputRecipient in AppCreateIntentOptions", () => {
+	it("is undefined when recipient field is empty", () => {
+		const recipient = "";
+		const outputRecipient = resolveRecipient(recipient);
+		expect(outputRecipient).toBeUndefined();
+	});
+
+	it("is set when a valid address is provided", () => {
+		const recipient = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+		const outputRecipient = resolveRecipient(recipient);
+		expect(outputRecipient).toBe(recipient);
+	});
+
+	it("is undefined for an invalid address, so wallet default is used", () => {
+		const recipient = "not-an-address";
+		const outputRecipient = resolveRecipient(recipient);
+		expect(outputRecipient).toBeUndefined();
+	});
+});

--- a/tests/unit/recipientField.test.ts
+++ b/tests/unit/recipientField.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { isAddress } from "viem";
+import { isValidSolanaAddress, solanaAddressToBytes32 } from "../../src/lib/utils/solana";
 
 // Mirrors the resolveRecipient helper in IssueIntent.svelte
 const resolveRecipient = (value: string): `0x${string}` | undefined =>
@@ -50,5 +51,54 @@ describe("outputRecipient in AppCreateIntentOptions", () => {
 		const recipient = "not-an-address";
 		const outputRecipient = resolveRecipient(recipient);
 		expect(outputRecipient).toBeUndefined();
+	});
+});
+
+// Known Solana devnet USDC mint and its expected bytes32 encoding
+const USDC_DEVNET_B58 = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+const USDC_DEVNET_BYTES32 = "0x3b442cb3912157f13a933d0134282d032b5ffecd01a2dbf1b7790608df002ea7";
+
+describe("isValidSolanaAddress", () => {
+	it("returns true for a valid 32-byte base58 pubkey", () => {
+		expect(isValidSolanaAddress(USDC_DEVNET_B58)).toBe(true);
+	});
+
+	it("returns true for a well-known system program address", () => {
+		expect(isValidSolanaAddress("11111111111111111111111111111111")).toBe(true);
+	});
+
+	it("returns false for an empty string", () => {
+		expect(isValidSolanaAddress("")).toBe(false);
+	});
+
+	it("returns false for an EVM address", () => {
+		expect(isValidSolanaAddress("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")).toBe(false);
+	});
+
+	it("returns false for invalid base58 characters (0, O, I, l)", () => {
+		expect(isValidSolanaAddress("0OIl" + "1".repeat(28))).toBe(false);
+	});
+
+	it("returns false for a base58 string that decodes to fewer than 32 bytes", () => {
+		expect(isValidSolanaAddress("1111111")).toBe(false);
+	});
+});
+
+describe("solanaAddressToBytes32", () => {
+	it("encodes a known devnet USDC mint to its expected bytes32", () => {
+		expect(solanaAddressToBytes32(USDC_DEVNET_B58)).toBe(USDC_DEVNET_BYTES32);
+	});
+
+	it("returns a 66-character hex string (0x + 64 hex chars)", () => {
+		const result = solanaAddressToBytes32(USDC_DEVNET_B58);
+		expect(result).toMatch(/^0x[0-9a-f]{64}$/);
+	});
+
+	it("throws for an invalid Solana address", () => {
+		expect(() => solanaAddressToBytes32("not-valid")).toThrow();
+	});
+
+	it("throws for a base58 string that decodes to fewer than 32 bytes", () => {
+		expect(() => solanaAddressToBytes32("1111111")).toThrow();
 	});
 });


### PR DESCRIPTION
## Summary

- Adds Solana devnet as a selectable output destination in the IssueIntent screen
- Adds `solanaMainnet`, `solanaTestnet`, `solanaDevnet` chain definitions via viem `defineChain`, merged into `chainMap` and `chainById`
- Imports `SOLANA_MAINNET_CHAIN_ID`, `SOLANA_TESTNET_CHAIN_ID`, `SOLANA_DEVNET_CHAIN_ID` from `@lifi/intent` — no more hardcoded numeric constants
- Exports `SOLANA_CHAIN_IDS` set, `evmCoinList`, and `solanaCoinList` helpers from `config.ts`
- Adds Solana USDC (devnet + mainnet) and native SOL tokens to `coinList`
- Adds a conditional "Solana Recipient" field (required when Solana output is selected) and "EVM Recipient" field (optional when EVM output is selected)
- Blocks intent submission with a disabled button when a Solana output is selected but no valid Solana recipient has been entered
- Fixes `getCoin()` address matching for 66-char bytes32 Solana token addresses
- Whitelists Solana output settler PDAs in `allowedOutputSettlers` via `SOLANA_OUTPUT_SETTLER_PDAS` from `@lifi/intent`

## Test Plan

- [x] Switch to testnet, select a Solana devnet output token (USDC) — "Solana Recipient" field appears and is required
- [x] Leave Solana Recipient empty — submit button shows "Solana Recipient Required" (disabled)
- [x] Enter a valid base58 Solana address — submit button becomes active
- [x] Submit an EVM→Solana intent and confirm it appears in the Intent API with correct output settler and oracle
- [x] Select an EVM-only output — only "EVM Recipient" field is shown (optional)
- [x] Run unit tests: `bun test tests/unit/recipientField.test.ts` — all 19 tests pass

## Linear Ticket

Closes [V2-111 — Issue EVM to Solana orders](https://linear.app/lifi-linear/issue/V2-111/issue-evm-to-solana-orders)

## Expected output


https://github.com/user-attachments/assets/86dab61b-bfb1-429f-b8dd-53937af21f05

