### PR TITLE
feat: bump Intent settler/oracle addresses, disable MegaETH (DO NOT MERGE: encodeMandateOutput mismatch)

### DIFF
--- a/.claude/skills/add-chain/SKILL.md
+++ b/.claude/skills/add-chain/SKILL.md
@@ -165,7 +165,8 @@ but the chain won't appear in the UI. The invariant check (Step 4) guards this.
 **Site 4 — `POLYMER_ORACLE` (L43–57):** add
 `<chainKey>: "<bucket address>"` using the deterministic per-bucket address:
 
-- mainnet → `0x0000003E06000007A224AeE90052fA6bb46d43C9`
+- mainnet → `0x008C3800F3Ad9b3B662d002E90Cc00000000eE17` (⚠️ `PolymerOracleMapped`; its
+  `chainIdMap` must be populated by the owner before proofs validate on a given chain)
 - testnet → `0xC401b53377b8A71A7cEB820e6a4dC53832343a90`
 
 **Site 5 — `coinList(mainnet)` (L95–282):** add one object per token to the correct
@@ -232,13 +233,13 @@ on the new chain vs the reference chain (`base` mainnet / `baseSepolia` testnet)
 NEW_RPC="<RPC>"
 REF_RPC="https://base-rpc.publicnode.com"          # testnet: https://base-sepolia-rpc.publicnode.com
 for a in \
-  0x0000000000eC36B683C2E6AC89e9A75989C22a2e \
+  0x75220B7600c300005038432a0000f308e0000068 \
   0x00000000000000171ede64904551eeDF3C6C9788 \
   0x0000000000cd5f7fDEc90a03a31F79E5Fbc6A9Cf \
-  0x000025c3226C00B2Cdc200005a1600509f4e00C0 \
+  0x00fC00edbe7C003b006f870068c548940000223e \
   0xb912b4c38ab54b94D45Ac001484dEBcbb519Bc2B \
   0x1fccC0807F25A58eB531a0B5b4bf3dCE88808Ed7 \
-  0x0000003E06000007A224AeE90052fA6bb46d43C9 ; do
+  0x008C3800F3Ad9b3B662d002E90Cc00000000eE17 ; do
   printf '%s new=%s ref=%s\n' "$a" "$(cast codehash $a --rpc-url "$NEW_RPC" 2>&1)" "$(cast codehash $a --rpc-url "$REF_RPC" 2>&1)"
 done
 ```
@@ -316,13 +317,13 @@ Output, concisely:
 
 ```
 ADDRESS_ZERO                      0x0000000000000000000000000000000000000000
-COIN_FILLER                       0x0000000000eC36B683C2E6AC89e9A75989C22a2e
+COIN_FILLER                       0x75220B7600c300005038432a0000f308e0000068
 COMPACT                           0x00000000000000171ede64904551eeDF3C6C9788
 INPUT_SETTLER_COMPACT_LIFI        0x0000000000cd5f7fDEc90a03a31F79E5Fbc6A9Cf
-INPUT_SETTLER_ESCROW_LIFI         0x000025c3226C00B2Cdc200005a1600509f4e00C0
+INPUT_SETTLER_ESCROW_LIFI         0x00fC00edbe7C003b006f870068c548940000223e
 MULTICHAIN_INPUT_SETTLER_ESCROW   0xb912b4c38ab54b94D45Ac001484dEBcbb519Bc2B
 MULTICHAIN_INPUT_SETTLER_COMPACT  0x1fccC0807F25A58eB531a0B5b4bf3dCE88808Ed7
