### PR TITLE
fix: use publicnode as primary BSC RPC

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -58,8 +58,7 @@ export const POLYMER_ORACLE = {
 
 export type availableAllocators = typeof ALWAYS_OK_ALLOCATOR | typeof POLYMER_ALLOCATOR;
 export type availableInputSettlers =
-	| typeof INPUT_SETTLER_COMPACT_LIFI
-	| typeof INPUT_SETTLER_ESCROW_LIFI;
+	typeof INPUT_SETTLER_COMPACT_LIFI | typeof INPUT_SETTLER_ESCROW_LIFI;
 
 export const chainMap = {
 	ethereum,
@@ -410,7 +409,10 @@ export const clients = {
 	}),
 	bsc: createPublicClient({
 		chain: bsc,
-		transport: fallback([...bsc.rpcUrls.default.http.map((v) => http(v))])
+		transport: fallback([
+			http("https://bsc-rpc.publicnode.com"),
+			...bsc.rpcUrls.default.http.map((v) => http(v))
+		])
 	}),
 	polygon: createPublicClient({
 		chain: base,


### PR DESCRIPTION
## What

Prepend `https://bsc-rpc.publicnode.com` as the primary transport for the BSC public client, keeping viem's default endpoints as fallback.

## Why

`clients.bsc` was the only mainnet client using viem defaults alone (Binance dataseed), which are flaky and rate-limited. `ethereum`, `base`, and `arbitrum` all prepend a publicnode primary — BSC was added later and missed that convention. This aligns it.

Verified: `eth_chainId` on the endpoint returns `0x38` (chain 56); `npm run build` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reformatted internal configuration and type declarations without changing functionality.
  * Preserved the existing BSC network connection options and supported input settler types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->