### PR TITLE
feat: issue solana to evm orders

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@solana/wallet-adapter-base": "^0.9.27",
         "@solana/wallet-adapter-phantom": "^0.9.29",
         "@solana/wallet-adapter-solflare": "^0.6.33",
+        "@solana/web3.js": "^1.98.4",
         "@sveltejs/adapter-cloudflare": "^7.0.3",
         "@wagmi/connectors": "^7.2.1",
         "@wagmi/core": "^3.4.0",
@@ -252,7 +253,7 @@
 
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
-    "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+    "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -1152,8 +1153,6 @@
 
     "@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "@solana/web3.js/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
-
     "@solana/web3.js/borsh": ["borsh@0.7.0", "", { "dependencies": { "bn.js": "^5.2.0", "bs58": "^4.0.0", "text-encoding-utf-8": "^1.0.2" } }, "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA=="],
 
     "@solflare-wallet/sdk/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
@@ -1165,8 +1164,6 @@
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "base-x/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
-    "eciesjs/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "ethereum-cryptography/@noble/curves": ["@noble/curves@1.4.2", "", { "dependencies": { "@noble/hashes": "1.4.0" } }, "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw=="],
 
@@ -1198,6 +1195,8 @@
 
     "obj-multiplex/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "postcss-load-config/lilconfig": ["lilconfig@2.1.0", "", {}, "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="],
@@ -1213,6 +1212,8 @@
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "wrangler/esbuild": ["esbuild@0.25.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.4", "@esbuild/android-arm": "0.25.4", "@esbuild/android-arm64": "0.25.4", "@esbuild/android-x64": "0.25.4", "@esbuild/darwin-arm64": "0.25.4", "@esbuild/darwin-x64": "0.25.4", "@esbuild/freebsd-arm64": "0.25.4", "@esbuild/freebsd-x64": "0.25.4", "@esbuild/linux-arm": "0.25.4", "@esbuild/linux-arm64": "0.25.4", "@esbuild/linux-ia32": "0.25.4", "@esbuild/linux-loong64": "0.25.4", "@esbuild/linux-mips64el": "0.25.4", "@esbuild/linux-ppc64": "0.25.4", "@esbuild/linux-riscv64": "0.25.4", "@esbuild/linux-s390x": "0.25.4", "@esbuild/linux-x64": "0.25.4", "@esbuild/netbsd-arm64": "0.25.4", "@esbuild/netbsd-x64": "0.25.4", "@esbuild/openbsd-arm64": "0.25.4", "@esbuild/openbsd-x64": "0.25.4", "@esbuild/sunos-x64": "0.25.4", "@esbuild/win32-arm64": "0.25.4", "@esbuild/win32-ia32": "0.25.4", "@esbuild/win32-x64": "0.25.4" }, "bin": "bin/esbuild" }, "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "cat-swapper",
       "dependencies": {
+        "@coral-xyz/anchor": "^0.32.1",
         "@electric-sql/pglite": "^0.3.15",
         "@lifi/intent": "0.0.4",
         "@metamask/sdk": "^0.34.0",
@@ -51,6 +52,9 @@
       },
     },
   },
+  "overrides": {
+    "bigint-buffer": "npm:bigint-buffer-fixed@^1.1.6",
+  },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.0", "", {}, "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="],
 
