### PR TITLE
chore: sync intent fillDeadline/expires with lifi-backend (EXP-432)

### DIFF
--- a/src/lib/libraries/intent.ts
+++ b/src/lib/libraries/intent.ts
@@ -115,8 +115,12 @@ export class Intent {
 
 	private _nonce?: bigint;
 
-	private expiry = ONE_DAY;
-	private fillDeadline = 2 * ONE_HOUR;
+	private get expiry() {
+		return this.isSameChain() ? 10 * ONE_MINUTE : 2 * ONE_DAY;
+	}
+	private get fillDeadline() {
+		return this.isSameChain() ? 10 * ONE_MINUTE : 44 * ONE_HOUR;
+	}
 
 	constructor(opts: CreateIntentOptionsEscrow | CreateIntentOptionsCompact) {
 		this.lock = opts.lock;

--- a/src/lib/libraries/intent.ts
+++ b/src/lib/libraries/intent.ts
@@ -115,12 +115,8 @@ export class Intent {
 
 	private _nonce?: bigint;
 
-	private get expiry() {
-		return this.isSameChain() ? 10 * ONE_MINUTE : 2 * ONE_DAY;
-	}
-	private get fillDeadline() {
-		return this.isSameChain() ? 10 * ONE_MINUTE : 44 * ONE_HOUR;
-	}
+	private expiry = 2 * ONE_DAY;
+	private fillDeadline = 44 * ONE_HOUR;
 
 	constructor(opts: CreateIntentOptionsEscrow | CreateIntentOptionsCompact) {
 		this.lock = opts.lock;

--- a/tests/unit/intent.test.ts
+++ b/tests/unit/intent.test.ts
@@ -4,7 +4,6 @@ import type { chain, Token } from "../../src/lib/config";
 
 const FORTY_FOUR_HOURS = 44 * 60 * 60; // 158_400
 const TWO_DAYS = 2 * 24 * 60 * 60; // 172_800
-const TEN_MINUTES = 10 * 60; // 600
 
 function token(chain: chain): Token {
 	return {
@@ -52,21 +51,21 @@ describe("Intent deadlines", () => {
 		expect(order.fillDeadline).toBeLessThanOrEqual(order.expires);
 	});
 
-	it("same-chain singlechain order uses 10m fillDeadline and 10m expires", () => {
+	it("same-chain singlechain order uses 44h fillDeadline and 2d expires", () => {
 		const before = Math.floor(Date.now() / 1000);
 		const { order } = makeIntent("base", "base").singlechain();
 		const after = Math.floor(Date.now() / 1000);
 
-		expect(order.fillDeadline).toBeGreaterThanOrEqual(before + TEN_MINUTES);
-		expect(order.fillDeadline).toBeLessThanOrEqual(after + TEN_MINUTES);
+		expect(order.fillDeadline).toBeGreaterThanOrEqual(before + FORTY_FOUR_HOURS);
+		expect(order.fillDeadline).toBeLessThanOrEqual(after + FORTY_FOUR_HOURS);
 
-		expect(order.expires).toBeGreaterThanOrEqual(before + TEN_MINUTES);
-		expect(order.expires).toBeLessThanOrEqual(after + TEN_MINUTES);
+		expect(order.expires).toBeGreaterThanOrEqual(before + TWO_DAYS);
+		expect(order.expires).toBeLessThanOrEqual(after + TWO_DAYS);
 
-		expect(order.fillDeadline).toBe(order.expires);
+		expect(order.fillDeadline).toBeLessThanOrEqual(order.expires);
 	});
 
-	it("multichain order uses cross-chain (44h / 2d) deadlines", () => {
+	it("multichain order uses 44h fillDeadline and 2d expires", () => {
 		const before = Math.floor(Date.now() / 1000);
 		const { order } = makeMultichainIntent(["base", "arbitrum"], "ethereum").multichain();
 		const after = Math.floor(Date.now() / 1000);

--- a/tests/unit/intent.test.ts
+++ b/tests/unit/intent.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import { Intent } from "../../src/lib/libraries/intent";
+import type { chain, Token } from "../../src/lib/config";
+
+const FORTY_FOUR_HOURS = 44 * 60 * 60; // 158_400
+const TWO_DAYS = 2 * 24 * 60 * 60; // 172_800
+const TEN_MINUTES = 10 * 60; // 600
+
+function token(chain: chain): Token {
+	return {
+		address: "0x0000000000000000000000000000000000000001",
+		name: "MOCK",
+		chain,
+		decimals: 18
+	};
+}
+
+function makeIntent(inputChain: chain, outputChain: chain) {
+	return new Intent({
+		exclusiveFor: "",
+		inputTokens: [{ token: token(inputChain), amount: 1n }],
+		outputTokens: [{ token: token(outputChain), amount: 1n }],
+		verifier: "polymer",
+		account: () => "0x1111111111111111111111111111111111111111",
+		lock: { type: "escrow" }
+	});
+}
+
+function makeMultichainIntent(inputChains: chain[], outputChain: chain) {
+	return new Intent({
+		exclusiveFor: "",
+		inputTokens: inputChains.map((c) => ({ token: token(c), amount: 1n })),
+		outputTokens: [{ token: token(outputChain), amount: 1n }],
+		verifier: "polymer",
+		account: () => "0x1111111111111111111111111111111111111111",
+		lock: { type: "escrow" }
+	});
+}
+
+describe("Intent deadlines", () => {
+	it("cross-chain singlechain order uses 44h fillDeadline and 2d expires", () => {
+		const before = Math.floor(Date.now() / 1000);
+		const { order } = makeIntent("base", "arbitrum").singlechain();
+		const after = Math.floor(Date.now() / 1000);
+
+		expect(order.fillDeadline).toBeGreaterThanOrEqual(before + FORTY_FOUR_HOURS);
+		expect(order.fillDeadline).toBeLessThanOrEqual(after + FORTY_FOUR_HOURS);
+
+		expect(order.expires).toBeGreaterThanOrEqual(before + TWO_DAYS);
+		expect(order.expires).toBeLessThanOrEqual(after + TWO_DAYS);
+
+		expect(order.fillDeadline).toBeLessThanOrEqual(order.expires);
+	});
+
+	it("same-chain singlechain order uses 10m fillDeadline and 10m expires", () => {
+		const before = Math.floor(Date.now() / 1000);
+		const { order } = makeIntent("base", "base").singlechain();
+		const after = Math.floor(Date.now() / 1000);
+
+		expect(order.fillDeadline).toBeGreaterThanOrEqual(before + TEN_MINUTES);
+		expect(order.fillDeadline).toBeLessThanOrEqual(after + TEN_MINUTES);
+
+		expect(order.expires).toBeGreaterThanOrEqual(before + TEN_MINUTES);
+		expect(order.expires).toBeLessThanOrEqual(after + TEN_MINUTES);
+
+		expect(order.fillDeadline).toBe(order.expires);
+	});
+
+	it("multichain order uses cross-chain (44h / 2d) deadlines", () => {
+		const before = Math.floor(Date.now() / 1000);
+		const { order } = makeMultichainIntent(["base", "arbitrum"], "ethereum").multichain();
+		const after = Math.floor(Date.now() / 1000);
+
+		expect(order.fillDeadline).toBeGreaterThanOrEqual(before + FORTY_FOUR_HOURS);
+		expect(order.fillDeadline).toBeLessThanOrEqual(after + FORTY_FOUR_HOURS);
+
+		expect(order.expires).toBeGreaterThanOrEqual(before + TWO_DAYS);
+		expect(order.expires).toBeLessThanOrEqual(after + TWO_DAYS);
+
+		expect(order.fillDeadline).toBeLessThanOrEqual(order.expires);
+	});
+});


### PR DESCRIPTION
## Summary

Bump `Intent` fillDeadline from 2h → 44h and expires from 24h → 2d, mirroring lifi-backend PR #8340 (`LIFI_INTENTS_FILL_DEADLINE_DURATION_SECONDS` / `LIFI_INTENTS_EXPIRES_DURATION_SECONDS`).

The change is two constants on the `Intent` class (`src/lib/libraries/intent.ts:118-119`); values are applied uniformly to every issued order via `singlechain()` and `multichain()`.

Linear: [EXP-432](https://linear.app/lifi-linear/issue/EXP-432/increase-lifiintents-filldeadline-to-44h-to-allow-fallback)
Backend PR: lifinance/lifi-backend#8340

## Test plan

- [x] `bun run test:unit` — 25/25 (3 new tests under `tests/unit/intent.test.ts` covering cross-chain singlechain, same-chain singlechain, and multichain — all asserting fillDeadline=44h, expires=2d)
- [x] `bun run test:e2e` — 3/3 (Chromium)
- [x] `bun run check` — no new errors introduced (pre-existing env-var errors on `main` unaffected)
- [x] `bun run lint` — clean on touched files
- [ ] Manual carousel walk: issued intent shows `in 44h` in IntentList