### PR TITLE
chore: add additional BSC fallback RPCs

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -524,6 +524,10 @@ export const clients = {
     transport: fallback([
       ...routemeshRpc(bsc.id),
       http("https://bsc-rpc.publicnode.com"),
+      http("https://bsc-dataseed.bnbchain.org"),
+      http("https://bsc-dataseed1.defibit.io"),
+      http("https://bsc.drpc.org"),
+      http("https://1rpc.io/bnb"),
       ...bsc.rpcUrls.default.http.map((v) => http(v))
     ])
   }),


### PR DESCRIPTION
## Summary
- Add four public fallback RPCs to the BSC client in `src/lib/config.ts`: `bsc-dataseed.bnbchain.org` (official BNB Chain), `bsc-dataseed1.defibit.io`, `bsc.drpc.org`, and `1rpc.io/bnb`
- They sit after the routemesh and publicnode endpoints in the fallback order, so existing priority is unchanged — these only kick in when earlier endpoints fail or rate-limit

## Testing
- Verified all four endpoints respond to `eth_chainId` with `0x38` (BSC mainnet)

## Notes
- Stacked on #49 since the BSC fallback structure was introduced there; will retarget to `main` when #49 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)