@@ -73,6 +77,12 @@
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250803.0", "", { "os": "win32", "cpu": "x64" }, "sha512-uLV8gdudz36o9sUaAKbBxxTwZwLFz1KyW7QpBvOo4+r3Ib8yVKXGiySIMWGD7A0urSMrjf3e5LlLcJKgZUOjMA=="],
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20250807.0", "", {}, "sha512-Zbrz9egAfwmlkUaZ1tQ+19pt5eomCJ57mAviT1HCsvnSFP1MoffMbYiU/xUomuekHtx0aVO4EacZwchCgjSvmw=="],
+
+    "@coral-xyz/anchor": ["@coral-xyz/anchor@0.32.1", "", { "dependencies": { "@coral-xyz/anchor-errors": "^0.31.1", "@coral-xyz/borsh": "^0.31.1", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.69.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-zAyxFtfeje2FbMA1wzgcdVs7Hng/MijPKpRijoySPCicnvcTQs/+dnPZ/cR+LcXM9v9UYSyW81uRNYZtN5G4yg=="],
+
+    "@coral-xyz/anchor-errors": ["@coral-xyz/anchor-errors@0.31.1", "", {}, "sha512-NhNEku4F3zzUSBtrYz84FzYWm48+9OvmT1Hhnwr6GnPQry2dsEqH/ti/7ASjjpoFTWRnPXrjAIT1qM6Isop+LQ=="],
+
+    "@coral-xyz/borsh": ["@coral-xyz/borsh@0.31.1", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.69.0" } }, "sha512-9N8AU9F0ubriKfNE3g1WF0/4dtlGXoBN/hd1PvbNBamBNwRgHxH4P+o3Zt7rSEloW1HUs6LfZEchlx9fW7POYw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -167,6 +177,8 @@
     "@ethereumjs/tx": ["@ethereumjs/tx@4.2.0", "", { "dependencies": { "@ethereumjs/common": "^3.2.0", "@ethereumjs/rlp": "^4.0.1", "@ethereumjs/util": "^8.1.0", "ethereum-cryptography": "^2.0.0" } }, "sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw=="],
 
     "@ethereumjs/util": ["@ethereumjs/util@8.1.0", "", { "dependencies": { "@ethereumjs/rlp": "^4.0.1", "ethereum-cryptography": "^2.0.0", "micro-ftch": "^0.3.1" } }, "sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA=="],
+
+    "@gar/promisify": ["@gar/promisify@1.1.3", "", {}, "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -263,6 +275,10 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@npmcli/fs": ["@npmcli/fs@2.1.2", "", { "dependencies": { "@gar/promisify": "^1.1.3", "semver": "^7.3.5" } }, "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ=="],
+
+    "@npmcli/move-file": ["@npmcli/move-file@2.0.1", "", { "dependencies": { "mkdirp": "^1.0.4", "rimraf": "^3.0.2" } }, "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ=="],
 
     "@paulmillr/qr": ["@paulmillr/qr@0.2.1", "", {}, "sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ=="],
 
@@ -412,6 +428,8 @@
 
     "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
 
+    "@tootallnate/once": ["@tootallnate/once@2.0.0", "", {}, "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="],
+
     "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
@@ -460,6 +478,8 @@
 
     "@wallet-standard/features": ["@wallet-standard/features@1.1.0", "", { "dependencies": { "@wallet-standard/base": "^1.1.0" } }, "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg=="],
 
+    "abbrev": ["abbrev@1.1.1", "", {}, "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="],
+
     "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" } }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": "bin/acorn" }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
@@ -468,7 +488,11 @@
 
     "acorn-walk": ["acorn-walk@8.3.2", "", {}, "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="],
 
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
+
+    "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
 
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
@@ -477,6 +501,10 @@
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "aproba": ["aproba@2.1.0", "", {}, "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew=="],
+
+    "are-we-there-yet": ["are-we-there-yet@3.0.1", "", { "dependencies": { "delegates": "^1.0.0", "readable-stream": "^3.6.0" } }, "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -496,7 +524,7 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "bigint-buffer": ["bigint-buffer@1.1.5", "", { "dependencies": { "bindings": "^1.3.0" } }, "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA=="],
+    "bigint-buffer": ["bigint-buffer-fixed@1.1.6", "", { "dependencies": { "bindings": "^1.5.0", "nan": "^2.14.2", "node-gyp": "^9.4.1" } }, "sha512-BSlDL9PxCwBn+Q3V/mrEr1sZuKNlS2py34gxNno9uVvbp2bBNSa1zkHsK3eCmh/Gv99p82TS6eLUXafoIm+EyQ=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
@@ -520,9 +548,13 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
+    "buffer-layout": ["buffer-layout@1.2.2", "", {}, "sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA=="],
+
     "bufferutil": ["bufferutil@4.1.0", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw=="],
 
     "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
+
+    "cacache": ["cacache@16.1.3", "", { "dependencies": { "@npmcli/fs": "^2.1.0", "@npmcli/move-file": "^2.0.0", "chownr": "^2.0.0", "fs-minipass": "^2.1.0", "glob": "^8.0.1", "infer-owner": "^1.0.4", "lru-cache": "^7.7.1", "minipass": "^3.1.6", "minipass-collect": "^1.0.2", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "mkdirp": "^1.0.4", "p-map": "^4.0.0", "promise-inflight": "^1.0.1", "rimraf": "^3.0.2", "ssri": "^9.0.0", "tar": "^6.1.11", "unique-filename": "^2.0.0" } }, "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
@@ -532,11 +564,15 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
+    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
+    "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
 
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
@@ -552,6 +588,8 @@
 
     "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
 
+    "color-support": ["color-support@1.1.3", "", { "bin": { "color-support": "bin.js" } }, "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="],
+
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
@@ -560,13 +598,15 @@
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
+    "console-control-strings": ["console-control-strings@1.1.0", "", {}, "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="],
+
     "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
-    "cross-fetch": ["cross-fetch@4.1.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw=="],
+    "cross-fetch": ["cross-fetch@3.2.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -588,6 +628,8 @@
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
+    "delegates": ["delegates@1.0.0", "", {}, "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="],
+
     "detect-browser": ["detect-browser@5.3.0", "", {}, "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="],
 
     "detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
@@ -606,6 +648,8 @@
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
+    "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
+
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "engine.io-client": ["engine.io-client@6.6.4", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.18.3", "xmlhttprequest-ssl": "~2.1.1" } }, "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw=="],
@@ -614,7 +658,11 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.18.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww=="],
 
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "err-code": ["err-code@2.0.3", "", {}, "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="],
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
@@ -666,9 +714,11 @@
 
     "eventemitter2": ["eventemitter2@6.4.9", "", {}, "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="],
 
-    "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "exit-hook": ["exit-hook@2.2.1", "", {}, "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="],
+
+    "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
 
     "exsolve": ["exsolve@1.0.7", "", {}, "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw=="],
 
@@ -712,9 +762,15 @@
 
     "form-data": ["form-data@4.0.4", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow=="],
 
+    "fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gauge": ["gauge@4.0.4", "", { "dependencies": { "aproba": "^1.0.3 || ^2.0.0", "color-support": "^1.1.3", "console-control-strings": "^1.1.0", "has-unicode": "^2.0.1", "signal-exit": "^3.0.7", "string-width": "^4.2.3", "strip-ansi": "^6.0.1", "wide-align": "^1.1.5" } }, "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg=="],
 
     "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 
@@ -725,6 +781,8 @@
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
+
+    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -746,11 +804,21 @@
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
+    "has-unicode": ["has-unicode@2.0.1", "", {}, "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="],
+
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@5.0.0", "", { "dependencies": { "@tootallnate/once": "2", "agent-base": "6", "debug": "4" } }, "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w=="],
+
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -760,7 +828,15 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "infer-owner": ["infer-owner@1.0.4", "", {}, "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="],
+
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
 
@@ -775,6 +851,8 @@
     "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-lambda": ["is-lambda@1.0.1", "", {}, "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -854,7 +932,11 @@
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
+    "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
     "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
+
+    "make-fetch-happen": ["make-fetch-happen@10.2.1", "", { "dependencies": { "agentkeepalive": "^4.2.1", "cacache": "^16.1.0", "http-cache-semantics": "^4.1.0", "http-proxy-agent": "^5.0.0", "https-proxy-agent": "^5.0.0", "is-lambda": "^1.0.1", "lru-cache": "^7.7.1", "minipass": "^3.1.6", "minipass-collect": "^1.0.2", "minipass-fetch": "^2.0.3", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^0.6.3", "promise-retry": "^2.0.1", "socks-proxy-agent": "^7.0.0", "ssri": "^9.0.0" } }, "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -878,6 +960,16 @@
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
+    "minipass-collect": ["minipass-collect@1.0.2", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA=="],
+
+    "minipass-fetch": ["minipass-fetch@2.1.2", "", { "dependencies": { "minipass": "^3.1.6", "minipass-sized": "^1.0.3", "minizlib": "^2.1.2" }, "optionalDependencies": { "encoding": "^0.1.13" } }, "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA=="],
+
+    "minipass-flush": ["minipass-flush@1.0.7", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA=="],
+
+    "minipass-pipeline": ["minipass-pipeline@1.2.4", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A=="],
+
+    "minipass-sized": ["minipass-sized@1.0.3", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g=="],
+
     "minizlib": ["minizlib@3.0.2", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA=="],
 
     "mipd": ["mipd@0.0.7", "", { "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-aAPZPNDQ3uMTdKbuO2YmAw2TxLHO0moa4YKAyETM/DTj5FloZo+a+8tU+iv4GmW+sOxKLSRwcSFuczk+Cpt6fg=="],
@@ -890,15 +982,25 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "nan": ["nan@2.26.2", "", {}, "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw=="],
+
     "nano-spawn": ["nano-spawn@1.0.3", "", {}, "sha512-jtpsQDetTnvS2Ts1fiRdci5rx0VYws5jGyC+4IYOTnIQ/wwdf6JdomlHBwqC3bJYOvaKu0C2GSZ1A60anrYpaA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
+    "negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
+
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
+    "node-gyp": ["node-gyp@9.4.1", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "glob": "^7.1.4", "graceful-fs": "^4.2.6", "make-fetch-happen": "^10.0.3", "nopt": "^6.0.0", "npmlog": "^6.0.0", "rimraf": "^3.0.2", "semver": "^7.3.5", "tar": "^6.1.2", "which": "^2.0.2" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ=="],
+
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
+    "nopt": ["nopt@6.0.0", "", { "dependencies": { "abbrev": "^1.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g=="],
+
+    "npmlog": ["npmlog@6.0.2", "", { "dependencies": { "are-we-there-yet": "^3.0.0", "console-control-strings": "^1.1.0", "gauge": "^4.0.3", "set-blocking": "^2.0.0" } }, "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg=="],
 
     "obj-multiplex": ["obj-multiplex@1.0.0", "", { "dependencies": { "end-of-stream": "^1.4.0", "once": "^1.4.0", "readable-stream": "^2.3.3" } }, "sha512-0GNJAOsHoBHeNTvl5Vt6IWnpUEcc3uSRxzBri7EDyIcMgYvnY2JL2qdeV5zTMjWQX5OHcD5amcW2HFfDh0gjIA=="],
 
@@ -920,9 +1022,15 @@
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
+    "p-map": ["p-map@4.0.0", "", { "dependencies": { "aggregate-error": "^3.0.0" } }, "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ=="],
+
+    "pako": ["pako@2.1.0", "", {}, "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="],
+
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -964,6 +1072,10 @@
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
+    "promise-inflight": ["promise-inflight@1.0.1", "", {}, "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g=="],
+
+    "promise-retry": ["promise-retry@2.0.1", "", { "dependencies": { "err-code": "^2.0.2", "retry": "^0.12.0" } }, "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g=="],
+
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
@@ -986,9 +1098,13 @@
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "rollup": ["rollup@4.46.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.46.2", "@rollup/rollup-android-arm64": "4.46.2", "@rollup/rollup-darwin-arm64": "4.46.2", "@rollup/rollup-darwin-x64": "4.46.2", "@rollup/rollup-freebsd-arm64": "4.46.2", "@rollup/rollup-freebsd-x64": "4.46.2", "@rollup/rollup-linux-arm-gnueabihf": "4.46.2", "@rollup/rollup-linux-arm-musleabihf": "4.46.2", "@rollup/rollup-linux-arm64-gnu": "4.46.2", "@rollup/rollup-linux-arm64-musl": "4.46.2", "@rollup/rollup-linux-loongarch64-gnu": "4.46.2", "@rollup/rollup-linux-ppc64-gnu": "4.46.2", "@rollup/rollup-linux-riscv64-gnu": "4.46.2", "@rollup/rollup-linux-riscv64-musl": "4.46.2", "@rollup/rollup-linux-s390x-gnu": "4.46.2", "@rollup/rollup-linux-x64-gnu": "4.46.2", "@rollup/rollup-linux-x64-musl": "4.46.2", "@rollup/rollup-win32-arm64-msvc": "4.46.2", "@rollup/rollup-win32-ia32-msvc": "4.46.2", "@rollup/rollup-win32-x64-msvc": "4.46.2", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg=="],
 
@@ -1000,11 +1116,15 @@
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
-    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "semver": ["semver@7.7.2", "", { "bin": "bin/semver.js" }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
+    "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
     "set-cookie-parser": ["set-cookie-parser@2.7.1", "", {}, "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="],
 
@@ -1024,15 +1144,23 @@
 
     "slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
 
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
     "socket.io-client": ["socket.io-client@4.8.3", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-client": "~6.6.1", "socket.io-parser": "~4.2.4" } }, "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g=="],
 
     "socket.io-parser": ["socket.io-parser@4.2.5", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1" } }, "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ=="],
+
+    "socks": ["socks@2.8.7", "", { "dependencies": { "ip-address": "^10.0.1", "smart-buffer": "^4.2.0" } }, "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@7.0.0", "", { "dependencies": { "agent-base": "^6.0.2", "debug": "^4.3.3", "socks": "^2.6.2" } }, "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "ssri": ["ssri@9.0.1", "", { "dependencies": { "minipass": "^3.1.1" } }, "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q=="],
 
     "stoppable": ["stoppable@1.1.0", "", {}, "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="],
 
@@ -1050,7 +1178,7 @@
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
-    "superstruct": ["superstruct@2.0.2", "", {}, "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="],
+    "superstruct": ["superstruct@0.15.5", "", {}, "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -1071,6 +1199,8 @@
     "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "toml": ["toml@3.0.0", "", {}, "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="],
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
@@ -1093,6 +1223,10 @@
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unenv": ["unenv@2.0.0-rc.19", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.7", "ohash": "^2.0.11", "pathe": "^2.0.3", "ufo": "^1.6.1" } }, "sha512-t/OMHBNAkknVCI7bVB9OWjUUAwhVv9vsPIAGnNUxnu3FxPQN11rjh0sksLMzc3g7IlTgvHmOTl4JM7JHpcv5wA=="],
+
+    "unique-filename": ["unique-filename@2.0.1", "", { "dependencies": { "unique-slug": "^3.0.0" } }, "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A=="],
+
+    "unique-slug": ["unique-slug@3.0.0", "", { "dependencies": { "imurmurhash": "^0.1.4" } }, "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
@@ -1123,6 +1257,8 @@
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
+
+    "wide-align": ["wide-align@1.1.5", "", { "dependencies": { "string-width": "^1.0.2 || 2 || 3 || 4" } }, "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -1168,11 +1304,17 @@
 
     "@metamask/rpc-errors/@metamask/utils": ["@metamask/utils@9.3.0", "", { "dependencies": { "@ethereumjs/tx": "^4.2.0", "@metamask/superstruct": "^3.1.0", "@noble/hashes": "^1.3.1", "@scure/base": "^1.1.3", "@types/debug": "^4.1.7", "debug": "^4.3.4", "pony-cause": "^2.1.10", "semver": "^7.5.4", "uuid": "^9.0.1" } }, "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g=="],
 
+    "@metamask/sdk/cross-fetch": ["cross-fetch@4.1.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw=="],
+
     "@metamask/sdk/debug": ["debug@4.3.4", "", { "dependencies": { "ms": "2.1.2" } }, "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ=="],
+
+    "@metamask/sdk-communication-layer/cross-fetch": ["cross-fetch@4.1.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw=="],
 
     "@metamask/sdk-communication-layer/debug": ["debug@4.3.4", "", { "dependencies": { "ms": "2.1.2" } }, "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ=="],
 
     "@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "@npmcli/move-file/mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
     "@poppinss/dumper/supports-color": ["supports-color@10.1.0", "", {}, "sha512-GBuewsPrhJPftT+fqDa9oI/zc5HNsG9nREqwzoSFDOIqf0NggOZbHQj2TE1P1CDJK8ZogFnlZY9hWoUiur7I/A=="],
 
@@ -1202,9 +1344,15 @@
 
     "@solana/options/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
 
+    "@solana/wallet-adapter-base/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
     "@solana/web3.js/borsh": ["borsh@0.7.0", "", { "dependencies": { "bn.js": "^5.2.0", "bs58": "^4.0.0", "text-encoding-utf-8": "^1.0.2" } }, "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA=="],
 
+    "@solana/web3.js/superstruct": ["superstruct@2.0.2", "", {}, "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="],
+
     "@solflare-wallet/sdk/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
+
+    "@solflare-wallet/sdk/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "@solflare-wallet/sdk/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
@@ -1212,7 +1360,17 @@
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "base-x/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+    "@wagmi/core/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "cacache/chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
+
+    "cacache/glob": ["glob@8.1.0", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^5.0.1", "once": "^1.3.0" } }, "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ=="],
+
+    "cacache/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "cacache/mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
+
+    "cacache/tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
 
     "ethereum-cryptography/@noble/curves": ["@noble/curves@1.4.2", "", { "dependencies": { "@noble/hashes": "1.4.0" } }, "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw=="],
 
@@ -1224,6 +1382,14 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "gauge/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "gauge/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "gauge/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "jayson/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "jayson/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
@@ -1232,7 +1398,11 @@
 
     "lint-staged/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "listr2/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
+
+    "make-fetch-happen/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -1242,9 +1412,25 @@
 
     "miniflare/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
 
+    "minipass-collect/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-fetch/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-fetch/minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
+
+    "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-sized/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "node-gyp/tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
+
     "obj-multiplex/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
+    "ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
@@ -1254,15 +1440,19 @@
 
     "rpc-websockets/@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
+    "rpc-websockets/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
     "rpc-websockets/utf-8-validate": ["utf-8-validate@6.0.6", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA=="],
 
     "rpc-websockets/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+    "ssri/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
+    "wide-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "wrangler/esbuild": ["esbuild@0.25.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.4", "@esbuild/android-arm": "0.25.4", "@esbuild/android-arm64": "0.25.4", "@esbuild/android-x64": "0.25.4", "@esbuild/darwin-arm64": "0.25.4", "@esbuild/darwin-x64": "0.25.4", "@esbuild/freebsd-arm64": "0.25.4", "@esbuild/freebsd-x64": "0.25.4", "@esbuild/linux-arm": "0.25.4", "@esbuild/linux-arm64": "0.25.4", "@esbuild/linux-ia32": "0.25.4", "@esbuild/linux-loong64": "0.25.4", "@esbuild/linux-mips64el": "0.25.4", "@esbuild/linux-ppc64": "0.25.4", "@esbuild/linux-riscv64": "0.25.4", "@esbuild/linux-s390x": "0.25.4", "@esbuild/linux-x64": "0.25.4", "@esbuild/netbsd-arm64": "0.25.4", "@esbuild/netbsd-x64": "0.25.4", "@esbuild/openbsd-arm64": "0.25.4", "@esbuild/openbsd-x64": "0.25.4", "@esbuild/sunos-x64": "0.25.4", "@esbuild/win32-arm64": "0.25.4", "@esbuild/win32-ia32": "0.25.4", "@esbuild/win32-x64": "0.25.4" }, "bin": "bin/esbuild" }, "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q=="],
 
@@ -1340,15 +1530,67 @@
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
+    "cacache/glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+
+    "cacache/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "cacache/tar/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
+
+    "cacache/tar/minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
+
+    "cacache/tar/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
     "ethereum-cryptography/@scure/bip32/@scure/base": ["@scure/base@1.1.9", "", {}, "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="],
 
     "ethereum-cryptography/@scure/bip39/@scure/base": ["@scure/base@1.1.9", "", {}, "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="],
+
+    "fs-minipass/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "gauge/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "gauge/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "gauge/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "log-update/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
+    "make-fetch-happen/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-collect/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-fetch/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-fetch/minizlib/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-flush/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-pipeline/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-sized/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "node-gyp/tar/chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
+
+    "node-gyp/tar/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
+
+    "node-gyp/tar/minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
+
+    "node-gyp/tar/mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
+
+    "node-gyp/tar/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "obj-multiplex/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
     "obj-multiplex/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "ssri/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "wide-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wide-align/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "wide-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q=="],
 
@@ -1407,5 +1649,13 @@
     "@solana/codecs/@solana/codecs-numbers/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "@solana/codecs/@solana/codecs-numbers/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "cacache/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "cacache/tar/minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "node-gyp/tar/minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "wide-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@electric-sql/pglite": "^0.3.15",
         "@lifi/intent": "0.0.4",
         "@metamask/sdk": "^0.34.0",
+        "@solana/spl-token": "^0.4.14",
         "@solana/wallet-adapter-base": "^0.9.27",
         "@solana/wallet-adapter-phantom": "^0.9.29",
         "@solana/wallet-adapter-solflare": "^0.6.33",
@@ -327,11 +328,27 @@
 
     "@solana/buffer-layout": ["@solana/buffer-layout@4.0.1", "", { "dependencies": { "buffer": "~6.0.3" } }, "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA=="],
 
+    "@solana/buffer-layout-utils": ["@solana/buffer-layout-utils@0.2.0", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/web3.js": "^1.32.0", "bigint-buffer": "^1.1.5", "bignumber.js": "^9.0.1" } }, "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g=="],
+
+    "@solana/codecs": ["@solana/codecs@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/codecs-data-structures": "2.0.0-rc.1", "@solana/codecs-numbers": "2.0.0-rc.1", "@solana/codecs-strings": "2.0.0-rc.1", "@solana/options": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ=="],
+
     "@solana/codecs-core": ["@solana/codecs-core@2.3.0", "", { "dependencies": { "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw=="],
+
+    "@solana/codecs-data-structures": ["@solana/codecs-data-structures@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/codecs-numbers": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog=="],
 
     "@solana/codecs-numbers": ["@solana/codecs-numbers@2.3.0", "", { "dependencies": { "@solana/codecs-core": "2.3.0", "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg=="],
 
+    "@solana/codecs-strings": ["@solana/codecs-strings@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/codecs-numbers": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5" } }, "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g=="],
+
     "@solana/errors": ["@solana/errors@2.3.0", "", { "dependencies": { "chalk": "^5.4.1", "commander": "^14.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ=="],
+
+    "@solana/options": ["@solana/options@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/codecs-data-structures": "2.0.0-rc.1", "@solana/codecs-numbers": "2.0.0-rc.1", "@solana/codecs-strings": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA=="],
+
+    "@solana/spl-token": ["@solana/spl-token@0.4.14", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-group": "^0.0.7", "@solana/spl-token-metadata": "^0.1.6", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.95.5" } }, "sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA=="],
+
+    "@solana/spl-token-group": ["@solana/spl-token-group@0.0.7", "", { "dependencies": { "@solana/codecs": "2.0.0-rc.1" }, "peerDependencies": { "@solana/web3.js": "^1.95.3" } }, "sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug=="],
+
+    "@solana/spl-token-metadata": ["@solana/spl-token-metadata@0.1.6", "", { "dependencies": { "@solana/codecs": "2.0.0-rc.1" }, "peerDependencies": { "@solana/web3.js": "^1.95.3" } }, "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA=="],
 
     "@solana/wallet-adapter-base": ["@solana/wallet-adapter-base@0.9.27", "", { "dependencies": { "@solana/wallet-standard-features": "^1.3.0", "@wallet-standard/base": "^1.1.0", "@wallet-standard/features": "^1.1.0", "eventemitter3": "^5.0.1" }, "peerDependencies": { "@solana/web3.js": "^1.98.0" } }, "sha512-kXjeNfNFVs/NE9GPmysBRKQ/nf+foSaq3kfVSeMcO/iVgigyRmB551OjU3WyAolLG/1jeEfKLqF9fKwMCRkUqg=="],
 
@@ -478,6 +495,12 @@
     "base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "bigint-buffer": ["bigint-buffer@1.1.5", "", { "dependencies": { "bindings": "^1.3.0" } }, "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
@@ -665,11 +688,15 @@
 
     "fast-stable-stringify": ["fast-stable-stringify@1.0.0", "", {}, "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="],
 
+    "fastestsmallesttextencoderdecoder": ["fastestsmallesttextencoderdecoder@1.0.22", "", {}, "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="],
+
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
     "fdir": ["fdir@6.4.6", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
@@ -1151,7 +1178,29 @@
 
     "@scure/bip32/@noble/curves": ["@noble/curves@1.9.6", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA=="],
 
+    "@solana/codecs/@solana/codecs-core": ["@solana/codecs-core@2.0.0-rc.1", "", { "dependencies": { "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ=="],
+
+    "@solana/codecs/@solana/codecs-numbers": ["@solana/codecs-numbers@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ=="],
+
+    "@solana/codecs-data-structures/@solana/codecs-core": ["@solana/codecs-core@2.0.0-rc.1", "", { "dependencies": { "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ=="],
+
+    "@solana/codecs-data-structures/@solana/codecs-numbers": ["@solana/codecs-numbers@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ=="],
+
+    "@solana/codecs-data-structures/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
+
+    "@solana/codecs-strings/@solana/codecs-core": ["@solana/codecs-core@2.0.0-rc.1", "", { "dependencies": { "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ=="],
+
+    "@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ=="],
+
+    "@solana/codecs-strings/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
+
     "@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/options/@solana/codecs-core": ["@solana/codecs-core@2.0.0-rc.1", "", { "dependencies": { "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ=="],
+
+    "@solana/options/@solana/codecs-numbers": ["@solana/codecs-numbers@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ=="],
+
+    "@solana/options/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
 
     "@solana/web3.js/borsh": ["borsh@0.7.0", "", { "dependencies": { "bn.js": "^5.2.0", "bs58": "^4.0.0", "text-encoding-utf-8": "^1.0.2" } }, "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA=="],
 
@@ -1271,6 +1320,22 @@
 
     "@metamask/sdk/debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
 
+    "@solana/codecs-data-structures/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/codecs-data-structures/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "@solana/codecs-strings/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/codecs-strings/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "@solana/codecs/@solana/codecs-core/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
+
+    "@solana/codecs/@solana/codecs-numbers/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
+
+    "@solana/options/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/options/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
     "@solflare-wallet/sdk/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
@@ -1334,5 +1399,13 @@
     "wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg=="],
 
     "wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.4", "", { "os": "win32", "cpu": "x64" }, "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ=="],
+
+    "@solana/codecs/@solana/codecs-core/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/codecs/@solana/codecs-core/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "@solana/codecs/@solana/codecs-numbers/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/codecs/@solana/codecs-numbers/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,11 @@
 		"typescript-eslint": "^8.20.0",
 		"vite": "^7.1.1"
 	},
+	"overrides": {
+		"bigint-buffer": "npm:bigint-buffer-fixed@^1.1.6"
+	},
 	"dependencies": {
+		"@coral-xyz/anchor": "^0.32.1",
 		"@electric-sql/pglite": "^0.3.15",
 		"@lifi/intent": "0.0.4",
 		"@metamask/sdk": "^0.34.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"@solana/wallet-adapter-base": "^0.9.27",
 		"@solana/wallet-adapter-phantom": "^0.9.29",
 		"@solana/wallet-adapter-solflare": "^0.6.33",
+		"@solana/web3.js": "^1.98.4",
 		"@sveltejs/adapter-cloudflare": "^7.0.3",
 		"@wagmi/connectors": "^7.2.1",
 		"@wagmi/core": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"@electric-sql/pglite": "^0.3.15",
 		"@lifi/intent": "0.0.4",
 		"@metamask/sdk": "^0.34.0",
+		"@solana/spl-token": "^0.4.14",
 		"@solana/wallet-adapter-base": "^0.9.27",
 		"@solana/wallet-adapter-phantom": "^0.9.29",
 		"@solana/wallet-adapter-solflare": "^0.6.33",

--- a/src/lib/abi/input_settler_escrow.json
+++ b/src/lib/abi/input_settler_escrow.json
@@ -1,0 +1,691 @@
+{
+	"address": "5QngyaYhNscSebqV4DwYQhk333p5CMP8A9yyLX3pPyXC",
+	"metadata": {
+		"name": "input_settler_escrow",
+		"version": "0.0.0",
+		"spec": "0.1.0"
+	},
+	"instructions": [
+		{
+			"name": "finalise",
+			"docs": [
+				"Finalise a filled order and send the order's input funds to the order's solver.",
+				"`order` is the order to be finalised.",
+				"`solve_params` are the solver parameters that filled each output (one per output). The first solver must be",
+				"the signer."
+			],
+			"discriminator": [197, 63, 114, 249, 245, 72, 39, 132],
+			"accounts": [
+				{
+					"name": "solver",
+					"writable": true,
+					"signer": true
+				},
+				{
+					"name": "input_settler_escrow",
+					"pda": {
+						"seeds": [
+							{
+								"kind": "const",
+								"value": [
+									105, 110, 112, 117, 116, 95, 115, 101, 116, 116, 108, 101, 114, 95, 101, 115, 99,
+									114, 111, 119
+								]
+							}
+						]
+					}
+				},
+				{
+					"name": "user"
+				},
+				{
+					"name": "destination"
+				},
+				{
+					"name": "destination_token_account",
+					"writable": true,
+					"pda": {
+						"seeds": [
+							{
+								"kind": "account",
+								"path": "destination"
+							},
+							{
+								"kind": "const",
+								"value": [
+									6, 221, 246, 225, 215, 101, 161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28,
+									180, 133, 237, 95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169
+								]
+							},
+							{
+								"kind": "account",
+								"path": "mint"
+							}
+						],
+						"program": {
+							"kind": "const",
+							"value": [
+								140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+								153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+							]
+						}
+					}
+				},
+				{
+					"name": "order_context",
+					"writable": true,
+					"pda": {
+						"seeds": [
+							{
+								"kind": "const",
+								"value": [111, 114, 100, 101, 114, 95, 99, 111, 110, 116, 101, 120, 116]
+							},
+							{
+								"kind": "arg",
+								"path": "order"
+							}
+						]
+					}
+				},
+				{
+					"name": "order_pda_token_account",
+					"writable": true,
+					"pda": {
+						"seeds": [
+							{
+								"kind": "account",
+								"path": "order_context"
+							},
+							{
+								"kind": "account",
+								"path": "token_program"
+							},
+							{
+								"kind": "account",
+								"path": "mint"
+							}
+						],
+						"program": {
+							"kind": "const",
+							"value": [
+								140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+								153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+							]
+						}
+					}
+				},
+				{
+					"name": "mint"
+				},
+				{
+					"name": "intents_protocol_program",
+					"address": "H1dVz9YXVys8c4tAihD14M5jnrUQi1MFsA65YQ92oCCz"
+				},
+				{
+					"name": "token_program"
+				},
+				{
+					"name": "associated_token_program",
+					"address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+				},
+				{
+					"name": "system_program",
+					"address": "11111111111111111111111111111111"
+				}
+			],
+			"args": [
+				{
+					"name": "order",
+					"type": {
+						"defined": {
+							"name": "StandardOrder"
+						}
+					}
+				},
+				{
+					"name": "solve_params",
+					"type": {
+						"vec": {
+							"defined": {
+								"name": "SolveParams"
+							}
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "initialize",
+			"discriminator": [175, 175, 109, 31, 13, 152, 155, 237],
+			"accounts": [
+				{
+					"name": "deployer",
+					"writable": true,
+					"signer": true
+				},
+				{
+					"name": "chain_id"
+				},
+				{
+					"name": "input_settler_escrow",
+					"writable": true,
+					"pda": {
+						"seeds": [
+							{
+								"kind": "const",
+								"value": [
+									105, 110, 112, 117, 116, 95, 115, 101, 116, 116, 108, 101, 114, 95, 101, 115, 99,
+									114, 111, 119
+								]
+							}
+						]
+					}
+				},
+				{
+					"name": "intents_protocol_program",
+					"address": "H1dVz9YXVys8c4tAihD14M5jnrUQi1MFsA65YQ92oCCz"
+				},
+				{
+					"name": "system_program",
+					"address": "11111111111111111111111111111111"
+				}
+			],
+			"args": []
+		},
+		{
+			"name": "open",
+			"docs": [
+				"Open the given `StandardOrder`. The order input funds will be pulled from the provided",
+				"user `signer` account, and will be escrowed until the order is finalised or expired."
+			],
+			"discriminator": [228, 220, 155, 71, 199, 189, 60, 45],
+			"accounts": [
+				{
+					"name": "user",
+					"writable": true,
+					"signer": true
+				},
+				{
+					"name": "input_settler_escrow",
+					"pda": {
+						"seeds": [
+							{
+								"kind": "const",
+								"value": [
+									105, 110, 112, 117, 116, 95, 115, 101, 116, 116, 108, 101, 114, 95, 101, 115, 99,
+									114, 111, 119
+								]
+							}
+						]
+					}
+				},
+				{
+					"name": "user_token_account",
+					"writable": true,
+					"pda": {
+						"seeds": [
+							{
+								"kind": "account",
+								"path": "user"
+							},
+							{
+								"kind": "account",
+								"path": "token_program"
+							},
+							{
+								"kind": "account",
+								"path": "mint"
+							}
+						],
+						"program": {
+							"kind": "const",
+							"value": [
+								140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+								153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+							]
+						}
+					}
+				},
+				{
+					"name": "order_context",
+					"writable": true,
+					"pda": {
+						"seeds": [
+							{
+								"kind": "const",
+								"value": [111, 114, 100, 101, 114, 95, 99, 111, 110, 116, 101, 120, 116]
+							},
+							{
+								"kind": "arg",
+								"path": "order"
+							}
+						]
+					}
+				},
+				{
+					"name": "order_pda_token_account",
+					"writable": true,
+					"pda": {
+						"seeds": [
+							{
+								"kind": "account",
+								"path": "order_context"
+							},
+							{
+								"kind": "account",
+								"path": "token_program"
+							},
+							{
+								"kind": "account",
+								"path": "mint"
+							}
+						],
+						"program": {
+							"kind": "const",
+							"value": [
+								140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+								153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+							]
+						}
+					}
+				},
+				{
+					"name": "mint"
+				},
+				{
+					"name": "token_program"
+				},
+				{
+					"name": "associated_token_program",
+					"address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+				},
+				{
+					"name": "system_program",
+					"address": "11111111111111111111111111111111"
+				}
+			],
+			"args": [
+				{
+					"name": "order",
+					"type": {
+						"defined": {
+							"name": "StandardOrder"
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "refund",
+			"docs": [
+				"Refund an order and send the order's input funds back to the user.",
+				"`order` is the order to be refunded."
+			],
+			"discriminator": [2, 96, 183, 251, 63, 208, 46, 46],
+			"accounts": [
+				{
+					"name": "signer",
+					"writable": true,
+					"signer": true
+				},
+				{
+					"name": "user"
+				},
+				{
+					"name": "input_settler_escrow",
+					"pda": {
+						"seeds": [
+							{
+								"kind": "const",
+								"value": [
+									105, 110, 112, 117, 116, 95, 115, 101, 116, 116, 108, 101, 114, 95, 101, 115, 99,
+									114, 111, 119
+								]
+							}
+						]
+					}
+				},
+				{
+					"name": "order_context",
+					"writable": true,
+					"pda": {
+						"seeds": [
+							{
+								"kind": "const",
+								"value": [111, 114, 100, 101, 114, 95, 99, 111, 110, 116, 101, 120, 116]
+							},
+							{
+								"kind": "arg",
+								"path": "order"
+							}
+						]
+					}
+				},
+				{
+					"name": "order_pda_token_account",
+					"writable": true,
+					"pda": {
+						"seeds": [
+							{
+								"kind": "account",
+								"path": "order_context"
+							},
+							{
+								"kind": "account",
+								"path": "token_program"
+							},
+							{
+								"kind": "account",
+								"path": "mint"
+							}
+						],
+						"program": {
+							"kind": "const",
+							"value": [
+								140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+								153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+							]
+						}
+					}
+				},
+				{
+					"name": "user_token_account",
+					"writable": true,
+					"pda": {
+						"seeds": [
+							{
+								"kind": "account",
+								"path": "user"
+							},
+							{
+								"kind": "const",
+								"value": [
+									6, 221, 246, 225, 215, 101, 161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28,
+									180, 133, 237, 95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169
+								]
+							},
+							{
+								"kind": "account",
+								"path": "mint"
+							}
+						],
+						"program": {
+							"kind": "const",
+							"value": [
+								140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+								153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+							]
+						}
+					}
+				},
+				{
+					"name": "mint"
+				},
+				{
+					"name": "token_program"
+				},
+				{
+					"name": "associated_token_program",
+					"address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+				},
+				{
+					"name": "system_program",
+					"address": "11111111111111111111111111111111"
+				}
+			],
+			"args": [
+				{
+					"name": "order",
+					"type": {
+						"defined": {
+							"name": "StandardOrder"
+						}
+					}
+				}
+			]
+		}
+	],
+	"accounts": [
+		{
+			"name": "ChainId",
+			"discriminator": [203, 146, 201, 161, 230, 71, 157, 218]
+		},
+		{
+			"name": "InputSettlerEscrowAccount",
+			"discriminator": [85, 112, 162, 215, 22, 13, 16, 72]
+		},
+		{
+			"name": "OrderContext",
+			"discriminator": [240, 83, 159, 216, 26, 11, 225, 229]
+		}
+	],
+	"events": [
+		{
+			"name": "RefundedEvent",
+			"discriminator": [220, 3, 153, 244, 133, 189, 73, 119]
+		}
+	],
+	"errors": [
+		{
+			"code": 6000,
+			"name": "SolversLengthMismatch",
+			"msg": "Solvers length mismatch."
+		},
+		{
+			"code": 6001,
+			"name": "FirstSolverNotInSolvers",
+			"msg": "First solver not in solvers."
+		}
+	],
+	"types": [
+		{
+			"name": "ChainId",
+			"docs": ["Type used to store the chain id of the chain."],
+			"type": {
+				"kind": "struct",
+				"fields": [
+					{
+						"name": "chain_id",
+						"type": "u128"
+					},
+					{
+						"name": "bump",
+						"type": "u8"
+					}
+				]
+			}
+		},
+		{
+			"name": "InputSettlerEscrowAccount",
+			"type": {
+				"kind": "struct",
+				"fields": [
+					{
+						"name": "chain_id",
+						"type": "u128"
+					},
+					{
+						"name": "bump",
+						"type": "u8"
+					}
+				]
+			}
+		},
+		{
+			"name": "MandateInput",
+			"type": {
+				"kind": "struct",
+				"fields": [
+					{
+						"name": "token",
+						"type": "pubkey"
+					},
+					{
+						"name": "amount",
+						"type": "u64"
+					}
+				]
+			}
+		},
+		{
+			"name": "MandateOutput",
+			"type": {
+				"kind": "struct",
+				"fields": [
+					{
+						"name": "oracle",
+						"type": {
+							"array": ["u8", 32]
+						}
+					},
+					{
+						"name": "settler",
+						"type": {
+							"array": ["u8", 32]
+						}
+					},
+					{
+						"name": "chain_id",
+						"type": {
+							"array": ["u8", 32]
+						}
+					},
+					{
+						"name": "token",
+						"type": {
+							"array": ["u8", 32]
+						}
+					},
+					{
+						"name": "amount",
+						"type": {
+							"array": ["u8", 32]
+						}
+					},
+					{
+						"name": "recipient",
+						"type": {
+							"array": ["u8", 32]
+						}
+					},
+					{
+						"name": "callback_data",
+						"type": "bytes"
+					},
+					{
+						"name": "context",
+						"type": "bytes"
+					}
+				]
+			}
+		},
+		{
+			"name": "OrderContext",
+			"docs": [
+				"The context to opened as an account after opening an order.",
+				"`input_token` is the token account of the input \"Mint\".",
+				"`user` is the user who opened the order.",
+				"`bump` is the bump of this account to be reused during finalisation."
+			],
+			"type": {
+				"kind": "struct",
+				"fields": [
+					{
+						"name": "input_token",
+						"type": "pubkey"
+					},
+					{
+						"name": "user",
+						"type": "pubkey"
+					},
+					{
+						"name": "bump",
+						"type": "u8"
+					}
+				]
+			}
+		},
+		{
+			"name": "RefundedEvent",
+			"type": {
+				"kind": "struct",
+				"fields": [
+					{
+						"name": "order_id",
+						"type": {
+							"array": ["u8", 32]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name": "SolveParams",
+			"type": {
+				"kind": "struct",
+				"fields": [
+					{
+						"name": "solver",
+						"type": {
+							"array": ["u8", 32]
+						}
+					},
+					{
+						"name": "timestamp",
+						"type": "u32"
+					}
+				]
+			}
+		},
+		{
+			"name": "StandardOrder",
+			"type": {
+				"kind": "struct",
+				"fields": [
+					{
+						"name": "user",
+						"type": "pubkey"
+					},
+					{
+						"name": "nonce",
+						"type": "u128"
+					},
+					{
+						"name": "origin_chain_id",
+						"type": "u128"
+					},
+					{
+						"name": "expires",
+						"type": "u32"
+					},
+					{
+						"name": "fill_deadline",
+						"type": "u32"
+					},
+					{
+						"name": "input_oracle",
+						"type": "pubkey"
+					},
+					{
+						"name": "input",
+						"type": {
+							"defined": {
+								"name": "MandateInput"
+							}
+						}
+					},
+					{
+						"name": "outputs",
+						"type": {
+							"vec": {
+								"defined": {
+									"name": "MandateOutput"
+								}
+							}
+						}
+					}
+				]
+			}
+		}
+	]
+}

--- a/src/lib/components/InputTokenModal.svelte
+++ b/src/lib/components/InputTokenModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { evmCoinList, getChainName, type Token } from "$lib/config";
+	import { evmClientsById, coinList, getChainName, isSolanaChain, type Token } from "$lib/config";
+	import solanaWallet from "$lib/utils/solana-wallet.svelte";
 	import FieldRow from "$lib/components/ui/FieldRow.svelte";
 	import FormControl from "$lib/components/ui/FormControl.svelte";
 	import InlineMetaField from "$lib/components/ui/InlineMetaField.svelte";
@@ -29,12 +30,34 @@
 			])
 		)
 	);
+
+	// Build initial enabledByToken from the full token set for the current name,
+	// enforcing Solana/EVM exclusivity from the start.
+	const _initTokenName = (currentInputTokens ?? [])[0]?.token.name ?? "";
+	const _initTokenSet = coinList(store.mainnet).filter(
+		(v) => v.name.toLowerCase() === _initTokenName.toLowerCase()
+	);
+	const _initHasEvmTokens = _initTokenSet.some((t) => !isSolanaChain(t.chainId));
+	const _initCurrentHasSolana = (currentInputTokens ?? []).some(({ token }) =>
+		isSolanaChain(token.chainId)
+	);
+	const _initCurrentAddrs = new Set(
+		(currentInputTokens ?? []).map(({ token }) =>
+			getInteropableAddress(token.address, token.chainId)
+		)
+	);
+
 	let enabledByToken = $state<{ [index: InteropableAddress]: boolean }>(
 		Object.fromEntries(
-			(currentInputTokens ?? []).map(({ token }) => [
-				getInteropableAddress(token.address, token.chainId),
-				true
-			])
+			_initTokenSet.map((token) => {
+				const iaddr = getInteropableAddress(token.address, token.chainId);
+				if (_initCurrentAddrs.has(iaddr)) return [iaddr, true];
+				// Don't auto-enable a chain that conflicts with the current side
+				if (_initCurrentHasSolana && !isSolanaChain(token.chainId)) return [iaddr, false];
+				if (!_initCurrentHasSolana && _initHasEvmTokens && isSolanaChain(token.chainId))
+					return [iaddr, false];
+				return [iaddr, true];
+			})
 		)
 	);
 	// svelte-ignore state_referenced_locally
@@ -45,7 +68,29 @@
 	const rowColumns = "4.5rem minmax(0,1fr) 2rem";
 	const iaddrFor = (token: Token) => getInteropableAddress(token.address, token.chainId);
 
-	const isEnabled = (address: InteropableAddress) => enabledByToken[address] ?? true;
+	const isEnabled = (address: InteropableAddress) => enabledByToken[address] ?? false;
+
+	function toggleEnabled(iaddr: InteropableAddress) {
+		const token = getTokenFor(iaddr);
+		if (!token) return;
+		const enabling = !enabledByToken[iaddr];
+		if (enabling) {
+			if (isSolanaChain(token.chainId)) {
+				// Enabling a Solana chain → disable all EVM chains
+				for (const addr of Object.keys(enabledByToken) as InteropableAddress[]) {
+					const t = getTokenFor(addr);
+					if (t && !isSolanaChain(t.chainId)) enabledByToken[addr] = false;
+				}
+			} else {
+				// Enabling an EVM chain → disable all Solana chains
+				for (const addr of Object.keys(enabledByToken) as InteropableAddress[]) {
+					const t = getTokenFor(addr);
+					if (t && isSolanaChain(t.chainId)) enabledByToken[addr] = false;
+				}
+			}
+		}
+		enabledByToken[iaddr] = enabling;
+	}
 
 	function getTokenFor(address: InteropableAddress): Token | undefined {
 		for (const token of tokenSet) {
@@ -54,19 +99,20 @@
 		}
 	}
 
+	const hasClient = (chainId: number) => !!evmClientsById[chainId];
+	const isChainAvailable = (chainId: number) => !isSolanaChain(chainId) || solanaWallet.connected;
+
 	function save() {
 		// Go over every single non-0 instance in the array:
 		const inputKeys = Object.keys(inputs) as InteropableAddress[];
 		const inputTokens: AppTokenContext[] = [];
 		for (const key of inputKeys) {
-			// Check that key is a number
 			const inputValue = v(inputs[key]);
-			// The token would be:
 			const token = getTokenFor(key);
-			// If we can't find the token, then it is most likely because the user changed their token.
+			// If we can't find the token, the user most likely changed their selection.
 			if (!token) continue;
 			if (!isEnabled(key)) continue;
-
+			if (!hasClient(token.chainId) && !isChainAvailable(token.chainId)) continue;
 			if (inputValue === 0) continue;
 			inputTokens.push({ token, amount: toBigIntWithDecimals(inputValue, token.decimals) });
 		}
@@ -80,7 +126,7 @@
 
 	const uniqueInputTokens = $derived([
 		...new Set(
-			evmCoinList(store.mainnet)
+			coinList(store.mainnet)
 				.map((v) => v.name)
 				.filter((v) => v !== "eth")
 		)
@@ -89,9 +135,7 @@
 	// svelte-ignore state_referenced_locally
 	let selectedTokenName = $state<string>(currentInputTokens[0].token.name);
 	const tokenSet = $derived(
-		evmCoinList(store.mainnet).filter(
-			(v) => v.name.toLowerCase() === selectedTokenName.toLowerCase()
-		)
+		coinList(store.mainnet).filter((v) => v.name.toLowerCase() === selectedTokenName.toLowerCase())
 	);
 
 	let circuitBreaker = false;
@@ -100,7 +144,14 @@
 		if (circuitBreaker || currentInputTokens[0].token.name !== selectedTokenName) {
 			circuitBreaker = true;
 			inputs = Object.fromEntries(tokenSet.map((token) => [iaddrFor(token), 0]));
-			enabledByToken = Object.fromEntries(tokenSet.map((token) => [iaddrFor(token), true]));
+			// When the token set has both EVM and Solana chains, default to EVM-only.
+			const hasEvmTokens = tokenSet.some((token) => !isSolanaChain(token.chainId));
+			enabledByToken = Object.fromEntries(
+				tokenSet.map((token) => [
+					iaddrFor(token),
+					hasEvmTokens ? !isSolanaChain(token.chainId) : true
+				])
+			);
 		}
 	});
 
@@ -108,7 +159,7 @@
 		const tokens = tokenSet;
 		const selectedIndices = tokens
 			.map((token, i) => [token, i] as const)
-			.filter(([token]) => isEnabled(iaddrFor(token)))
+			.filter(([token]) => hasClient(token.chainId) && isEnabled(iaddrFor(token)))
 			.map(([, i]) => i);
 		if (selectedIndices.length === 0) {
 			for (const token of tokens) {
@@ -214,32 +265,72 @@
 				<div>
 					{#each tokenSet as tkn, rowIndex}
 						{@const iaddr = iaddrFor(tkn)}
+						{@const evmChain = hasClient(tkn.chainId)}
+						{@const chainAvailable = isChainAvailable(tkn.chainId)}
 						<div data-testid={`input-token-row-${getChainName(tkn.chainId)}`}>
 							<FieldRow columns={rowColumns} striped index={rowIndex}>
-								<div class="truncate text-xs font-medium text-gray-700">
+								<div
+									class="truncate text-xs font-medium {evmChain ||
+									(isSolanaChain(tkn.chainId) && chainAvailable)
+										? 'text-gray-700'
+										: 'text-gray-400'}"
+								>
 									{getChainName(tkn.chainId)}
 								</div>
-								{#await (store.intentType === "compact" ? store.compactBalances : store.balances)[tkn.chainId][tkn.address]}
+								{#if evmChain}
+									{#await (store.intentType === "compact" ? store.compactBalances : store.balances)[tkn.chainId][tkn.address]}
+										<InlineMetaField
+											bind:value={inputs[iaddr]}
+											metaText="..."
+											disabled={!isEnabled(iaddr) || !chainAvailable}
+										/>
+									{:then balance}
+										<InlineMetaField
+											bind:value={inputs[iaddr]}
+											metaText={formatBalance(balance, tkn.decimals)}
+											disabled={!isEnabled(iaddr) || !chainAvailable}
+										/>
+									{:catch}
+										<InlineMetaField
+											bind:value={inputs[iaddr]}
+											metaText="err"
+											disabled={!isEnabled(iaddr) || !chainAvailable}
+										/>
+									{/await}
+								{:else if store.solanaBalances[tkn.chainId]?.[tkn.address]}
+									{#await store.solanaBalances[tkn.chainId]![tkn.address]}
+										<InlineMetaField
+											bind:value={inputs[iaddr]}
+											metaText="..."
+											disabled={!isEnabled(iaddr) || !chainAvailable}
+										/>
+									{:then balance}
+										<InlineMetaField
+											bind:value={inputs[iaddr]}
+											metaText={balance !== null ? formatBalance(balance, tkn.decimals) : "err"}
+											disabled={!isEnabled(iaddr) || !chainAvailable}
+										/>
+									{:catch}
+										<InlineMetaField
+											bind:value={inputs[iaddr]}
+											metaText="err"
+											disabled={!isEnabled(iaddr) || !chainAvailable}
+										/>
+									{/await}
+								{:else}
 									<InlineMetaField
 										bind:value={inputs[iaddr]}
-										metaText="..."
-										disabled={!isEnabled(iaddr)}
+										metaText="—"
+										disabled={!isEnabled(iaddr) || !chainAvailable}
 									/>
-								{:then balance}
-									<InlineMetaField
-										bind:value={inputs[iaddr]}
-										metaText={formatBalance(balance, tkn.decimals)}
-										disabled={!isEnabled(iaddr)}
-									/>
-								{:catch _}
-									<InlineMetaField
-										bind:value={inputs[iaddr]}
-										metaText="err"
-										disabled={!isEnabled(iaddr)}
-									/>
-								{/await}
+								{/if}
 								<div class="flex justify-center">
-									<input type="checkbox" bind:checked={enabledByToken[iaddr]} />
+									<input
+										type="checkbox"
+										checked={isEnabled(iaddr)}
+										onchange={() => toggleEnabled(iaddr)}
+										disabled={!chainAvailable}
+									/>
 								</div>
 							</FieldRow>
 						</div>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -71,7 +71,12 @@ const _solanaDevnetConn = new Connection(SOLANA_DEVNET_RPC, "confirmed");
 const _solanaMainnetConn = new Connection(SOLANA_MAINNET_RPC, "confirmed");
 
 export function getSolanaConnection(chainId: number | bigint): Connection {
-	return Number(chainId) === solanaMainnet.id ? _solanaMainnetConn : _solanaDevnetConn;
+	const id = Number(chainId);
+	if (id === solanaMainnet.id) return _solanaMainnetConn;
+	if (id === solanaDevnet.id) return _solanaDevnetConn;
+	throw new Error(
+		`No Solana connection configured for chain ID ${id}. Solana testnet is not supported.`
+	);
 }
 
 export function isSolanaChain(chainId: number | bigint): boolean {
@@ -178,7 +183,8 @@ type ChainName = keyof typeof chainMap;
 export const chains = Object.keys(chainMap) as ChainName[];
 export const chainList = (mainnet: boolean): ChainName[] => {
 	if (mainnet) {
-		return ["ethereum", "base", "arbitrum", "megaeth", "katana", "polygon", "bsc", "solanaMainnet"];
+		// solanaMainnet omitted until SOLANA_PROGRAMS.mainnet are deployed and tested.
+		return ["ethereum", "base", "arbitrum", "megaeth", "katana", "polygon", "bsc"];
 	} else {
 		return [
 			"sepolia",
@@ -309,14 +315,6 @@ export const coinList = (mainnet: boolean): Token[] => {
 				address: `0x2791bca1f2de4661ed88a30c99a7a9449aa84174`,
 				name: "usdc.e",
 				chainId: polygon.id,
-				decimals: 6
-			},
-			// Solana mainnet — SPL mint addresses encoded as bytes32 (66 chars); ADDRESS_ZERO = native SOL
-			{ address: ADDRESS_ZERO, name: "sol", chainId: SOLANA_MAINNET_CHAIN_ID_NUM, decimals: 9 },
-			{
-				address: `0xc6fa7af3bedbad3a3d65f36aabc97431b1bbe4c2d2f6e0e47ca60203452f5d61`,
-				name: "usdc",
-				chainId: SOLANA_MAINNET_CHAIN_ID_NUM,
 				decimals: 6
 			}
 		] as const;
@@ -569,7 +567,7 @@ export const evmClients = {
 		])
 	}),
 	polygon: createPublicClient({
-		chain: base,
+		chain: polygon,
 		transport: fallback([
 			http("https://polygon-bor-rpc.publicnode.com"),
 			...polygon.rpcUrls.default.http.map((v) => http(v))

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,5 @@
 import { createPublicClient, createWalletClient, custom, defineChain, fallback, http } from "viem";
+import { Connection } from "@solana/web3.js";
 import {
 	SOLANA_MAINNET_CHAIN_ID,
 	SOLANA_TESTNET_CHAIN_ID,
@@ -41,30 +42,96 @@ export const SOLANA_CHAIN_IDS = new Set([
 	SOLANA_DEVNET_CHAIN_ID_NUM
 ]);
 
+const SOLANA_DEVNET_RPC = "https://api.devnet.solana.com";
+const SOLANA_MAINNET_RPC = "https://api.mainnet-beta.solana.com";
+const SOLANA_TESTNET_RPC = "https://api.testnet.solana.com";
+
 export const solanaMainnet = defineChain({
 	id: SOLANA_MAINNET_CHAIN_ID_NUM,
 	name: "Solana",
 	nativeCurrency: { name: "SOL", symbol: "SOL", decimals: 9 },
-	rpcUrls: { default: { http: ["https://api.mainnet-beta.solana.com"] } }
+	rpcUrls: { default: { http: [SOLANA_MAINNET_RPC] } }
 });
 export const solanaTestnet = defineChain({
 	id: SOLANA_TESTNET_CHAIN_ID_NUM,
 	name: "Solana Testnet",
 	nativeCurrency: { name: "SOL", symbol: "SOL", decimals: 9 },
-	rpcUrls: { default: { http: ["https://api.testnet.solana.com"] } },
+	rpcUrls: { default: { http: [SOLANA_TESTNET_RPC] } },
 	testnet: true
 });
 export const solanaDevnet = defineChain({
 	id: SOLANA_DEVNET_CHAIN_ID_NUM,
 	name: "Solana Devnet",
 	nativeCurrency: { name: "SOL", symbol: "SOL", decimals: 9 },
-	rpcUrls: { default: { http: ["https://api.devnet.solana.com"] } },
+	rpcUrls: { default: { http: [SOLANA_DEVNET_RPC] } },
 	testnet: true
 });
 
-// Source: PDA(seed: "polymer", program: SOLANA_POLYMER_ORACLE) — confirmed in default_orders.json
-const SOLANA_POLYMER_ORACLE_DEVNET =
-	"0xe48a6f95df84c28a030f60ba5b74e4a02922a4a5724c9633109f089b2287edfc" as const;
+const _solanaDevnetConn = new Connection(SOLANA_DEVNET_RPC, "confirmed");
+const _solanaMainnetConn = new Connection(SOLANA_MAINNET_RPC, "confirmed");
+
+export function getSolanaConnection(chainId: number | bigint): Connection {
+	return Number(chainId) === solanaMainnet.id ? _solanaMainnetConn : _solanaDevnetConn;
+}
+
+export function isSolanaChain(chainId: number | bigint): boolean {
+	return SOLANA_CHAIN_IDS.has(Number(chainId));
+}
+
+// catalyst-intent-svm program IDs, keyed by network
+export const SOLANA_PROGRAMS: {
+	devnet: Record<string, string>;
+	mainnet: Record<string, string | null>;
+} = {
+	devnet: {
+		// from Anchor.toml
+		INTENTS_PROTOCOL: "H1dVz9YXVys8c4tAihD14M5jnrUQi1MFsA65YQ92oCCz",
+		OUTPUT_SETTLER_SIMPLE: "58CsNaufL383JL7J1jafGW4eWgeQFX5vSZssjsk4WKXd",
+		INPUT_SETTLER_ESCROW: "5QngyaYhNscSebqV4DwYQhk333p5CMP8A9yyLX3pPyXC",
+		POLYMER_ORACLE: "C2rAFLS6xQ78t18rK5s9madY9fztbhTaHwShgYtzonk7"
+	},
+	mainnet: {
+		// Mainnet program IDs are not yet deployed. Remove solanaMainnet from chainList(true)
+		// until these are filled in and re-tested.
+		INTENTS_PROTOCOL: null,
+		OUTPUT_SETTLER_SIMPLE: null,
+		INPUT_SETTLER_ESCROW: null,
+		POLYMER_ORACLE: null
+	}
+};
+
+/** Throws a descriptive error when a mainnet Solana program ID is accessed before deployment. */
+export function requireSolanaProgram(id: string | null, name: string): string {
+	if (id === null)
+		throw new Error(
+			`Solana mainnet program "${name}" is not deployed yet. Update SOLANA_PROGRAMS.mainnet and re-test before enabling mainnet.`
+		);
+	return id;
+}
+
+// Derived PDAs, keyed by network
+export const SOLANA_PDAS = {
+	devnet: {
+		// PDA(seed: "output_settler_simple", program: SOLANA_PROGRAMS.devnet.OUTPUT_SETTLER_SIMPLE)
+		OUTPUT_SETTLER:
+			"0xabb04f05c412a4892f8c93efa4eda9f360ba8b5c8342bed51207c7a4fdd036d6" as `0x${string}`,
+		// PDA(seed: "polymer", program: SOLANA_PROGRAMS.devnet.POLYMER_ORACLE)
+		POLYMER_ORACLE:
+			"0xe48a6f95df84c28a030f60ba5b74e4a02922a4a5724c9633109f089b2287edfc" as `0x${string}`
+	},
+	mainnet: {
+		OUTPUT_SETTLER: BYTES32_ZERO,
+		POLYMER_ORACLE: BYTES32_ZERO
+	}
+} as const;
+
+// Flat exports for use throughout the codebase
+export const SOLANA_INTENTS_PROTOCOL = SOLANA_PROGRAMS.devnet.INTENTS_PROTOCOL;
+export const SOLANA_OUTPUT_SETTLER_SIMPLE = SOLANA_PROGRAMS.devnet.OUTPUT_SETTLER_SIMPLE;
+export const SOLANA_INPUT_SETTLER_ESCROW = SOLANA_PROGRAMS.devnet.INPUT_SETTLER_ESCROW;
+export const SOLANA_POLYMER_ORACLE = SOLANA_PROGRAMS.devnet.POLYMER_ORACLE;
+export const SOLANA_OUTPUT_SETTLER_PDA = SOLANA_PDAS.devnet.OUTPUT_SETTLER;
+
 export const WORMHOLE_ORACLE: Partial<Record<number, `0x${string}`>> = {
 	[ethereum.id]: "0x0000000000000000000000000000000000000000",
 	[arbitrum.id]: "0x0000000000000000000000000000000000000000",
@@ -83,7 +150,7 @@ export const POLYMER_ORACLE: Partial<Record<number, `0x${string}`>> = {
 	[baseSepolia.id]: "0x00d5b500ECa100F7cdeDC800eC631Aca00BaAC00",
 	[arbitrumSepolia.id]: "0x00d5b500ECa100F7cdeDC800eC631Aca00BaAC00",
 	[optimismSepolia.id]: "0x00d5b500ECa100F7cdeDC800eC631Aca00BaAC00",
-	[SOLANA_DEVNET_CHAIN_ID_NUM]: SOLANA_POLYMER_ORACLE_DEVNET
+	[SOLANA_DEVNET_CHAIN_ID_NUM]: SOLANA_PDAS.devnet.POLYMER_ORACLE
 };
 
 export type availableAllocators = typeof ALWAYS_OK_ALLOCATOR | typeof POLYMER_ALLOCATOR;

--- a/src/lib/libraries/intentFactory.ts
+++ b/src/lib/libraries/intentFactory.ts
@@ -1,6 +1,9 @@
 import {
 	getChain,
 	getClient,
+	getSolanaConnection,
+	isSolanaChain,
+	SOLANA_INPUT_SETTLER_ESCROW,
 	INPUT_SETTLER_COMPACT_LIFI,
 	INPUT_SETTLER_ESCROW_LIFI,
 	MULTICHAIN_INPUT_SETTLER_ESCROW,
@@ -14,27 +17,19 @@ import type {
 	NoSignature,
 	OrderContainer,
 	Signature,
-	StandardOrder
+	StandardOrder,
+	StandardSolana
 } from "@lifi/intent";
-import {
-	Intent,
-	IntentApi,
-	StandardSolanaIntent,
-	SOLANA_MAINNET_CHAIN_ID,
-	SOLANA_TESTNET_CHAIN_ID,
-	SOLANA_DEVNET_CHAIN_ID
-} from "@lifi/intent";
+import { Intent, IntentApi, StandardSolanaIntent } from "@lifi/intent";
+import type { StandardEVMIntent, MultichainOrderIntent } from "@lifi/intent";
 import type { AppCreateIntentOptions, AppTokenContext } from "$lib/appTypes";
 import { ERC20_ABI } from "$lib/abi/erc20";
 import { store } from "$lib/state.svelte";
 import { depositAndRegisterCompact, openEscrowIntent, signIntentCompact } from "./intentExecution";
 import { intentDeps } from "./coreDeps";
-
-const SOLANA_CHAIN_IDS = new Set([
-	SOLANA_MAINNET_CHAIN_ID,
-	SOLANA_TESTNET_CHAIN_ID,
-	SOLANA_DEVNET_CHAIN_ID
-]);
+import { openSolanaEscrow } from "./solanaEscrowLib";
+import solanaWallet from "$lib/utils/solana-wallet.svelte";
+import { solanaAddressToBytes32 } from "$lib/utils/solana";
 
 function toCoreTokenContext(input: AppTokenContext): TokenContext {
 	const chainId = BigInt(input.token.chainId);
@@ -44,7 +39,7 @@ function toCoreTokenContext(input: AppTokenContext): TokenContext {
 			name: input.token.name,
 			chainId,
 			decimals: input.token.decimals,
-			chainNamespace: SOLANA_CHAIN_IDS.has(chainId) ? "solana" : "eip155"
+			chainNamespace: isSolanaChain(chainId) ? "solana" : "eip155"
 		},
 		amount: input.amount
 	};
@@ -114,7 +109,7 @@ export class IntentFactory {
 	}
 
 	private saveOrder(options: {
-		order: StandardOrder | MultichainOrder;
+		order: StandardOrder | MultichainOrder | StandardSolana;
 		inputSettler: `0x${string}`;
 		sponsorSignature?: Signature | NoSignature;
 		allocatorSignature?: Signature | NoSignature;
@@ -218,31 +213,66 @@ export class IntentFactory {
 
 	openIntent(opts: AppCreateIntentOptions) {
 		return async () => {
-			const { inputTokens, account } = opts;
-			const intent = new Intent(toCoreCreateIntentOptions(opts), intentDeps).order();
-			if (intent instanceof StandardSolanaIntent)
-				throw new Error("openEscrowIntent is not supported for Solana intents.");
-
+			const { inputTokens, outputTokens, account } = opts;
 			const inputChain = inputTokens[0].token.chainId;
-			if (this.preHook) await this.preHook(inputChain);
 
-			// Execute the open.
-			const transactionHashes = await openEscrowIntent(intent, account(), this.walletClient);
-			console.log({ tsh: transactionHashes });
+			let transactionHashes: string[];
 
-			// for (const hash of transactionHashes) {
-			// 	await clients[inputChain].waitForTransactionReceipt({
-			// 		hash: await hash
-			// 	});
-			// }
+			if (isSolanaChain(inputChain)) {
+				if (!solanaWallet.adapter || !solanaWallet.publicKey) {
+					throw new Error("Solana wallet not connected");
+				}
+				// When there is a Solana output the caller already resolved outputRecipient to bytes32.
+				// Fall back to the connected EVM wallet for EVM-only outputs.
+				const outputRecipient = opts.outputRecipient ?? account();
+				const solanaOrderIntent = new Intent(
+					{
+						exclusiveFor: opts.exclusiveFor,
+						inputTokens: [toCoreTokenContext(inputTokens[0])],
+						outputTokens: outputTokens.map(toCoreTokenContext),
+						verifier: opts.verifier,
+						account: solanaAddressToBytes32(solanaWallet.publicKey),
+						outputRecipient,
+						lock: { type: "escrow" }
+					},
+					intentDeps
+				).singlechain() as StandardSolanaIntent;
+
+				// fillDeadline must be strictly less than expires (Solana program requirement).
+				const baseOrder = solanaOrderIntent.asOrder();
+				const solanaOrder = { ...baseOrder, fillDeadline: baseOrder.expires - 1 };
+
+				try {
+					transactionHashes = [
+						await openSolanaEscrow({
+							order: solanaOrder,
+							solanaPublicKey: solanaWallet.publicKey,
+							walletAdapter: solanaWallet.adapter,
+							connection: getSolanaConnection(inputChain)
+						})
+					];
+				} catch (e) {
+					const message = e instanceof Error ? e.message : String(e);
+					throw new Error(`Failed to open Solana escrow: ${message}`);
+				}
+
+				this.saveOrder({
+					order: solanaOrder,
+					inputSettler: solanaAddressToBytes32(SOLANA_INPUT_SETTLER_ESCROW)
+				});
+			} else {
+				if (this.preHook) await this.preHook(inputChain);
+				const intent = new Intent(toCoreCreateIntentOptions(opts), intentDeps).order() as
+					| StandardEVMIntent
+					| MultichainOrderIntent;
+				transactionHashes = await openEscrowIntent(intent, account(), this.walletClient);
+				this.saveOrder({
+					order: intent.asOrder(),
+					inputSettler: store.inputSettler
+				});
+			}
 
 			if (this.postHook) await this.postHook();
-
-			this.saveOrder({
-				order: intent.asOrder(),
-				inputSettler: store.inputSettler
-			});
-
 			return transactionHashes;
 		};
 	}

--- a/src/lib/libraries/intentFactory.ts
+++ b/src/lib/libraries/intentFactory.ts
@@ -17,8 +17,7 @@ import type {
 	NoSignature,
 	OrderContainer,
 	Signature,
-	StandardOrder,
-	StandardSolana
+	StandardOrder
 } from "@lifi/intent";
 import { Intent, IntentApi, StandardSolanaIntent } from "@lifi/intent";
 import type { StandardEVMIntent, MultichainOrderIntent } from "@lifi/intent";
@@ -109,7 +108,7 @@ export class IntentFactory {
 	}
 
 	private saveOrder(options: {
-		order: StandardOrder | MultichainOrder | StandardSolana;
+		order: StandardOrder | MultichainOrder;
 		inputSettler: `0x${string}`;
 		sponsorSignature?: Signature | NoSignature;
 		allocatorSignature?: Signature | NoSignature;
@@ -142,11 +141,6 @@ export class IntentFactory {
 				throw new Error("Compact signing is not supported for Solana intents.");
 
 			const sponsorSignature = await signIntentCompact(intent, account(), this.walletClient);
-
-			console.log({
-				order: intent.asOrder(),
-				sponsorSignature
-			});
 
 			this.saveOrder({
 				order: intent.asOrder(),
@@ -185,7 +179,7 @@ export class IntentFactory {
 
 			let transactionHash = await depositAndRegisterCompact(intent, account(), this.walletClient);
 
-			const receipt = await getClient(inputTokens[0].token.chainId).waitForTransactionReceipt({
+			await getClient(inputTokens[0].token.chainId).waitForTransactionReceipt({
 				hash: transactionHash
 			});
 

--- a/src/lib/libraries/intentList.ts
+++ b/src/lib/libraries/intentList.ts
@@ -2,6 +2,7 @@ import {
 	formatTokenAmount,
 	getChainName,
 	getCoin,
+	isSolanaChain,
 	INPUT_SETTLER_ESCROW_LIFI,
 	INPUT_SETTLER_COMPACT_LIFI,
 	MULTICHAIN_INPUT_SETTLER_ESCROW,
@@ -75,23 +76,30 @@ function shortAddress(value: string, start = 6, end = 4) {
 }
 
 function summarizeInput(chainId: bigint, tokenId: bigint, amount: bigint): string {
-	const tokenAddress = idToToken(tokenId);
+	// After a DB round-trip, bigint fields are serialized as strings — coerce them back.
+	const tokenIdBig = BigInt(tokenId);
+	const amountBig = BigInt(amount);
+	// Solana token IDs are full 32-byte SPL mint pubkeys; idToToken is EVM-only (strips to 20 bytes)
+	const tokenAddress = isSolanaChain(chainId)
+		? (`0x${tokenIdBig.toString(16).padStart(64, "0")}` as `0x${string}`)
+		: idToToken(tokenIdBig);
 	const chainName = safeChainName(chainId);
 	if (!chainName) {
-		return `${amount.toString()} ${shortAddress(tokenAddress)} on chain-${chainId.toString()}`;
+		return `${amountBig.toString()} ${shortAddress(tokenAddress)} on chain-${chainId.toString()}`;
 	}
 	const coin = getCoin({ address: tokenAddress, chainId });
-	const amountText = formatTokenAmount(amount, coin.decimals);
+	const amountText = formatTokenAmount(amountBig, coin.decimals);
 	return `${amountText} ${coin.name.toUpperCase()} on ${chainName}`;
 }
 
 function summarizeOutput(chainId: bigint, token: `0x${string}`, amount: bigint): string {
+	const amountBig = BigInt(amount);
 	const chainName = safeChainName(chainId);
 	if (!chainName) {
-		return `${amount.toString()} ${shortAddress(token)} on chain-${chainId.toString()}`;
+		return `${amountBig.toString()} ${shortAddress(token)} on chain-${chainId.toString()}`;
 	}
 	const coin = getCoin({ address: token, chainId });
-	const amountText = formatTokenAmount(amount, coin.decimals);
+	const amountText = formatTokenAmount(amountBig, coin.decimals);
 	return `${amountText} ${coin.name.toUpperCase()} on ${chainName}`;
 }
 

--- a/src/lib/libraries/solanaEscrowLib.ts
+++ b/src/lib/libraries/solanaEscrowLib.ts
@@ -1,0 +1,155 @@
+import { keccak256 } from "viem";
+import idl from "../abi/input_settler_escrow.json";
+import { SOLANA_INPUT_SETTLER_ESCROW, SOLANA_POLYMER_ORACLE } from "../config";
+import type { MandateOutput, StandardSolana } from "@lifi/intent";
+import type { SignerWalletAdapter } from "@solana/wallet-adapter-base";
+import type { Connection } from "@solana/web3.js";
+import { sendAndConfirmSolanaTx } from "$lib/utils/solanaTx";
+
+/** Convert a 0x-prefixed hex string (32 bytes) to a number[] */
+function hexToBytes32(hex: `0x${string}`): number[] {
+	return Array.from(Buffer.from(hex.slice(2), "hex"));
+}
+
+/** Convert a bigint to a 32-byte big-endian number[] */
+function bigintToBeBytes32(n: bigint): number[] {
+	return Array.from(Buffer.from(n.toString(16).padStart(64, "0"), "hex"));
+}
+
+/**
+ * Open a Solana→EVM intent by calling input_settler_escrow.open() on Solana devnet.
+ *
+ * Builds the transaction via Anchor, signs it with the wallet adapter, then submits
+ * it through `sendAndConfirmSolanaTx` which monitors confirmation and retries once
+ * on timeout before giving up.
+ *
+ * @param order           StandardSolana from @lifi/intent
+ * @param solanaPublicKey Base58-encoded Solana wallet public key (becomes order.user)
+ * @param walletAdapter   Connected Solana wallet adapter (Phantom, Solflare, …)
+ * @param connection      Solana Connection instance
+ * @returns               Solana transaction signature string
+ */
+export async function openSolanaEscrow(params: {
+	order: StandardSolana;
+	solanaPublicKey: string;
+	walletAdapter: SignerWalletAdapter;
+	connection: Connection;
+}): Promise<string> {
+	const { order, solanaPublicKey, walletAdapter, connection } = params;
+
+	if (!order.inputs.length) throw new Error("StandardSolana order has no inputs");
+
+	// Dynamic imports to avoid CJS/ESM bundling issues with Rollup
+	const { AnchorProvider, BN, Program } = await import("@coral-xyz/anchor");
+	const { PublicKey, SystemProgram } = await import("@solana/web3.js");
+	const { ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID, getAssociatedTokenAddressSync } =
+		await import("@solana/spl-token");
+
+	const userPubkey = new PublicKey(solanaPublicKey);
+	const inputSettlerProgramId = new PublicKey(SOLANA_INPUT_SETTLER_ESCROW);
+	const polymerProgramId = new PublicKey(SOLANA_POLYMER_ORACLE);
+
+	// Wrap the wallet adapter as an Anchor-compatible wallet.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const anchorWallet = {
+		publicKey: userPubkey,
+		signTransaction: (tx: any) => walletAdapter.signTransaction(tx),
+		signAllTransactions: (txs: any[]) => walletAdapter.signAllTransactions(txs)
+	};
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const typedIdl = idl as any;
+	const provider = new AnchorProvider(connection as any, anchorWallet as any, {
+		commitment: "confirmed"
+	});
+	// Program converts the IDL to camelCase internally; its coder uses camelCase field names.
+	const program = new Program(typedIdl, provider);
+
+	// Derive polymer oracle PDA (seed: "polymer", program: SOLANA_POLYMER_ORACLE)
+	const [polymerOraclePda] = PublicKey.findProgramAddressSync(
+		[Buffer.from("polymer")],
+		polymerProgramId
+	);
+
+	// Derive input settler escrow PDA (seed: "input_settler_escrow", program: SOLANA_INPUT_SETTLER_ESCROW)
+	const [inputSettlerEscrowPda] = PublicKey.findProgramAddressSync(
+		[Buffer.from("input_settler_escrow")],
+		inputSettlerProgramId
+	);
+
+	// Extract input token from StandardSolana.
+	// Solana token IDs are full 32-byte public keys stored as bigint — do NOT use idToToken()
+	// which strips the first 12 bytes (EVM-only helper that returns 20-byte addresses).
+	const tokenIdHex = order.inputs[0][0].toString(16).padStart(64, "0");
+	const inputMint = new PublicKey(Buffer.from(tokenIdHex, "hex"));
+	const inputAmount = new BN(order.inputs[0][1].toString());
+
+	// Build Anchor-format order (camelCase; Anchor's BorshCoder maps to IDL snake_case).
+	const anchorOrder = {
+		user: userPubkey,
+		nonce: new BN(order.nonce.toString()),
+		originChainId: new BN(order.originChainId.toString()),
+		expires: order.expires,
+		fillDeadline: order.fillDeadline,
+		inputOracle: polymerOraclePda,
+		input: { token: inputMint, amount: inputAmount },
+		outputs: order.outputs.map((o: MandateOutput) => ({
+			oracle: hexToBytes32(o.oracle),
+			settler: hexToBytes32(o.settler),
+			chainId: bigintToBeBytes32(o.chainId),
+			token: hexToBytes32(o.token),
+			amount: bigintToBeBytes32(o.amount),
+			recipient: hexToBytes32(o.recipient),
+			callbackData:
+				o.callbackData === "0x" ? Buffer.alloc(0) : Buffer.from(o.callbackData.slice(2), "hex"),
+			context: o.context === "0x" ? Buffer.alloc(0) : Buffer.from(o.context.slice(2), "hex")
+		}))
+	};
+
+	// Compute orderId = keccak256(borsh(anchorOrder)) — mirrors Rust's StandardOrder::derive_id().
+	let encoded: Uint8Array;
+	try {
+		encoded = program.coder.types.encode("standardOrder", anchorOrder);
+	} catch (e) {
+		const message = e instanceof Error ? e.message : String(e);
+		throw new Error(`Borsh encoding failed for standardOrder: ${message}`);
+	}
+
+	const orderIdHex = keccak256(encoded);
+	const orderId = Buffer.from(orderIdHex.slice(2), "hex");
+
+	// Derive orderContext PDA (seeds: ["order_context", orderId], program: SOLANA_INPUT_SETTLER_ESCROW)
+	const [orderContext] = PublicKey.findProgramAddressSync(
+		[Buffer.from("order_context"), orderId],
+		inputSettlerProgramId
+	);
+
+	// ATA for the user (must already exist — user has a balance)
+	const userTokenAccount = getAssociatedTokenAddressSync(inputMint, userPubkey, false);
+	// ATA for the order PDA (created by the Anchor instruction)
+	const orderPdaTokenAccount = getAssociatedTokenAddressSync(inputMint, orderContext, true);
+
+	// Build the transaction without sending so we can use sendAndConfirmSolanaTx.
+	const tx = await program.methods
+		.open(anchorOrder)
+		.accounts({
+			user: userPubkey,
+			inputSettlerEscrow: inputSettlerEscrowPda,
+			userTokenAccount,
+			orderContext,
+			orderPdaTokenAccount,
+			mint: inputMint,
+			tokenProgram: TOKEN_PROGRAM_ID,
+			associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+			systemProgram: SystemProgram.programId
+		})
+		.transaction();
+
+	const { blockhash } = await connection.getLatestBlockhash("confirmed");
+	tx.feePayer = userPubkey;
+	tx.recentBlockhash = blockhash;
+
+	const signedTx = await walletAdapter.signTransaction(tx);
+
+	return sendAndConfirmSolanaTx(connection, signedTx.serialize());
+}

--- a/src/lib/libraries/solanaEscrowLib.ts
+++ b/src/lib/libraries/solanaEscrowLib.ts
@@ -3,7 +3,7 @@ import idl from "../abi/input_settler_escrow.json";
 import { SOLANA_INPUT_SETTLER_ESCROW, SOLANA_POLYMER_ORACLE } from "../config";
 import type { MandateOutput, StandardSolana } from "@lifi/intent";
 import type { SignerWalletAdapter } from "@solana/wallet-adapter-base";
-import type { Connection } from "@solana/web3.js";
+import type { Connection, Transaction, VersionedTransaction } from "@solana/web3.js";
 import { sendAndConfirmSolanaTx } from "$lib/utils/solanaTx";
 
 /** Convert a 0x-prefixed hex string (32 bytes) to a number[] */
@@ -50,18 +50,23 @@ export async function openSolanaEscrow(params: {
 	const polymerProgramId = new PublicKey(SOLANA_POLYMER_ORACLE);
 
 	// Wrap the wallet adapter as an Anchor-compatible wallet.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const anchorWallet = {
 		publicKey: userPubkey,
-		signTransaction: (tx: any) => walletAdapter.signTransaction(tx),
-		signAllTransactions: (txs: any[]) => walletAdapter.signAllTransactions(txs)
+		signTransaction: <T extends Transaction | VersionedTransaction>(tx: T) =>
+			walletAdapter.signTransaction(tx),
+		signAllTransactions: <T extends Transaction | VersionedTransaction>(txs: T[]) =>
+			walletAdapter.signAllTransactions(txs)
 	};
 
+	// `idl` is typed as a plain JSON object; cast to any so Anchor's Program generic accepts it.
+	// `anchorWallet` is cast to any because Anchor's internal AnchorWallet type may differ across
+	// peer-dependency versions of @solana/web3.js.
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const typedIdl = idl as any;
-	const provider = new AnchorProvider(connection as any, anchorWallet as any, {
+	const provider = new AnchorProvider(connection, anchorWallet as any, {
 		commitment: "confirmed"
 	});
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const typedIdl = idl as any;
 	// Program converts the IDL to camelCase internally; its coder uses camelCase field names.
 	const program = new Program(typedIdl, provider);
 

--- a/src/lib/libraries/token.ts
+++ b/src/lib/libraries/token.ts
@@ -3,6 +3,7 @@ import { COMPACT_ABI } from "../abi/compact";
 import { ERC20_ABI } from "../abi/erc20";
 import { ADDRESS_ZERO, evmClients, COMPACT } from "../config";
 import { ResetPeriod, toId } from "@lifi/intent";
+import { Connection, PublicKey } from "@solana/web3.js";
 
 export async function getBalance(
 	user: `0x${string}` | undefined,
@@ -59,5 +60,45 @@ export async function getCompactBalance(
 		});
 	} catch {
 		return 0n;
+	}
+}
+
+const SOLANA_RPC_TIMEOUT_MS = 10_000;
+
+export async function getSolanaBalance(
+	userBase58: string | undefined,
+	asset: `0x${string}`,
+	connection: Connection
+): Promise<bigint | null> {
+	if (!userBase58) return null;
+	try {
+		const signal = AbortSignal.timeout(SOLANA_RPC_TIMEOUT_MS);
+		const userPubkey = new PublicKey(userBase58);
+		if (asset === ADDRESS_ZERO) {
+			const lamports = await Promise.race([
+				connection.getBalance(userPubkey),
+				new Promise<never>((_, reject) =>
+					signal.addEventListener("abort", () => reject(signal.reason))
+				)
+			]);
+			return BigInt(lamports);
+		}
+		const mintBytes = Buffer.from(asset.replace("0x", ""), "hex");
+		const mintPubkey = new PublicKey(mintBytes);
+		const tokenAccounts = await Promise.race([
+			connection.getParsedTokenAccountsByOwner(userPubkey, { mint: mintPubkey }),
+			new Promise<never>((_, reject) =>
+				signal.addEventListener("abort", () => reject(signal.reason))
+			)
+		]);
+		if (tokenAccounts.value.length === 0) return 0n;
+		const amount = tokenAccounts.value[0]?.account?.data?.parsed?.info?.tokenAmount?.amount;
+		if (typeof amount !== "string") {
+			throw new Error("Unexpected Solana RPC response: missing tokenAmount in parsed account data");
+		}
+		return BigInt(amount);
+	} catch (e) {
+		console.error("getSolanaBalance failed", { userBase58, asset, error: e });
+		return null;
 	}
 }

--- a/src/lib/screens/IssueIntent.svelte
+++ b/src/lib/screens/IssueIntent.svelte
@@ -42,6 +42,9 @@
 	const resolveSolanaRecipient = (value: string): `0x${string}` | undefined =>
 		isValidSolanaAddress(value) ? solanaAddressToBytes32(value) : undefined;
 
+	const hasSolanaInput = $derived(
+		store.inputTokens.some((t) => SOLANA_CHAIN_IDS.has(t.token.chainId))
+	);
 	const hasSolanaOutput = $derived(
 		store.outputTokens.some((t) => SOLANA_CHAIN_IDS.has(t.token.chainId))
 	);
@@ -131,15 +134,30 @@
 	let balanceCheckWallet = $state(true);
 	$effect(() => {
 		balanceCheckWallet = true;
-		if (!store.balances[store.inputTokens[0].token.chainId]) {
-			balanceCheckWallet = false;
-			return;
-		}
-		for (let i = 0; i < store.inputTokens.length; ++i) {
-			const { token, amount } = store.inputTokens[i];
-			store.balances[token.chainId][token.address].then((b) => {
-				balanceCheckWallet = balanceCheckWallet && b >= amount;
-			});
+		const firstToken = store.inputTokens[0];
+		if (SOLANA_CHAIN_IDS.has(firstToken.token.chainId)) {
+			for (let i = 0; i < store.inputTokens.length; ++i) {
+				const { token, amount } = store.inputTokens[i];
+				const balPromise = store.solanaBalances[token.chainId]?.[token.address];
+				if (!balPromise) {
+					balanceCheckWallet = false;
+					return;
+				}
+				balPromise.then((b) => {
+					balanceCheckWallet = balanceCheckWallet && b !== null && b >= amount;
+				});
+			}
+		} else {
+			if (!store.balances[firstToken.token.chainId]) {
+				balanceCheckWallet = false;
+				return;
+			}
+			for (let i = 0; i < store.inputTokens.length; ++i) {
+				const { token, amount } = store.inputTokens[i];
+				store.balances[token.chainId][token.address].then((b) => {
+					balanceCheckWallet = balanceCheckWallet && b >= amount;
+				});
+			}
 		}
 	});
 	let balanceCheckCompact = $state(true);
@@ -396,7 +414,7 @@
 				>
 					Solana Recipient Required
 				</button>
-			{:else if !allowanceCheck}
+			{:else if !allowanceCheck && !hasSolanaInput}
 				<AwaitButton buttonFunction={approveFunction}>
 					{#snippet name()}
 						Set allowance

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -9,12 +9,15 @@ import {
 	INPUT_SETTLER_ESCROW_LIFI,
 	MULTICHAIN_INPUT_SETTLER_COMPACT,
 	MULTICHAIN_INPUT_SETTLER_ESCROW,
+	getSolanaConnection,
+	isSolanaChain,
 	type availableAllocators,
 	type Token,
 	type Verifier,
 	type WC
 } from "./config";
-import { getAllowance, getBalance, getCompactBalance } from "./libraries/token";
+import { getAllowance, getBalance, getCompactBalance, getSolanaBalance } from "./libraries/token";
+import solanaWallet from "./utils/solana-wallet.svelte";
 import { browser } from "$app/environment";
 import { initDb, db } from "./db";
 import {
@@ -258,6 +261,27 @@ class Store {
 			scopeKey: `${account ?? "none"}:${allocatorId}`,
 			fetcher: (asset, client) => getCompactBalance(account, asset, client, allocatorId)
 		});
+	});
+
+	solanaPublicKey = $derived(solanaWallet.publicKey ?? "");
+
+	solanaBalances = $derived.by(() => {
+		this.refreshEpoch;
+		const account = this.solanaPublicKey || undefined;
+		const resolved: Partial<Record<number, Record<`0x${string}`, Promise<bigint | null>>>> = {};
+		if (!account) return resolved;
+		for (const token of coinList(this.mainnet)) {
+			if (!isSolanaChain(token.chainId)) continue;
+			const cid = token.chainId;
+			if (!resolved[cid]) resolved[cid] = {};
+			const key = `solana-balance:${this.mainnet ? "mainnet" : "testnet"}:${cid}:${token.address}:${account}`;
+			resolved[cid]![token.address] = getOrFetchRpc(
+				key,
+				() => getSolanaBalance(account, token.address, getSolanaConnection(cid)),
+				{ ttlMs: 30_000 }
+			);
+		}
+		return resolved;
 	});
 
 	multichain = $derived([...new Set(this.inputTokens.map((i) => i.token.chainId))].length > 1);

--- a/src/lib/utils/intent.ts
+++ b/src/lib/utils/intent.ts
@@ -22,7 +22,9 @@ export function containerToIntent(
 	if (!("originChainId" in order)) {
 		return orderToIntent({ namespace: "eip155", inputSettler, order });
 	}
-	if (SOLANA_CHAIN_IDS.has(order.originChainId)) {
+	// After a JSON round-trip through the DB, bigints are serialized as strings.
+	// Wrap in BigInt() so the Set comparison works regardless.
+	if (SOLANA_CHAIN_IDS.has(BigInt(order.originChainId))) {
 		return orderToIntent({ namespace: "solana", inputSettler, order });
 	}
 	return orderToIntent({ namespace: "eip155", inputSettler, order });

--- a/src/lib/utils/solanaTx.ts
+++ b/src/lib/utils/solanaTx.ts
@@ -1,12 +1,12 @@
 import type { Connection } from "@solana/web3.js";
 
-const CONFIRM_TIMEOUT_MS = 5_000;
+const CONFIRM_TIMEOUT_MS = 30_000;
 const MAX_RETRIES = 1;
 
 /**
  * Sends a serialized signed Solana transaction and waits for on-chain confirmation.
  *
- * If confirmation does not arrive within `confirmTimeoutMs` (default 5 s), the same
+ * If confirmation does not arrive within `confirmTimeoutMs` (default 30 s), the same
  * transaction is re-submitted once more and the wait is repeated. Throws if all
  * attempts are exhausted without confirmation.
  *

--- a/src/lib/utils/solanaTx.ts
+++ b/src/lib/utils/solanaTx.ts
@@ -1,0 +1,67 @@
+import type { Connection } from "@solana/web3.js";
+
+const CONFIRM_TIMEOUT_MS = 5_000;
+const MAX_RETRIES = 1;
+
+/**
+ * Sends a serialized signed Solana transaction and waits for on-chain confirmation.
+ *
+ * If confirmation does not arrive within `confirmTimeoutMs` (default 5 s), the same
+ * transaction is re-submitted once more and the wait is repeated. Throws if all
+ * attempts are exhausted without confirmation.
+ *
+ * Program-level errors (returned inside the confirmed result) are thrown immediately
+ * without retrying — only confirmation timeouts trigger a retry.
+ *
+ * @param connection      Solana RPC connection
+ * @param rawTransaction  Serialized signed transaction (output of `tx.serialize()`)
+ * @returns               Transaction signature
+ */
+export async function sendAndConfirmSolanaTx(
+	connection: Connection,
+	rawTransaction: Uint8Array,
+	options?: { confirmTimeoutMs?: number; maxRetries?: number }
+): Promise<string> {
+	const timeoutMs = options?.confirmTimeoutMs ?? CONFIRM_TIMEOUT_MS;
+	const maxRetries = options?.maxRetries ?? MAX_RETRIES;
+
+	let lastError: Error | undefined;
+
+	for (let attempt = 0; attempt <= maxRetries; attempt++) {
+		// Fetch a fresh blockhash anchor for the confirmation polling window.
+		// The transaction's own embedded blockhash (valid ~90 slots / ~60 s) remains unchanged.
+		const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash("confirmed");
+
+		const signature = await connection.sendRawTransaction(rawTransaction, {
+			skipPreflight: false,
+			preflightCommitment: "confirmed"
+		});
+
+		try {
+			const result = await Promise.race([
+				connection.confirmTransaction({ signature, blockhash, lastValidBlockHeight }, "confirmed"),
+				new Promise<never>((_, reject) =>
+					setTimeout(
+						() => reject(new Error(`Confirmation timed out after ${timeoutMs / 1_000}s`)),
+						timeoutMs
+					)
+				)
+			]);
+
+			if (result.value.err) {
+				throw new Error(`Transaction failed: ${JSON.stringify(result.value.err)}`);
+			}
+
+			return signature;
+		} catch (err) {
+			const error = err instanceof Error ? err : new Error(String(err));
+			// Program / simulation errors are not retriable — surface them immediately.
+			if (!error.message.startsWith("Confirmation timed out")) {
+				throw error;
+			}
+			lastError = error;
+		}
+	}
+
+	throw lastError ?? new Error("Solana transaction failed to confirm");
+}

--- a/tests/unit/solanaEscrowLib.test.ts
+++ b/tests/unit/solanaEscrowLib.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, mock, beforeAll } from "bun:test";
+import type { MandateOutput, StandardSolana } from "@lifi/intent";
+import type { SignerWalletAdapter } from "@solana/wallet-adapter-base";
+import type { Connection } from "@solana/web3.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const DEVNET_CHAIN_ID = 1151111081099712n;
+const FAKE_ORACLE = ("0x" + "ab".repeat(32)) as `0x${string}`;
+const FAKE_SETTLER = ("0x" + "cd".repeat(32)) as `0x${string}`;
+const FAKE_TOKEN = ("0x" + "ef".repeat(32)) as `0x${string}`;
+const FAKE_RECIPIENT = ("0x" + "12".repeat(32)) as `0x${string}`;
+
+const fakeOutput: MandateOutput = {
+	oracle: FAKE_ORACLE,
+	settler: FAKE_SETTLER,
+	chainId: 84532n,
+	token: FAKE_TOKEN,
+	amount: 1_000_000n,
+	recipient: FAKE_RECIPIENT,
+	callbackData: "0x",
+	context: "0x"
+};
+
+function makeOrder(inputs: [bigint, bigint][]): StandardSolana {
+	return {
+		user: ("0x" + "aa".repeat(20)) as `0x${string}`,
+		nonce: 1n,
+		originChainId: DEVNET_CHAIN_ID,
+		expires: Math.floor(Date.now() / 1000) + 3600,
+		fillDeadline: Math.floor(Date.now() / 1000) + 3599,
+		inputOracle: ("0x" + "bb".repeat(20)) as `0x${string}`,
+		// Cast required: StandardSolana mandates exactly one input; we test zero below
+		inputs: inputs as unknown as [[bigint, bigint]],
+		outputs: [fakeOutput]
+	};
+}
+
+/** Minimal Connection mock — not exercised by the empty-inputs guard */
+function makeConnection(): Connection {
+	return {
+		getLatestBlockhash: mock(async () => ({ blockhash: "abc", lastValidBlockHeight: 999 })),
+		sendRawTransaction: mock(async () => "fakeSig"),
+		confirmTransaction: mock(async () => ({ value: { err: null } }))
+	} as unknown as Connection;
+}
+
+/** Minimal wallet adapter mock */
+function makeAdapter(): SignerWalletAdapter {
+	return {
+		signTransaction: mock(async (tx: unknown) => tx),
+		signAllTransactions: mock(async (txs: unknown[]) => txs)
+	} as unknown as SignerWalletAdapter;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("openSolanaEscrow", () => {
+	it("throws immediately when order.inputs is empty", async () => {
+		const { openSolanaEscrow } = await import("../../src/lib/libraries/solanaEscrowLib");
+
+		const order = makeOrder([]);
+		await expect(
+			openSolanaEscrow({
+				order,
+				solanaPublicKey: "GsbwXfJraMomNxBcjYLcG3mxkBUiyWXAB32fGbSMQH7x",
+				walletAdapter: makeAdapter(),
+				connection: makeConnection()
+			})
+		).rejects.toThrow("StandardSolana order has no inputs");
+	});
+
+	it("wraps Borsh encoding errors with a descriptive message", async () => {
+		// Mock @coral-xyz/anchor so Program.coder.types.encode throws
+		mock.module("@coral-xyz/anchor", () => {
+			class FakePublicKey {
+				constructor(public key: unknown) {}
+				static findProgramAddressSync() {
+					return [new FakePublicKey("pda"), 255];
+				}
+			}
+			class FakeBN {
+				constructor(public n: string) {}
+				toString() {
+					return this.n;
+				}
+			}
+			class FakeProgram {
+				get coder() {
+					return {
+						types: {
+							encode(_name: string, _data: unknown): never {
+								throw new Error("IDL type not found: standardOrder");
+							}
+						}
+					};
+				}
+				get methods() {
+					return new Proxy(
+						{},
+						{
+							get: () => () => ({
+								accounts: () => ({
+									transaction: async () => ({ feePayer: null, recentBlockhash: null })
+								})
+							})
+						}
+					);
+				}
+			}
+			class FakeAnchorProvider {
+				constructor(
+					public conn: unknown,
+					public wallet: unknown,
+					public opts: unknown
+				) {}
+			}
+			return {
+				AnchorProvider: FakeAnchorProvider,
+				BN: FakeBN,
+				Program: FakeProgram
+			};
+		});
+
+		mock.module("@solana/web3.js", () => {
+			class FakePublicKey {
+				constructor(public key: unknown) {}
+				static findProgramAddressSync() {
+					return [new FakePublicKey("pda"), 255];
+				}
+			}
+			const SystemProgram = { programId: new FakePublicKey("system") };
+			return { PublicKey: FakePublicKey, SystemProgram };
+		});
+
+		mock.module("@solana/spl-token", () => ({
+			ASSOCIATED_TOKEN_PROGRAM_ID: "assocProg",
+			TOKEN_PROGRAM_ID: "tokenProg",
+			getAssociatedTokenAddressSync: () => "ataAddr"
+		}));
+
+		const { openSolanaEscrow } = await import("../../src/lib/libraries/solanaEscrowLib");
+
+		// 32-byte token ID as bigint (Solana SPL mint)
+		const mintBigint = BigInt(
+			"0x" + "3b442cb3912157f13a933d0134282d032b5ffecd01a2dbf1b7790608df002ea7"
+		);
+		const order = makeOrder([[mintBigint, 100_000n]]);
+
+		await expect(
+			openSolanaEscrow({
+				order,
+				solanaPublicKey: "GsbwXfJraMomNxBcjYLcG3mxkBUiyWXAB32fGbSMQH7x",
+				walletAdapter: makeAdapter(),
+				connection: makeConnection()
+			})
+		).rejects.toThrow("Borsh encoding failed for standardOrder");
+	});
+});

--- a/tests/unit/solanaTx.test.ts
+++ b/tests/unit/solanaTx.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, mock } from "bun:test";
+import { sendAndConfirmSolanaTx } from "../../src/lib/utils/solanaTx";
+import type { Connection } from "@solana/web3.js";
+
+const FAKE_BLOCKHASH = { blockhash: "fakeBlockhash", lastValidBlockHeight: 9999 };
+const FAKE_SIG = "fakeSig123";
+const RAW_TX = new Uint8Array([1, 2, 3]);
+
+const OK = { value: { err: null } };
+const PROGRAM_ERR = { value: { err: { InstructionError: [0, "InvalidArgument"] } } };
+
+/** Resolves after `ms` milliseconds with `value`. */
+const delay = <T>(ms: number, value: T) =>
+	new Promise<T>((res) => setTimeout(() => res(value), ms));
+
+/** Builds a minimal Connection mock. Each field can be overridden. */
+function makeConnection(overrides: Partial<Record<string, unknown>> = {}): Connection {
+	return {
+		getLatestBlockhash: mock(async () => FAKE_BLOCKHASH),
+		sendRawTransaction: mock(async () => FAKE_SIG),
+		confirmTransaction: mock(async () => OK),
+		...overrides
+	} as unknown as Connection;
+}
+
+describe("sendAndConfirmSolanaTx", () => {
+	it("returns the signature when confirmation succeeds on the first attempt", async () => {
+		const conn = makeConnection();
+
+		const sig = await sendAndConfirmSolanaTx(conn, RAW_TX);
+
+		expect(sig).toBe(FAKE_SIG);
+		expect(conn.sendRawTransaction).toHaveBeenCalledTimes(1);
+		expect(conn.confirmTransaction).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries once when the first confirmation times out, succeeds on retry", async () => {
+		let call = 0;
+		const confirmTransaction = mock(async () => {
+			// First call: slow (misses 1 ms timeout). Second call: immediate.
+			return call++ === 0 ? delay(50, OK) : OK;
+		});
+		const conn = makeConnection({ confirmTransaction });
+
+		const sig = await sendAndConfirmSolanaTx(conn, RAW_TX, { confirmTimeoutMs: 1 });
+
+		expect(sig).toBe(FAKE_SIG);
+		expect(conn.sendRawTransaction).toHaveBeenCalledTimes(2);
+		expect(conn.confirmTransaction).toHaveBeenCalledTimes(2);
+	});
+
+	it("throws after all retries are exhausted", async () => {
+		// Both calls are slow — neither confirms within the timeout.
+		const confirmTransaction = mock(() => delay(50, OK));
+		const conn = makeConnection({ confirmTransaction });
+
+		await expect(sendAndConfirmSolanaTx(conn, RAW_TX, { confirmTimeoutMs: 1 })).rejects.toThrow(
+			"Confirmation timed out after"
+		);
+
+		expect(conn.sendRawTransaction).toHaveBeenCalledTimes(2); // initial + 1 retry
+	});
+
+	it("throws immediately on a program error without retrying", async () => {
+		const confirmTransaction = mock(async () => PROGRAM_ERR);
+		const conn = makeConnection({ confirmTransaction });
+
+		await expect(sendAndConfirmSolanaTx(conn, RAW_TX)).rejects.toThrow("Transaction failed");
+
+		expect(conn.sendRawTransaction).toHaveBeenCalledTimes(1);
+	});
+
+	it("throws immediately on an RPC error without retrying", async () => {
+		const confirmTransaction = mock(async () => {
+			throw new Error("RPC node unreachable");
+		});
+		const conn = makeConnection({ confirmTransaction });
+
+		await expect(sendAndConfirmSolanaTx(conn, RAW_TX)).rejects.toThrow("RPC node unreachable");
+
+		expect(conn.sendRawTransaction).toHaveBeenCalledTimes(1);
+	});
+
+	it("passes the serialized transaction bytes to sendRawTransaction", async () => {
+		const conn = makeConnection();
+
+		await sendAndConfirmSolanaTx(conn, RAW_TX);
+
+		expect(conn.sendRawTransaction).toHaveBeenCalledWith(RAW_TX, expect.anything());
+	});
+
+	it("passes signature + blockhash anchor to confirmTransaction", async () => {
+		const conn = makeConnection();
+
+		await sendAndConfirmSolanaTx(conn, RAW_TX);
+
+		expect(conn.confirmTransaction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				signature: FAKE_SIG,
+				blockhash: FAKE_BLOCKHASH.blockhash,
+				lastValidBlockHeight: FAKE_BLOCKHASH.lastValidBlockHeight
+			}),
+			"confirmed"
+		);
+	});
+
+	it("fetches a fresh blockhash for each attempt", async () => {
+		let call = 0;
+		const confirmTransaction = mock(async () => (call++ === 0 ? delay(50, OK) : OK));
+		const conn = makeConnection({ confirmTransaction });
+
+		await sendAndConfirmSolanaTx(conn, RAW_TX, { confirmTimeoutMs: 1 });
+
+		expect(conn.getLatestBlockhash).toHaveBeenCalledTimes(2);
+	});
+
+	it("respects a custom maxRetries of 0 (no retry)", async () => {
+		const confirmTransaction = mock(() => delay(50, OK));
+		const conn = makeConnection({ confirmTransaction });
+
+		await expect(
+			sendAndConfirmSolanaTx(conn, RAW_TX, { confirmTimeoutMs: 1, maxRetries: 0 })
+		).rejects.toThrow("Confirmation timed out after");
+
+		expect(conn.sendRawTransaction).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary

- Add Solana→EVM intent issuance: users on Solana devnet can open escrow intents targeting EVM output tokens
- Integrate Solana wallet connection (Phantom, Solflare) for transaction signing via `@solana/wallet-adapter-*`
- Add `openSolanaEscrow` in `solanaEscrowLib.ts`: Anchor-based Borsh encoding, PDA derivation, ATA resolution, and `sendAndConfirmSolanaTx` submission
- Add `solanaTx.ts`: resilient send-and-confirm loop with 30 s timeout, 1 retry on timeout, immediate throw on program errors
- Guard Solana/EVM input exclusivity in `InputTokenModal` — cannot mix chains in a single order
- Route Solana balance checks to `store.solanaBalances` in `IssueIntent.svelte`
- Fix intent-list display for Solana inputs: use full 32-byte mint address instead of `idToToken()` (EVM-only)
- Fix `containerToIntent` routing after JSON round-trip (bigint-as-string from DB)
- Replace `bigint-buffer` (CVE-2025-3194) with `bigint-buffer-fixed@^1.1.6` via bun `overrides`

## Code changes

| File | What changed |
|---|---|
| `src/lib/libraries/solanaEscrowLib.ts` | New: Anchor tx builder for Solana escrow open |
| `src/lib/utils/solanaTx.ts` | New: resilient send+confirm with retry |
| `src/lib/utils/solana-wallet.svelte.ts` | New: Svelte 5 reactive Solana wallet state |
| `src/lib/libraries/intentFactory.ts` | Branch on Solana input chain → call `openSolanaEscrow` |
| `src/lib/screens/IssueIntent.svelte` | Skip EVM allowance check for Solana inputs; fix balance check |
| `src/lib/components/InputTokenModal.svelte` | Enforce Solana/EVM exclusivity on toggle |
| `src/lib/libraries/intentList.ts` | Fix Solana token display (full 32-byte mint) |
| `src/lib/utils/intent.ts` | `BigInt()` coerce originChainId after DB round-trip |
| `src/lib/config.ts` | Solana devnet chain + tokens + oracle; fix polygon client chain |
| `package.json` | Add `@coral-xyz/anchor`; `bigint-buffer` CVE override |

## Test plan

- [x] Run `bun run test:unit` — all 44 tests pass
- [x] Testnet: select Solana devnet USDC as input + Base Sepolia USDC as output → intent submits, appears in list with correct amounts
- [x] Reload page → intent list renders without `InvalidAddressError`
- [x] InputTokenModal: enabling Solana chain auto-disables all EVM chains and vice-versa
- [x] IssueIntent with Solana input: "Execute Open" button shown (not "Set Allow"); balance check uses Solana balance
- [x] Confirm Solana devnet oracle address in submitted order: `outputs[0].oracle = 0xe48a6f95...`

## Closes

- V2-117
- V2-112

## Expected output 
https://github.com/user-attachments/assets/59f355c8-7bc2-4ca6-a1b0-6a64c313eb0b


