### PR TITLE
fix(polymer): allow poll-by-polymerIndex without source-log fields

### DIFF
--- a/src/routes/polymer/+server.ts
+++ b/src/routes/polymer/+server.ts
@@ -18,9 +18,6 @@ function getPolymerKey(mainnet: boolean) {
   return mainnet ? PRIVATE_POLYMER_MAINNET_ZONE_API_KEY : PRIVATE_POLYMER_TESTNET_ZONE_API_KEY;
 }
 
-// `isSafeInteger`, not `isInteger`: JSON numbers past 2^53 are already rounded by the time we
-// see them, so a caller could request a proof for coordinates that differ from the ones they
-// actually sent.
 function isPositiveInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
 }
@@ -33,8 +30,6 @@ export const POST: RequestHandler = async ({ request }) => {
     return json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  // `JSON.parse("null")` succeeds, and destructuring it throws outside the try above — which
-  // surfaced as a framework 500 rather than a controlled 400.
   if (typeof body !== "object" || body === null || Array.isArray(body)) {
     return json({ error: "Body must be a JSON object" }, { status: 400 });
   }
@@ -47,16 +42,8 @@ export const POST: RequestHandler = async ({ request }) => {
     mainnet?: boolean;
   };
 
-  // A caller that already holds a `polymerIndex` is polling an existing job, not asking us to
-  // open a new one — the source-log coordinates are only needed on the request-a-proof path.
-  // Validating them unconditionally made the documented poll-by-index flow unreachable: it
-  // answered 400 in ~1ms without ever calling Polymer, and clients retrying that read it as a
-  // stalled settlement.
   const isPolling = polymerIndex !== undefined && polymerIndex !== null;
 
-  // Truthiness would let `"false"`, `1` or `{}` select mainnet and `0` or `""` select testnet,
-  // silently spending the wrong environment's key — or polling a numeric job id in the wrong
-  // network's namespace, where it may resolve to an unrelated job.
   if (mainnet !== undefined && mainnet !== null && typeof mainnet !== "boolean") {
     return json({ error: "Invalid 'mainnet'" }, { status: 400 });
   }
@@ -73,7 +60,6 @@ export const POST: RequestHandler = async ({ request }) => {
     if (!isPositiveInteger(srcBlockNumber)) {
       return json({ error: "Missing or invalid 'srcBlockNumber'" }, { status: 400 });
     }
-    // Not `isPositiveInteger`: a log index of 0 is legitimate. Same safe-integer bound though.
     if (
       typeof globalLogIndex !== "number" ||
       !Number.isSafeInteger(globalLogIndex) ||

--- a/src/routes/polymer/+server.ts
+++ b/src/routes/polymer/+server.ts
@@ -18,8 +18,11 @@ function getPolymerKey(mainnet: boolean) {
   return mainnet ? PRIVATE_POLYMER_MAINNET_ZONE_API_KEY : PRIVATE_POLYMER_TESTNET_ZONE_API_KEY;
 }
 
+// `isSafeInteger`, not `isInteger`: JSON numbers past 2^53 are already rounded by the time we
+// see them, so a caller could request a proof for coordinates that differ from the ones they
+// actually sent.
 function isPositiveInteger(value: unknown): value is number {
-  return typeof value === "number" && Number.isInteger(value) && value > 0;
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
 }
 
 export const POST: RequestHandler = async ({ request }) => {
@@ -28,6 +31,12 @@ export const POST: RequestHandler = async ({ request }) => {
     body = await request.json();
   } catch {
     return json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  // `JSON.parse("null")` succeeds, and destructuring it throws outside the try above — which
+  // surfaced as a framework 500 rather than a controlled 400.
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return json({ error: "Body must be a JSON object" }, { status: 400 });
   }
 
   const { srcChainId, srcBlockNumber, globalLogIndex, polymerIndex, mainnet } = body as {
@@ -44,6 +53,14 @@ export const POST: RequestHandler = async ({ request }) => {
   // answered 400 in ~1ms without ever calling Polymer, and clients retrying that read it as a
   // stalled settlement.
   const isPolling = polymerIndex !== undefined && polymerIndex !== null;
+
+  // Truthiness would let `"false"`, `1` or `{}` select mainnet and `0` or `""` select testnet,
+  // silently spending the wrong environment's key — or polling a numeric job id in the wrong
+  // network's namespace, where it may resolve to an unrelated job.
+  if (mainnet !== undefined && mainnet !== null && typeof mainnet !== "boolean") {
+    return json({ error: "Invalid 'mainnet'" }, { status: 400 });
+  }
+  const useMainnet = mainnet ?? true;
 
   if (isPolling) {
     if (!isPositiveInteger(polymerIndex)) {
@@ -66,8 +83,8 @@ export const POST: RequestHandler = async ({ request }) => {
   }
 
   try {
-    const POLYMER_URL = getPolymerUrl(mainnet ?? true);
-    const PRIVATE_POLYMER_ZONE_API_KEY = getPolymerKey(mainnet ?? true);
+    const POLYMER_URL = getPolymerUrl(useMainnet);
+    const PRIVATE_POLYMER_ZONE_API_KEY = getPolymerKey(useMainnet);
 
     let polymerRequestIndex = polymerIndex;
     if (!isPolling) {

--- a/src/routes/polymer/+server.ts
+++ b/src/routes/polymer/+server.ts
@@ -38,18 +38,31 @@ export const POST: RequestHandler = async ({ request }) => {
     mainnet?: boolean;
   };
 
-  if (!isPositiveInteger(srcChainId)) {
-    return json({ error: "Missing or invalid 'srcChainId'" }, { status: 400 });
-  }
-  if (!isPositiveInteger(srcBlockNumber)) {
-    return json({ error: "Missing or invalid 'srcBlockNumber'" }, { status: 400 });
-  }
-  if (
-    typeof globalLogIndex !== "number" ||
-    !Number.isInteger(globalLogIndex) ||
-    globalLogIndex < 0
-  ) {
-    return json({ error: "Missing or invalid 'globalLogIndex'" }, { status: 400 });
+  // A caller that already holds a `polymerIndex` is polling an existing job, not asking us to
+  // open a new one — the source-log coordinates are only needed on the request-a-proof path.
+  // Validating them unconditionally made the documented poll-by-index flow unreachable: it
+  // answered 400 in ~1ms without ever calling Polymer, and clients retrying that read it as a
+  // stalled settlement.
+  const isPolling = polymerIndex !== undefined && polymerIndex !== null;
+
+  if (isPolling) {
+    if (!isPositiveInteger(polymerIndex)) {
+      return json({ error: "Invalid 'polymerIndex'" }, { status: 400 });
+    }
+  } else {
+    if (!isPositiveInteger(srcChainId)) {
+      return json({ error: "Missing or invalid 'srcChainId'" }, { status: 400 });
+    }
+    if (!isPositiveInteger(srcBlockNumber)) {
+      return json({ error: "Missing or invalid 'srcBlockNumber'" }, { status: 400 });
+    }
+    if (
+      typeof globalLogIndex !== "number" ||
+      !Number.isInteger(globalLogIndex) ||
+      globalLogIndex < 0
+    ) {
+      return json({ error: "Missing or invalid 'globalLogIndex'" }, { status: 400 });
+    }
   }
 
   try {
@@ -57,7 +70,7 @@ export const POST: RequestHandler = async ({ request }) => {
     const PRIVATE_POLYMER_ZONE_API_KEY = getPolymerKey(mainnet ?? true);
 
     let polymerRequestIndex = polymerIndex;
-    if (!polymerRequestIndex) {
+    if (!isPolling) {
       // V2-199 (#53) + #63: confirm the referenced log really is one of the allowlisted
       // output-settler events before spending a Polymer proof request on it.
       const verification = await verifyProvableLog(
@@ -66,6 +79,11 @@ export const POST: RequestHandler = async ({ request }) => {
         Number(globalLogIndex)
       );
       if (verification === "mismatch") {
+        console.warn("polymer proof request rejected: log is not an allowlisted event", {
+          srcChainId,
+          srcBlockNumber,
+          globalLogIndex
+        });
         return json(
           { error: "log is not an OutputFilled or OutputNotFilled event" },
           { status: 400 }
@@ -148,7 +166,14 @@ export const POST: RequestHandler = async ({ request }) => {
       status: dat.result.status
     });
   } catch (error) {
-    console.error("polymer proof request failed", { srcChainId });
+    console.error("polymer proof request failed", {
+      srcChainId,
+      srcBlockNumber,
+      globalLogIndex,
+      polymerIndex: polymerIndex ?? null,
+      polling: isPolling,
+      error: error instanceof Error ? error.message : String(error)
+    });
     return json({ error: "Polymer proof request failed" }, { status: 502 });
   }
 };

--- a/src/routes/polymer/+server.ts
+++ b/src/routes/polymer/+server.ts
@@ -73,9 +73,10 @@ export const POST: RequestHandler = async ({ request }) => {
     if (!isPositiveInteger(srcBlockNumber)) {
       return json({ error: "Missing or invalid 'srcBlockNumber'" }, { status: 400 });
     }
+    // Not `isPositiveInteger`: a log index of 0 is legitimate. Same safe-integer bound though.
     if (
       typeof globalLogIndex !== "number" ||
-      !Number.isInteger(globalLogIndex) ||
+      !Number.isSafeInteger(globalLogIndex) ||
       globalLogIndex < 0
     ) {
       return json({ error: "Missing or invalid 'globalLogIndex'" }, { status: 400 });

--- a/tests/unit/polymerRoute.test.ts
+++ b/tests/unit/polymerRoute.test.ts
@@ -1,0 +1,276 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { EXPECTED_TOPIC0 } from "../../src/lib/libraries/provableEvents";
+
+// `$env/static/private` is a Vite virtual module with no file behind it, so the real one can
+// never resolve under `bun test`. Stub it before importing the module under test.
+mock.module("$env/static/private", () => ({
+  PRIVATE_POLYMER_MAINNET_ZONE_API_KEY: "mainnet-key",
+  PRIVATE_POLYMER_TESTNET_ZONE_API_KEY: "testnet-key",
+  PRIVATE_ROUTEMESH_API_KEY: "routemesh-key"
+}));
+
+type PolymerCall = { url: string; method: string; params: unknown[]; auth: string };
+
+const polymerCalls: PolymerCall[] = [];
+let verifyCalls = 0;
+let verifyResult: "match" | "mismatch" | "unknown" = "match";
+let queryProofResult: unknown = { jobID: 1, createdAt: 0, updatedAt: 0, status: "initialized" };
+
+// Drive the real `verifyProvableLog` through its RPC instead of `mock.module`-ing it: bun runs
+// every test file in one process and module mocks are global, so stubbing that path clobbered
+// provableLogVerify.test.ts's own subject. Intercepting fetch also means these tests exercise
+// the actual gate rather than a stand-in for it.
+const realFetch = global.fetch;
+global.fetch = (async (_url: string, init?: RequestInit) => {
+  const call = JSON.parse(String(init?.body)) as { method: string };
+  if (call.method !== "eth_getLogs") {
+    return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: [] }), { status: 200 });
+  }
+  verifyCalls += 1;
+  if (verifyResult === "unknown") throw new Error("rpc down");
+  const result =
+    verifyResult === "match"
+      ? [
+          {
+            address: "0x75220b7600c300005038432a0000f308e0000068",
+            topics: [EXPECTED_TOPIC0.OutputFilled, `0x${"11".repeat(32)}`],
+            data: "0x",
+            blockNumber: "0x64",
+            blockHash: `0x${"22".repeat(32)}`,
+            transactionHash: `0x${"33".repeat(32)}`,
+            transactionIndex: "0x0",
+            logIndex: "0x4",
+            removed: false
+          },
+          // logIndex 0 too, so the "globalLogIndex may be 0" case has something to match.
+          {
+            address: "0x75220b7600c300005038432a0000f308e0000068",
+            topics: [EXPECTED_TOPIC0.OutputNotFilled, `0x${"11".repeat(32)}`],
+            data: "0x",
+            blockNumber: "0x64",
+            blockHash: `0x${"22".repeat(32)}`,
+            transactionHash: `0x${"33".repeat(32)}`,
+            transactionIndex: "0x0",
+            logIndex: "0x0",
+            removed: false
+          }
+        ]
+      : [];
+  return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }), {
+    status: 200,
+    headers: { "content-type": "application/json" }
+  });
+}) as unknown as typeof fetch;
+
+afterAll(() => {
+  global.fetch = realFetch;
+});
+
+// No other test imports axios today, so this module mock has no one to leak onto — but it is
+// global for the whole run, so anything added later that uses axios must not rely on the real one.
+mock.module("axios", () => ({
+  default: {
+    post: async (url: string, payload: { method: string; params: unknown[] }, config: never) => {
+      const headers = (config as unknown as { headers: Record<string, string> }).headers;
+      polymerCalls.push({
+        url,
+        method: payload.method,
+        params: payload.params,
+        auth: headers.Authorization
+      });
+      if (payload.method === "polymer_requestProof") {
+        return { data: { jsonrpc: "2.0", id: 1, result: 7777 } };
+      }
+      return { data: { jsonrpc: "2.0", id: 1, result: queryProofResult } };
+    }
+  }
+}));
+
+const { POST } = await import("../../src/routes/polymer/+server");
+
+function post(body: unknown) {
+  const request = new Request("https://lintent.org/polymer", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+  // The handler only touches `request`; the rest of the SvelteKit event is irrelevant here.
+  return POST({ request } as unknown as Parameters<typeof POST>[0]);
+}
+
+const methods = () => polymerCalls.map((c) => c.method);
+
+beforeEach(() => {
+  polymerCalls.length = 0;
+  verifyCalls = 0;
+  verifyResult = "match";
+  queryProofResult = { jobID: 1, createdAt: 0, updatedAt: 0, status: "initialized" };
+});
+
+describe("POST /polymer — poll by polymerIndex", () => {
+  // Regression: the source-log fields used to be validated unconditionally, so a caller
+  // polling an existing job got 400 in ~1ms and never reached Polymer at all.
+  it("accepts a bare polymerIndex with no source-log fields", async () => {
+    const res = await post({ polymerIndex: 6931827, mainnet: true });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ polymerIndex: 6931827, status: "initialized" });
+  });
+
+  it("queries the existing job instead of opening a new one", async () => {
+    await post({ polymerIndex: 6931827 });
+
+    expect(methods()).toEqual(["polymer_queryProof"]);
+    expect(polymerCalls[0].params).toEqual([6931827]);
+    // No proof request spent, and no RPC round-trip to re-verify the log.
+    expect(verifyCalls).toBe(0);
+  });
+
+  it("still polls when source-log fields are also supplied", async () => {
+    await post({ srcChainId: 8453, srcBlockNumber: 23011456, globalLogIndex: 4, polymerIndex: 42 });
+
+    expect(methods()).toEqual(["polymer_queryProof"]);
+    expect(verifyCalls).toBe(0);
+  });
+
+  it("hex-encodes a completed proof", async () => {
+    queryProofResult = { jobID: 1, createdAt: 0, updatedAt: 0, status: "complete", proof: "q80=" };
+
+    const res = await post({ polymerIndex: 42 });
+
+    expect(await res.json()).toMatchObject({ proof: "abcd", status: "complete" });
+  });
+
+  it.each([0, -1, 1.5, "42", null])(
+    "rejects a non-positive-integer polymerIndex: %p",
+    async (v) => {
+      const res = await post({ polymerIndex: v, srcChainId: 8453 });
+
+      // `null` means "absent" and falls through to the request path, which then needs the
+      // source-log fields; every other bad value is an outright invalid index.
+      expect(res.status).toBe(400);
+      expect(polymerCalls).toHaveLength(0);
+    }
+  );
+});
+
+describe("POST /polymer — request a proof", () => {
+  it("verifies the log, requests a proof, then queries it", async () => {
+    const res = await post({ srcChainId: 8453, srcBlockNumber: 23011456, globalLogIndex: 4 });
+
+    expect(res.status).toBe(200);
+    expect(verifyCalls).toBe(1);
+    expect(methods()).toEqual(["polymer_requestProof", "polymer_queryProof"]);
+    expect(polymerCalls[0].params).toEqual([
+      { srcChainId: 8453, srcBlockNumber: 23011456, globalLogIndex: 4 }
+    ]);
+    expect(await res.json()).toMatchObject({ polymerIndex: 7777 });
+  });
+
+  it("proceeds when verification is inconclusive", async () => {
+    verifyResult = "unknown";
+
+    const res = await post({ srcChainId: 8453, srcBlockNumber: 23011456, globalLogIndex: 4 });
+
+    expect(res.status).toBe(200);
+    expect(methods()).toEqual(["polymer_requestProof", "polymer_queryProof"]);
+  });
+
+  it("spends no proof request when the log is not an allowlisted event", async () => {
+    verifyResult = "mismatch";
+
+    const res = await post({ srcChainId: 8453, srcBlockNumber: 23011456, globalLogIndex: 4 });
+
+    expect(res.status).toBe(400);
+    expect(polymerCalls).toHaveLength(0);
+  });
+
+  it.each([
+    ["srcChainId", { srcBlockNumber: 23011456, globalLogIndex: 4 }],
+    ["srcBlockNumber", { srcChainId: 8453, globalLogIndex: 4 }],
+    ["globalLogIndex", { srcChainId: 8453, srcBlockNumber: 23011456 }]
+  ])("rejects a request missing %s", async (_field, body) => {
+    const res = await post(body);
+
+    expect(res.status).toBe(400);
+    expect(verifyCalls).toBe(0);
+    expect(polymerCalls).toHaveLength(0);
+  });
+
+  it("accepts globalLogIndex 0", async () => {
+    const res = await post({ srcChainId: 8453, srcBlockNumber: 23011456, globalLogIndex: 0 });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects an unsafe-integer srcBlockNumber", async () => {
+    // Already rounded by JSON.parse, so the proof would be minted for different coordinates
+    // than the caller actually sent.
+    const res = await post({
+      srcChainId: 8453,
+      srcBlockNumber: Number.MAX_SAFE_INTEGER + 2,
+      globalLogIndex: 4
+    });
+
+    expect(res.status).toBe(400);
+    expect(polymerCalls).toHaveLength(0);
+  });
+
+  it.each([null, "[]", '"str"', "42"])("rejects a non-object JSON body: %p", async (raw) => {
+    const request = new Request("https://lintent.org/polymer", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: raw === null ? "null" : raw
+    });
+    const res = await POST({ request } as unknown as Parameters<typeof POST>[0]);
+
+    // `null` used to destructure-throw into a framework 500 instead of a controlled 400.
+    expect(res.status).toBe(400);
+    expect(polymerCalls).toHaveLength(0);
+  });
+
+  it("rejects a malformed JSON body", async () => {
+    const request = new Request("https://lintent.org/polymer", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not json"
+    });
+    const res = await POST({ request } as unknown as Parameters<typeof POST>[0]);
+
+    expect(res.status).toBe(400);
+    expect(polymerCalls).toHaveLength(0);
+  });
+});
+
+describe("POST /polymer — network selection", () => {
+  it("defaults to mainnet", async () => {
+    await post({ polymerIndex: 42 });
+
+    expect(polymerCalls[0].url).toBe("https://api.polymer.zone/v1/");
+    expect(polymerCalls[0].auth).toBe("Bearer mainnet-key");
+  });
+
+  it("uses the testnet endpoint and key when mainnet is false", async () => {
+    await post({ polymerIndex: 42, mainnet: false });
+
+    expect(polymerCalls[0].url).toBe("https://api.testnet.polymer.zone/v1/");
+    expect(polymerCalls[0].auth).toBe("Bearer testnet-key");
+  });
+
+  // Wrapped in objects because bun's `it.each` spreads a bare array row into separate args,
+  // which would turn the `[]` case into "no argument at all".
+  it.each([
+    { label: '"false"', value: "false" },
+    { label: "1", value: 1 },
+    { label: "0", value: 0 },
+    { label: "{}", value: {} },
+    { label: "[]", value: [] }
+  ])("rejects a non-boolean mainnet: $label", async ({ value }) => {
+    // Under truthiness `"false"` and `1` would have selected mainnet and `0` testnet, spending
+    // the wrong environment's key.
+    const res = await post({ polymerIndex: 42, mainnet: value });
+
+    expect(res.status).toBe(400);
+    expect(polymerCalls).toHaveLength(0);
+  });
+});

--- a/tests/unit/polymerRoute.test.ts
+++ b/tests/unit/polymerRoute.test.ts
@@ -141,17 +141,29 @@ describe("POST /polymer — poll by polymerIndex", () => {
     expect(await res.json()).toMatchObject({ proof: "abcd", status: "complete" });
   });
 
-  it.each([0, -1, 1.5, "42", null])(
-    "rejects a non-positive-integer polymerIndex: %p",
+  it.each([0, -1, 1.5, "42", Number.MAX_SAFE_INTEGER + 2])(
+    "rejects a non-positive-safe-integer polymerIndex: %p",
     async (v) => {
       const res = await post({ polymerIndex: v, srcChainId: 8453 });
 
-      // `null` means "absent" and falls through to the request path, which then needs the
-      // source-log fields; every other bad value is an outright invalid index.
       expect(res.status).toBe(400);
       expect(polymerCalls).toHaveLength(0);
     }
   );
+
+  it("treats an explicit null polymerIndex as absent and creates a job", async () => {
+    // Serialisers routinely emit null for an unset optional field, so with full coordinates
+    // this means "no job yet" rather than "poll job null".
+    const res = await post({
+      polymerIndex: null,
+      srcChainId: 8453,
+      srcBlockNumber: 23011456,
+      globalLogIndex: 4
+    });
+
+    expect(res.status).toBe(200);
+    expect(methods()).toEqual(["polymer_requestProof", "polymer_queryProof"]);
+  });
 });
 
 describe("POST /polymer — request a proof", () => {
@@ -203,16 +215,26 @@ describe("POST /polymer — request a proof", () => {
     expect(res.status).toBe(200);
   });
 
-  it("rejects an unsafe-integer srcBlockNumber", async () => {
-    // Already rounded by JSON.parse, so the proof would be minted for different coordinates
-    // than the caller actually sent.
-    const res = await post({
-      srcChainId: 8453,
-      srcBlockNumber: Number.MAX_SAFE_INTEGER + 2,
-      globalLogIndex: 4
-    });
+  // Already rounded by JSON.parse, so the proof would be minted for coordinates other than the
+  // ones the caller actually sent. Every numeric field needs the bound, not just the block.
+  it.each([
+    [
+      "srcChainId",
+      { srcChainId: Number.MAX_SAFE_INTEGER + 2, srcBlockNumber: 23011456, globalLogIndex: 4 }
+    ],
+    [
+      "srcBlockNumber",
+      { srcChainId: 8453, srcBlockNumber: Number.MAX_SAFE_INTEGER + 2, globalLogIndex: 4 }
+    ],
+    [
+      "globalLogIndex",
+      { srcChainId: 8453, srcBlockNumber: 23011456, globalLogIndex: Number.MAX_SAFE_INTEGER + 2 }
+    ]
+  ])("rejects an unsafe-integer %s", async (_field, body) => {
+    const res = await post(body);
 
     expect(res.status).toBe(400);
+    expect(verifyCalls).toBe(0);
     expect(polymerCalls).toHaveLength(0);
   });
 


### PR DESCRIPTION
## Problem

`POST /polymer` validates `srcChainId`, `srcBlockNumber` and `globalLogIndex` **unconditionally**, but the handler only needs them on the request-a-proof path — when `polymerIndex` is supplied it skips `verifyProvableLog` + `polymer_requestProof` and goes straight to `polymer_queryProof`.

That made the poll-by-index flow unreachable. A caller polling with just `{"polymerIndex":N,"mainnet":true}` got a **400 in ~1ms**, with no outbound call to Polymer and no log line.

## Evidence

Cloudflare Workers Logs, `lintent-worker`, 2026-08-06 (one solver's client, `user-agent: node`, `14.32.133.68`):

| Body size | Status | Wall time |
|---|---|---|
| 39 bytes | **400** | 1ms |
| 78–105 bytes | 200 | 80–900ms |

39 bytes is exactly `{"polymerIndex":6931827,"mainnet":true}`. The 400s arrive on a fixed ~2.24s retry interval — a client loop hammering a request we reject instantly. At 16:44:36 the same operator sent a 39-byte body via `curl` (400, 1ms) then an 81-byte body 0.5s later (200, 336ms), bisecting it themselves.

This is the reported "Polymer timeouts" incident. Nothing was wrong on Polymer's side because **we never called Polymer**. It didn't reproduce for other solvers because the other clients in the logs re-send the full source fields on every poll instead of polling by index.

`src/lib/libraries/solver.ts:321` confirms the intended contract: the client caches `polymerIndex` and keeps sending the original coordinates alongside it, so a truthy index must mean "poll", never "create another paid job".

## Changes

**The fix**
- Gate the source-log checks behind the request-a-proof path
- Validate `polymerIndex` itself when polling
- Explicit `isPolling` flag — the old `if (!polymerRequestIndex)` treated index `0` as absent

**Hardening found while reviewing the same validation block**
- Reject unsafe integers on all three coordinates and on `polymerIndex`: JSON numbers past 2^53 are already rounded when we see them, so a proof could be minted for coordinates other than the ones sent
- Reject non-object JSON bodies: `JSON.parse("null")` succeeded and the destructure threw *outside* the try, surfacing as a framework 500
- Require `mainnet` to be a boolean: under truthiness `"false"` and `1` selected mainnet while `0` selected testnet, spending the wrong environment's key — and when polling, querying a numeric job id in the wrong network's namespace

**Logging** — the `mismatch` 400 and the 502 catch were near-silent, which is why this took a day to diagnose. Both now carry the coordinates and the index.

## Tests

`tests/unit/polymerRoute.test.ts` — 32 cases, the first coverage this route has had. The regression is pinned by asserting a bare `polymerIndex` makes exactly one `polymer_queryProof` call and spends no proof request. The `globalLogIndex` safe-integer case was verified RED on `isInteger` / GREEN on `isSafeInteger`.

Tests drive the real `verifyProvableLog` through an intercepted `fetch` rather than `mock.module`-ing it: bun runs every test file in one process and module mocks are global, so stubbing that path clobbered `provableLogVerify.test.ts`'s own subject.

Full suite: 126 pass, 0 fail. Typecheck and lint clean.

## Out of scope — pre-existing, worth separate issues

Surfaced by review, deliberately **not** fixed here:

1. **`verifyProvableLog` does not pin the emitting contract.** It filters `eth_getLogs` on topic0 across the whole block and never checks `log.address`. `provableEvents.ts` says the allowlist exists so the endpoint "must not become a general-purpose proof oracle for arbitrary logs" — but anyone can deploy a contract emitting an event with the same signature and have proofs minted on our key. This is the most significant of the three.
2. **No auth, rate limit or idempotency on proof creation.** Reposting valid coordinates opens a new paid Polymer job every time.
3. **`"unknown"` fails open by design.** An RPC blip removes the quota gate for every caller. Documented as intentional in `provableLogVerify.ts`; flagging it so the tradeoff is a live decision rather than an inherited one.

## Review

Cross-reviewed with Codex (independent blind pass + cross-critique). It found the three out-of-scope items above and the `globalLogIndex` gap in my own fix. It initially argued mixed `index + coordinates` payloads should be rejected as ambiguous and that `polymerIndex: null` should not route to create; it withdrew both after checking `solver.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for request bodies, network flags, and numeric values.
  * Added clearer handling for new proof requests versus proof polling.
  * Improved error reporting for verification and request failures.
  * Ensured network and API settings are selected consistently.

* **Tests**
  * Expanded coverage for proof creation, polling, verification outcomes, invalid input, encoding, and network selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->