-POLYMER_ORACLE (mainnet bucket)   0x0000003E06000007A224AeE90052fA6bb46d43C9
+POLYMER_ORACLE (mainnet bucket)   0x008C3800F3Ad9b3B662d002E90Cc00000000eE17
 POLYMER_ORACLE (testnet bucket)   0xC401b53377b8A71A7cEB820e6a4dC53832343a90
 ```
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -27,28 +27,38 @@ export const BYTES32_ZERO =
 	"0x0000000000000000000000000000000000000000000000000000000000000000" as const;
 export const COMPACT = "0x00000000000000171ede64904551eeDF3C6C9788" as const;
 export const INPUT_SETTLER_COMPACT_LIFI = "0x0000000000cd5f7fDEc90a03a31F79E5Fbc6A9Cf" as const;
-export const INPUT_SETTLER_ESCROW_LIFI = "0x000025c3226C00B2Cdc200005a1600509f4e00C0" as const;
+export const INPUT_SETTLER_ESCROW_LIFI = "0x00fC00edbe7C003b006f870068c548940000223e" as const;
 export const MULTICHAIN_INPUT_SETTLER_ESCROW =
 	"0xb912b4c38ab54b94D45Ac001484dEBcbb519Bc2B" as const;
 export const MULTICHAIN_INPUT_SETTLER_COMPACT =
 	"0x1fccC0807F25A58eB531a0B5b4bf3dCE88808Ed7" as const;
 export const ALWAYS_OK_ALLOCATOR = "281773970620737143753120258" as const;
 export const POLYMER_ALLOCATOR = "116450367070547927622991121" as const; // 0x02ecC89C25A5DCB1206053530c58E002a737BD11 signing by 0x934244C8cd6BeBDBd0696A659D77C9BDfE86Efe6
-export const COIN_FILLER = "0x0000000000eC36B683C2E6AC89e9A75989C22a2e" as const;
+export const COIN_FILLER = "0x75220B7600c300005038432a0000f308e0000068" as const;
 export const WORMHOLE_ORACLE = {
 	ethereum: "0x0000000000000000000000000000000000000000",
 	arbitrum: "0x0000000000000000000000000000000000000000",
 	base: "0x0000000000000000000000000000000000000000"
 } as const;
+// ⚠️ NOT PRODUCTION-READY: the mainnet bucket below points at `PolymerOracleMapped`
+// (0x008C3800F3Ad9b3B662d002E90Cc00000000eE17), which is deployed but not yet operational.
+// It inherits `ChainMap`, and `chainIdMap`/`reverseChainIdMap` are still empty (all zero) on
+// every mainnet chain checked (ethereum, base, arbitrum, optimism, unichain, polygon), so
+// `_getMappedChainId` reverts with `ZeroValue()` and every proof validation reverts.
+// `setChainMap` is `onlyOwner` (owner 0x712E90032d8f44bE276A903E1769d64dD1C7F45a).
+// This map is what `getOracle()` feeds into `inputOracle` for freshly created orders, i.e.
+// there is no separate activation switch — do not merge until the chain maps are populated.
+// The superseded oracle 0x0000003E06000007A224AeE90052fA6bb46d43C9 is functional today.
 export const POLYMER_ORACLE = {
-	ethereum: "0x0000003E06000007A224AeE90052fA6bb46d43C9",
-	arbitrum: "0x0000003E06000007A224AeE90052fA6bb46d43C9",
-	base: "0x0000003E06000007A224AeE90052fA6bb46d43C9",
+	ethereum: "0x008C3800F3Ad9b3B662d002E90Cc00000000eE17",
+	arbitrum: "0x008C3800F3Ad9b3B662d002E90Cc00000000eE17",
+	base: "0x008C3800F3Ad9b3B662d002E90Cc00000000eE17",
+	// TODO: MegaETH is not part of the current mainnet deployment set; address below is stale.
 	megaeth: "0x0000003E06000007A224AeE90052fA6bb46d43C9",
-	katana: "0x0000003E06000007A224AeE90052fA6bb46d43C9",
-	polygon: "0x0000003E06000007A224AeE90052fA6bb46d43C9",
-	bsc: "0x0000003E06000007A224AeE90052fA6bb46d43C9",
-	pharos: "0x0000003E06000007A224AeE90052fA6bb46d43C9",
+	katana: "0x008C3800F3Ad9b3B662d002E90Cc00000000eE17",
+	polygon: "0x008C3800F3Ad9b3B662d002E90Cc00000000eE17",
+	bsc: "0x008C3800F3Ad9b3B662d002E90Cc00000000eE17",
+	pharos: "0x008C3800F3Ad9b3B662d002E90Cc00000000eE17",
 	// testnet
 	sepolia: "0xC401b53377b8A71A7cEB820e6a4dC53832343a90",
 	baseSepolia: "0xC401b53377b8A71A7cEB820e6a4dC53832343a90",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -40,20 +40,29 @@ export const WORMHOLE_ORACLE = {
 	arbitrum: "0x0000000000000000000000000000000000000000",
 	base: "0x0000000000000000000000000000000000000000"
 } as const;
-// ⚠️ NOT PRODUCTION-READY: the mainnet bucket below points at `PolymerOracleMapped`
-// (0x008C3800F3Ad9b3B662d002E90Cc00000000eE17), which is deployed but not yet operational.
-// It inherits `ChainMap`, and `chainIdMap`/`reverseChainIdMap` are still empty (all zero) on
-// every mainnet chain checked (ethereum, base, arbitrum, optimism, unichain, polygon), so
-// `_getMappedChainId` reverts with `ZeroValue()` and every proof validation reverts.
-// `setChainMap` is `onlyOwner` (owner 0x712E90032d8f44bE276A903E1769d64dD1C7F45a).
-// This map is what `getOracle()` feeds into `inputOracle` for freshly created orders, i.e.
-// there is no separate activation switch — do not merge until the chain maps are populated.
-// The superseded oracle 0x0000003E06000007A224AeE90052fA6bb46d43C9 is functional today.
+// The mainnet bucket points at `PolymerOracleMapped`
+// (0x008C3800F3Ad9b3B662d002E90Cc00000000eE17). It inherits `ChainMap`: `_getMappedChainId`
+// reverts with `ZeroValue()` for any protocol chain id that has not been mapped, so a route
+// only works if the *input* chain's oracle has the *output* chain mapped. `setChainMap` is
+// `onlyOwner` (0x712E90032d8f44bE276A903E1769d64dD1C7F45a) and write-once per chain.
+//
+// The maps are being populated chain by chain and were incomplete when last measured
+// (2026-07-31 ~09:40 UTC, mappings are identity: protocolId == chainId):
+//   ethereum, arbitrum, bsc  all of the chains below mapped
+//   katana                   only ethereum, polygon, pharos
+//   base                     only ethereum
+//   polygon, pharos          nothing mapped
+// Same-chain swaps are unaffected: `intent.ts` uses COIN_FILLER as `inputOracle` when
+// `isSameChain()`, bypassing the oracle entirely.
+//
+// Re-measure before widening `coinList`/`chainList` — see the note above `chainList`.
 export const POLYMER_ORACLE = {
 	ethereum: "0x008C3800F3Ad9b3B662d002E90Cc00000000eE17",
 	arbitrum: "0x008C3800F3Ad9b3B662d002E90Cc00000000eE17",
 	base: "0x008C3800F3Ad9b3B662d002E90Cc00000000eE17",
-	// TODO: MegaETH is not part of the current mainnet deployment set; address below is stale.
+	// MegaETH (4326) is not part of the mainnet deployment set: there is no code at the settler,
+	// filler or oracle addresses there. Kept only to satisfy the `chain` key type; the chain is
+	// disabled in `chainList`/`coinList` below, so this value is never read.
 	megaeth: "0x0000003E06000007A224AeE90052fA6bb46d43C9",
 	katana: "0x008C3800F3Ad9b3B662d002E90Cc00000000eE17",
 	polygon: "0x008C3800F3Ad9b3B662d002E90Cc00000000eE17",
@@ -87,9 +96,12 @@ export const chainMap = {
 } as const;
 export const chains = Object.keys(chainMap) as (keyof typeof chainMap)[];
 export type chain = (typeof chains)[number];
+// Output-chain selector. MegaETH is omitted because `OutputSettlerSimple` is not deployed there,
+// so it cannot settle a fill. Every other chain here is a valid destination from the origin chains
+// `coinList` offers — see the chain-map notes above `POLYMER_ORACLE`.
 export const chainList = (mainnet: boolean) => {
 	if (mainnet == true) {
-		return ["ethereum", "base", "arbitrum", "megaeth", "katana", "polygon", "bsc", "pharos"];
+		return ["ethereum", "base", "arbitrum", "katana", "polygon", "bsc", "pharos"];
 	} else return ["sepolia", "optimismSepolia", "baseSepolia", "arbitrumSepolia"];
 };
 
@@ -159,18 +171,8 @@ export const coinList = (mainnet: boolean) => {
 				chain: "arbitrum",
 				decimals: 18
 			},
-			{
-				address: `0x4200000000000000000000000000000000000006`,
-				name: "weth",
-				chain: "megaeth",
-				decimals: 18
-			},
-			{
-				address: `0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7`,
-				name: "usdm",
-				chain: "megaeth",
-				decimals: 18
-			},
+			// MegaETH tokens removed: no InputSettlerEscrowLIFI / OutputSettlerSimple deployed on
+			// chain 4326, so neither leg of an intent can execute there.
 			{
 				address: `0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d`,
 				name: "usdc-b",

--- a/tests/e2e/issuance.spec.ts
+++ b/tests/e2e/issuance.spec.ts
@@ -38,7 +38,7 @@ test.beforeEach(async ({ page }) => {
 							}
 						]
 					},
-					inputSettler: "0x000025c3226C00B2Cdc200005a1600509f4e00C0",
+					inputSettler: "0x00fC00edbe7C003b006f870068c548940000223e",
 					sponsorSignature: null,
 					allocatorSignature: null
 				}

--- a/tests/unit/intentList.test.ts
+++ b/tests/unit/intentList.test.ts
@@ -11,14 +11,14 @@ import {
 
 const baseRow: BaseIntentRow = {
 	orderContainer: {
-		inputSettler: "0x000025c3226C00B2Cdc200005a1600509f4e00C0",
+		inputSettler: "0x00fC00edbe7C003b006f870068c548940000223e",
 		order: {
 			user: "0x1111111111111111111111111111111111111111",
 			nonce: 1n,
 			originChainId: 8453n,
 			expires: Math.floor(Date.now() / 1000) + 3600,
 			fillDeadline: Math.floor(Date.now() / 1000) + 3600,
-			inputOracle: "0x0000003E06000007A224AeE90052fA6bb46d43C9",
+			inputOracle: "0x008C3800F3Ad9b3B662d002E90Cc00000000eE17",
 			inputs: [[1n, 1n]],
 			outputs: [
 				{

--- a/tests/unit/orderServer.test.ts
+++ b/tests/unit/orderServer.test.ts
@@ -28,7 +28,7 @@ describe("parseOrderStatusPayload", () => {
 						}
 					]
 				},
-				inputSettler: "0x000025c3226C00B2Cdc200005a1600509f4e00C0",
+				inputSettler: "0x00fC00edbe7C003b006f870068c548940000223e",
 				sponsorSignature: null,
 				allocatorSignature: "0x1234"
 			}
@@ -36,7 +36,7 @@ describe("parseOrderStatusPayload", () => {
 
 		const parsed = parseOrderStatusPayload(payload);
 
-		expect(parsed.inputSettler).toBe("0x000025c3226C00B2Cdc200005a1600509f4e00C0");
+		expect(parsed.inputSettler).toBe("0x00fC00edbe7C003b006f870068c548940000223e");
 		expect(parsed.order.nonce).toBe(123n);
 		expect("originChainId" in parsed.order && parsed.order.originChainId).toBe(8453n);
 		expect(parsed.sponsorSignature).toEqual({ type: "None", payload: "0x" });
@@ -68,7 +68,7 @@ describe("parseOrderStatusPayload", () => {
 						}
 					]
 				},
-				inputSettler: "0x000025c3226C00B2Cdc200005a1600509f4e00C0",
+				inputSettler: "0x00fC00edbe7C003b006f870068c548940000223e",
 				sponsorSignature: null,
 				allocatorSignature: "0x1234",
 				meta: { submitTime }
@@ -104,7 +104,7 @@ describe("parseOrderStatusPayload", () => {
 						}
 					]
 				},
-				inputSettler: "0x000025c3226C00B2Cdc200005a1600509f4e00C0",
+				inputSettler: "0x00fC00edbe7C003b006f870068c548940000223e",
 				sponsorSignature: null,
 				allocatorSignature: "0x1234",
 				meta: { submitTime: seconds * 1000 }


### PR DESCRIPTION
## ⚠️ DO NOT MERGE YET — `encodeMandateOutput` does not match the new settlers

`MandateOutputEncodingLib` now prefixes every serialised `FillDescription` with a 4-byte domain
magic, `FILL_MAGIC = bytes4(keccak256("OIF.Fill")) = 0xd1252dff`
(`src/libs/MandateOutputEncodingLib.sol:57`, dispatched at `OutputSettlerBase.sol:350`), and adds a
second payload type `NotFilledDescription` (`0x830c1e1c`). The client-side encoder in `intent.ts`
(`src/output.ts:35`) still emits the old unprefixed layout, so `keccak256(encodeMandateOutput(...))`
can never equal the payload hash the oracles store. `isProven` returns **false with no error**.

This repo consumes exactly that path at `src/lib/libraries/flowProgress.ts:150` and
`src/lib/components/ReceiveMessage.svelte:83`, so fill-proof progress and the solver validation path
would silently report "not proven" for fills that did happen. Fixing it requires a change in
`intent.ts`, not here. Order ids are unaffected — `getOutputHash` uses the old `MandateOutput`
preimage, which upstream pins in `MandateOutputHash.equiv.t.sol`.

## Correction: the oracle chain maps are being populated, not empty

An earlier revision of this PR body claimed `chainIdMap` / `reverseChainIdMap` were empty on every
mainnet chain and that the new oracle therefore never works. **That was measured correctly at the
time but is now wrong** — the owner (`0x712E90032d8f44bE276A903E1769d64dD1C7F45a`) is populating the
maps chain by chain while this PR was open. On base, `ChainMapConfigured` events landed at blocks
49348926–49348928.

Measured state at 2026-07-31 ~09:40 UTC, from `chainIdMap` reads plus `ChainMapConfigured` events
(mappings are identity, `protocolId == chainId`):

| Input chain | Output chains mapped (of those this app offers) |
|---|---|
| ethereum, arbitrum, bsc | all of them |
| katana | ethereum, polygon, pharos only |
| base | ethereum only |
| polygon, pharos | none |

The constraint is directional: a route works only if the **input** chain's oracle has the **output**
chain mapped. Same-chain swaps are unaffected — `intent.ts:227` uses `COIN_FILLER` as `inputOracle`
when `isSameChain()`, bypassing the oracle. Re-measure before merging; this table will have moved.

`POLYMER_ORACLE` is still read directly by `getOracle()` into `inputOracle`
(`src/lib/libraries/intent.ts:227,247`) and by `orderLib.ts:123,135`, so there remains no separate
activation switch — the constant *is* the activation.

## MegaETH disabled

MegaETH (4326) is not in the mainnet deployment set: `eth_getCode` is empty at
`InputSettlerEscrowLIFI`, `OutputSettlerSimple` **and** `PolymerOracleMapped`. Neither leg of an
intent can execute there, under any future chain-map state. Removed from `chainList` (output
selector) and its two tokens dropped from `coinList` so it cannot be chosen as an origin either.

The remaining partially-mapped chains (base, katana, polygon, pharos) are **not** gated in this PR.
Doing that correctly needs route-level filtering — the origin chain comes from `coinList` and the
destination from `chainList`, so a flat chain list cannot express "base can only send to ethereum".
Left for a decision once the map rollout settles.

Secondary consequence, unchanged from the original body: orders already in flight carrying the old
oracle/settler addresses will be treated as unrecognised by `orderLib`'s validation and by
`intentTypeFromSettler`. Worth a migration thought before shipping.

## What changed

CREATE2 deployments, so each address is identical on every EVM chain.

| Constant | Old | New |
|---|---|---|
| `INPUT_SETTLER_ESCROW_LIFI` | `0x000025c3226C00B2Cdc200005a1600509f4e00C0` | `0x00fC00edbe7C003b006f870068c548940000223e` |
| `COIN_FILLER` (`OutputSettlerSimple`) | `0x0000000000eC36B683C2E6AC89e9A75989C22a2e` | `0x75220B7600c300005038432a0000f308e0000068` |
| `POLYMER_ORACLE` mainnet bucket | `0x0000003E06000007A224AeE90052fA6bb46d43C9` | `0x008C3800F3Ad9b3B662d002E90Cc00000000eE17` |

Files:

- `src/lib/config.ts` — the three constants, plus a `⚠️ NOT PRODUCTION-READY` comment above
  `POLYMER_ORACLE` recording the empty-chain-map finding.
- `tests/unit/intentList.test.ts`, `tests/unit/orderServer.test.ts`, `tests/e2e/issuance.spec.ts` —
  fixtures that asserted on the old escrow settler / old oracle.
- `.claude/skills/add-chain/SKILL.md` — the infra-constants reference table and the codehash
  compare loop, plus a note that `PolymerOracleMapped` needs its `chainIdMap` populated per chain.

## Deliberately NOT changed

- `COMPACT` `0x00000000000000171ede64904551eeDF3C6C9788` — unchanged upstream.
- `INPUT_SETTLER_COMPACT_LIFI` `0x0000000000cd5f7fDEc90a03a31F79E5Fbc6A9Cf` — the compact input
  settler is an opt-in deploy path and is not part of this rollout.
- `MULTICHAIN_INPUT_SETTLER_ESCROW` / `MULTICHAIN_INPUT_SETTLER_COMPACT` — no new-generation
  addresses were supplied for these; they still point at the previous generation. **Needs a human
  decision.**
- Testnet Polymer bucket `0xC401b53377b8A71A7cEB820e6a4dC53832343a90` — mainnet-only rollout.
  (Note: this differs from the contracts repo's testnet oracle
  `0x00d5b500ECa100F7cdeDC800eC631Aca00BaAC00`, so the testnet bucket here looks stale too.
  Out of scope, flagging it.)
- `POLYMER_ORACLE.megaeth` — MegaETH is **not** in the new deployment set (absent from
  `script/polymer.json` in the contracts repo). Left at the old address with a `TODO`.
  **Needs a human decision:** repoint, or drop MegaETH from the mainnet chain list.

## Chains

Deployed set for the new generation: 1, 8453, 42161, 10, 130, 56, 137, 43114, 100, 57073, 747474,
143, 9745, 1672, 4663, 1776. This repo's mainnet chain list is a subset (ethereum, base, arbitrum,
megaeth, katana, polygon, bsc, pharos) — every entry except MegaETH is covered. `optimism` is not
in this branch's `chainMap` at all, so nothing to do here.

## ABI compatibility

I diffed the checked-in ABIs against freshly built artifacts from the contracts repo at
`7e32479 "Simplify and harden settlers: native ETH inputs, direct-hash encoding, Polymer Solana proofs"`.

- `src/lib/abi/outputsettler.ts` and `src/lib/abi/polymeroracle.ts` — **strict subsets** of the new
  ABIs. No signature changed, nothing removed. Safe.
- `src/lib/abi/escrow.ts` — selectors all still match, but `open`, `openFor` and `purchaseOrder`
  went `nonpayable → payable` (that is the native-ETH-input feature) and the error
  `UnexpectedCaller(bytes32)` was dropped. ERC-20 flows are unaffected; **native-ETH inputs cannot
  be used until this ABI is refreshed**. New surface not represented locally: `refundOnNonFill`,
  the governance-fee getters/setters, `Ownable`, and errors `FilledTooLate`,
  `InvalidNativeValue`, `NativeTokenNotSupported`, `OutputIndexOutOfBounds`.
- Not covered by an address bump: `MandateOutputEncodingLib` changed the **FillDescription
  encoding**. It now leads with a 4-byte domain magic `FILL_MAGIC = bytes4(keccak256("OIF.Fill"))
  = 0xd1252dff` (and a new `NotFilledDescription` with `0x830c1e1c`). This repo computes
  `keccak256(encodeMandateOutput(...))` and passes it to `isProven`
  (`src/lib/libraries/flowProgress.ts`, `src/lib/screens/ReceiveMessage.svelte`), via
  `@lifi/intent`'s `encodeMandateOutput`, which still emits the **old, unprefixed** layout. Against
  the new contracts those hashes will never match, so fill-proof progress and the solver's
  validation path silently report "not proven". This needs a fix in `intent.ts`
  (`src/output.ts`) plus a released version bump here. The `MandateOutput` identity hash
  (`getOutputHash`) is unchanged — the upstream `MandateOutputHash.equiv.t.sol` pins the old
  preimage — so order ids are unaffected.

## Verification

Baseline is `origin/main`; results are identical before and after my edits.

- `bun run test:unit` — 33 pass, 0 fail (both before and after).
- `bun run check` (svelte-check) — 0 errors, 0 warnings.
- `bun run test:e2e` (playwright) — 3 passed. These fully mock the quote/status API and never
  touch a live RPC, so **no test in this repo exercises oracle proof validation on-chain**; the
  empty-chain-map problem is invisible to CI.
- `bun run lint` — fails, **pre-existing on `origin/main`**: prettier flags `.vscode/settings.json`
  and `README.md`. Neither is touched by this PR.
  ```
  Checking formatting...
  [warn] .vscode/settings.json
  [warn] README.md
  [warn] Code style issues found in 2 files. Run Prettier with --write to fix.
  ```

## Open questions

1. When will the `PolymerOracleMapped` chain maps be populated? This PR is blocked on that.
2. `MULTICHAIN_INPUT_SETTLER_ESCROW` / `MULTICHAIN_INPUT_SETTLER_COMPACT`: new-generation addresses?
3. MegaETH: repoint or remove?
4. Testnet Polymer bucket looks stale versus the contracts repo. Separate PR?
5. Who owns the `FILL_MAGIC` fix in `@lifi/intent`, and should this PR wait on that release?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

