### PR TITLE
[SOLV-544] chore: Increase intent exclusiveFor window from 1m to 5m 

### DIFF
--- a/src/lib/libraries/intent.ts
+++ b/src/lib/libraries/intent.ts
@@ -98,6 +98,7 @@ function encodeOutputs(outputs: MandateOutput[]) {
 const ONE_MINUTE = 60;
 const ONE_HOUR = 60 * ONE_MINUTE;
 const ONE_DAY = 24 * ONE_HOUR;
+const EXCLUSIVITY_WINDOW = 5 * ONE_MINUTE; // gives solvers time to fill before exclusivity ends
 
 /**
  * @notice Class representing a Li.Fi Intent. Contains intent abstractions and helpers.
@@ -179,16 +180,12 @@ export class Intent {
 	}
 
 	encodeOutputs(currentTime: number) {
-		// Get the current epoch timestamp:
-		currentTime;
-		const ONE_MINUTE = 60;
-
 		let context: `0x${string}` = "0x";
 		if (this.exclusiveFor) {
 			const paddedExclusiveFor: `0x${string}` = `0x${this.exclusiveFor.replace("0x", "").padStart(64, "0")}`;
 			context = encodePacked(
 				["bytes1", "bytes32", "uint32"],
-				["0xe0", paddedExclusiveFor, currentTime + ONE_MINUTE]
+				["0xe0", paddedExclusiveFor, currentTime + EXCLUSIVITY_WINDOW]
 			);
 		}
 

--- a/tests/unit/intent.test.ts
+++ b/tests/unit/intent.test.ts
@@ -4,6 +4,7 @@ import type { chain, Token } from "../../src/lib/config";
 
 const FORTY_FOUR_HOURS = 44 * 60 * 60; // 158_400
 const TWO_DAYS = 2 * 24 * 60 * 60; // 172_800
+const FIVE_MINUTES = 5 * 60; // 300
 
 function token(chain: chain): Token {
 	return {
@@ -14,9 +15,9 @@ function token(chain: chain): Token {
 	};
 }
 
-function makeIntent(inputChain: chain, outputChain: chain) {
+function makeIntent(inputChain: chain, outputChain: chain, exclusiveFor = "") {
 	return new Intent({
-		exclusiveFor: "",
+		exclusiveFor,
 		inputTokens: [{ token: token(inputChain), amount: 1n }],
 		outputTokens: [{ token: token(outputChain), amount: 1n }],
 		verifier: "polymer",
@@ -77,5 +78,23 @@ describe("Intent deadlines", () => {
 		expect(order.expires).toBeLessThanOrEqual(after + TWO_DAYS);
 
 		expect(order.fillDeadline).toBeLessThanOrEqual(order.expires);
+	});
+
+	it("encodes exclusiveFor deadline as now + 5 minutes in output context", () => {
+		const exclusiveFor = "0x2222222222222222222222222222222222222222";
+		const before = Math.floor(Date.now() / 1000);
+		const { order } = makeIntent("base", "arbitrum", exclusiveFor).singlechain();
+		const after = Math.floor(Date.now() / 1000);
+
+		const context = order.outputs[0].context;
+		expect(context.length).toBeGreaterThan(2); // not just "0x"
+
+		// Layout: bytes1 0xe0 || bytes32 exclusiveFor || uint32 deadline
+		// = 37 bytes = 74 hex chars after the "0x" prefix.
+		expect(context.length).toBe(2 + 74);
+
+		const deadline = parseInt(context.slice(-8), 16);
+		expect(deadline).toBeGreaterThanOrEqual(before + FIVE_MINUTES);
+		expect(deadline).toBeLessThanOrEqual(after + FIVE_MINUTES);
 	});
 });


### PR DESCRIPTION
## Summary

- Increase the exclusivity window encoded into intent output `context` bytes from 60s to 5 minutes (`5 * ONE_MINUTE`) via a new `EXCLUSIVITY_WINDOW` constant in `src/lib/libraries/intent.ts`.
- The previous 1-minute window was too short for solver devs to exercise fills end-to-end during manual testing.
- Lock the value with a unit test that decodes the trailing `uint32` deadline from `order.outputs[0].context` and asserts it is `now + 5m`.

Linear: https://linear.app/lifi-linear/issue/SOLV-544/increase-intent-exclusivefor-window-from-1m-to-5m-for-solver-testing

## Test plan

- [x] `bun run test:unit`
- [x] `bun run check`
- [x] `bun run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancement**
  * Extended the exclusivity window duration for exclusive intents to 5 minutes, allowing exclusive intents to remain active longer before reaching their expiration deadline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lifinance/lintent/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->