### PR TITLE
feat: add Solana support in both directions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,10 @@ PUBLIC_ROUTEMESH_API_KEY=
 PRIVATE_POLYMER_MAINNET_ZONE_API_KEY=
 PRIVATE_POLYMER_TESTNET_ZONE_API_KEY=
 PRIVATE_ROUTEMESH_API_KEY=
+# Server-side Solana RPC used by /polymer to pre-verify a Solana source transaction.
+# One endpoint for the network this deployment serves; falls back to the public
+# api.mainnet-beta / api.devnet endpoints when unset.
+PRIVATE_SOLANA_RPC_URL=
+# Client-side Solana RPC endpoints, per network.
+PUBLIC_SOLANA_MAINNET_RPC_URL=
+PUBLIC_SOLANA_DEVNET_RPC_URL=

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@coinbase/wallet-sdk": "^4.3.6",
         "@coral-xyz/anchor": "^0.31",
         "@electric-sql/pglite": "^0.3.15",
-        "@lifi/intent": "file:../intent.ts",
+        "@lifi/intent": "0.4.0",
         "@metamask/sdk": "^0.34.0",
         "@safe-global/safe-apps-provider": "~0.18.6",
         "@safe-global/safe-apps-sdk": "^9.1.0",
@@ -250,7 +250,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.29", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="],
 
-    "@lifi/intent": ["@lifi/intent@file:../intent.ts", { "dependencies": { "@scure/base": "^2.2.0", "borsh": "^2.0.0", "ky": "^1.12.0", "viem": "~2.45.1" }, "devDependencies": { "@types/bun": "^1.3.8", "bun": "^1.3.5", "husky": "9.1.7", "lint-staged": "16.1.0", "prettier": "3.4.2", "rollup": "^4.61.0", "rollup-plugin-esbuild": "^6.2.1", "typescript": "^5.6.3" } }],
+    "@lifi/intent": ["@lifi/intent@0.4.0", "", { "dependencies": { "@scure/base": "^2.2.0", "borsh": "^2.0.0", "ky": "^1.12.0", "viem": "~2.45.1" } }, "sha512-QkYTz+VADj2T2NBrwWZ5Ir4ezo+j7NxLkxWmf7WDLWRGaGuRLr8P0ydAhhZ6AcEpJuJspmFxGt8ylYzTjD6kOg=="],
 
     "@lit-labs/ssr-dom-shim": ["@lit-labs/ssr-dom-shim@1.5.1", "", {}, "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA=="],
 
@@ -286,8 +286,6 @@
 
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
-    "@napi-rs/lzma-linux-x64-gnu": ["@napi-rs/lzma-linux-x64-gnu@1.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ=="],
-
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
@@ -303,38 +301,6 @@
     "@npmcli/fs": ["@npmcli/fs@2.1.2", "", { "dependencies": { "@gar/promisify": "^1.1.3", "semver": "^7.3.5" } }, "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ=="],
 
     "@npmcli/move-file": ["@npmcli/move-file@2.0.1", "", { "dependencies": { "mkdirp": "^1.0.4", "rimraf": "^3.0.2" } }, "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ=="],
-
-    "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A=="],
-
-    "@oven/bun-darwin-x64": ["@oven/bun-darwin-x64@1.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-FFj3QdU/OhlDyZOJ8CWfN5eWLpRlT4qjZg7lMQi7jA6GuoY5ajlO1zWLP/MuHYRSbXQUvV52RejNi8DVnAp13w=="],
-
-    "@oven/bun-darwin-x64-baseline": ["@oven/bun-darwin-x64-baseline@1.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-OSfsTZstc898HHElhU4NccaBGOSSDn5VfahiVTnidZ9B/+wb7WTyfZJaBeJcfjwJ9H2W9uTh2TGtl3UfcXgV9g=="],
-
-    "@oven/bun-freebsd-aarch64": ["@oven/bun-freebsd-aarch64@1.3.14", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-LIKrXaFxAHybVO5Pf+9XP2FHUj/5APvXTUKk9dqHm5iFz4oH+W24cmhjkJirNujh9hKeTyrpWSe3no9JZKowIw=="],
-
-    "@oven/bun-freebsd-x64": ["@oven/bun-freebsd-x64@1.3.14", "", { "os": "freebsd", "cpu": "x64" }, "sha512-uwD+fGUH1ADpIF3B1U2jWzzb20QwRLZfj5QZ28GUCGrAJ/nTmWrD6YYGsblCY1wuhldRez3lU40AyuvSCyLYmw=="],
-
-    "@oven/bun-linux-aarch64": ["@oven/bun-linux-aarch64@1.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-X5SsPZHs+iYO8R/efIcRtc7gT2Q2DgPfliCxEkx4cXBumwkw0c/EsHMNwH3EgGpCDaZ7IYVPhpCG/xBOQHEwZw=="],
-
-    "@oven/bun-linux-aarch64-android": ["@oven/bun-linux-aarch64-android@1.3.14", "", { "os": "android", "cpu": "arm64" }, "sha512-y4kq5b85lsrmFb9Xvi4w9mA5IEFJkLMrSmYn06q24KjL9rUWDWO3VFZEtteZxUN5+ec3Zm5S8OnJw1umaCbVjA=="],
-
-    "@oven/bun-linux-aarch64-musl": ["@oven/bun-linux-aarch64-musl@1.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-jmqOA92Cd1NL/1XBd4bFkJLxQ86K0RW7ohxS2qzzAvuitO4JiIxjjTeCspoU44zCozH72HpfZfUE2On31OjnWA=="],
-
-    "@oven/bun-linux-x64": ["@oven/bun-linux-x64@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-7OVTAKvwfPmSbIV1HpdOoVVx5VRc427GuPPne93N6vk4eQBPId9nXmZDh9/zGaKPdbVjVtQSZafWQoUjx38Utw=="],
-
-    "@oven/bun-linux-x64-android": ["@oven/bun-linux-x64-android@1.3.14", "", { "os": "android", "cpu": "x64" }, "sha512-qe9e1d+3VAEU7nAA2ol9Jvmy/o99PVMSgZhHn7Q/9O3YcDrfEqyQ8zm4zoe5qTEo8HZH0dN03Le0Ys2eQPs7eg=="],
-
-    "@oven/bun-linux-x64-baseline": ["@oven/bun-linux-x64-baseline@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-q/8EdOC0yUE8FPeoOVq8/Pw5I9/tJaYmUfO/uDUAREx8IUnOJH1RJ5A3BjFqre8pvJoiZA9AovPJq5FnNNjSxA=="],
-
-    "@oven/bun-linux-x64-musl": ["@oven/bun-linux-x64-musl@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-GBCB/k/sIqcr06eTNgg7g46qiUv35Jasx4XiccJ/n7RGqrE4RWUD/XJBbWFprVPjvqd59+QtSnS99XGqvftHfg=="],
-
-    "@oven/bun-linux-x64-musl-baseline": ["@oven/bun-linux-x64-musl-baseline@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-n6iE71G4lQE4XkrZhQQcL5YUlxDbnq6nqV7zeQi33PMsLT/0kYE+RvHOtBWZ3w0wMdXZfINmp63hIb9ijUBGtw=="],
-
-    "@oven/bun-windows-aarch64": ["@oven/bun-windows-aarch64@1.3.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-T7s3x/BsVKQObGU6QDkZeI6wKynzqGbBH1yI77jrrj5siElclxr3DQrDIk8CV4G5/SJq2HHq4kpLyYY2DKCSmA=="],
-
-    "@oven/bun-windows-x64": ["@oven/bun-windows-x64@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-mUFWL3BoYkNpjd8e9PqROiFF/1Xeotq20mABJsiQH62jM1g5zqWh4khw1RZ6bX8Q8fWvlPaxG1PjofkmjUi3vg=="],
-
-    "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw=="],
 
     "@paulmillr/qr": ["@paulmillr/qr@0.2.1", "", {}, "sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ=="],
 
@@ -388,15 +354,9 @@
 
     "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.46.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg=="],
 
-    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA=="],
-
-    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ=="],
-
     "@rollup/rollup-linux-loongarch64-gnu": ["@rollup/rollup-linux-loongarch64-gnu@4.46.2", "", { "os": "linux", "cpu": "none" }, "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA=="],
 
     "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.46.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw=="],
-
-    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w=="],
 
     "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.46.2", "", { "os": "linux", "cpu": "none" }, "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ=="],
 
@@ -408,15 +368,9 @@
 
     "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.46.2", "", { "os": "linux", "cpu": "x64" }, "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA=="],
 
-    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ=="],
-
-    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.4", "", { "os": "none", "cpu": "arm64" }, "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ=="],
-
     "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.46.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g=="],
 
     "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.46.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ=="],
-
-    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.4", "", { "os": "win32", "cpu": "x64" }, "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.46.2", "", { "os": "win32", "cpu": "x64" }, "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg=="],
 
@@ -778,8 +732,6 @@
 
     "bufferutil": ["bufferutil@4.1.0", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw=="],
 
-    "bun": ["bun@1.3.14", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.3.14", "@oven/bun-darwin-x64": "1.3.14", "@oven/bun-darwin-x64-baseline": "1.3.14", "@oven/bun-freebsd-aarch64": "1.3.14", "@oven/bun-freebsd-x64": "1.3.14", "@oven/bun-linux-aarch64": "1.3.14", "@oven/bun-linux-aarch64-android": "1.3.14", "@oven/bun-linux-aarch64-musl": "1.3.14", "@oven/bun-linux-x64": "1.3.14", "@oven/bun-linux-x64-android": "1.3.14", "@oven/bun-linux-x64-baseline": "1.3.14", "@oven/bun-linux-x64-musl": "1.3.14", "@oven/bun-linux-x64-musl-baseline": "1.3.14", "@oven/bun-windows-aarch64": "1.3.14", "@oven/bun-windows-x64": "1.3.14", "@oven/bun-windows-x64-baseline": "1.3.14" }, "os": [ "!aix", "!sunos", "!openbsd", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bunx.exe" } }, "sha512-aB6GVd42x1Y5ie1K16SF+oLGtgSkwX9hgoDdIW88pjvfTccU8F1vfpoOt34QLv0dZ1v3XimtaxPlZUG81Gx9Zg=="],
-
     "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 
     "cacache": ["cacache@16.1.3", "", { "dependencies": { "@npmcli/fs": "^2.1.0", "@npmcli/move-file": "^2.0.0", "chownr": "^2.0.0", "fs-minipass": "^2.1.0", "glob": "^8.0.1", "infer-owner": "^1.0.4", "lru-cache": "^7.7.1", "minipass": "^3.1.6", "minipass-collect": "^1.0.2", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "mkdirp": "^1.0.4", "p-map": "^4.0.0", "promise-inflight": "^1.0.1", "rimraf": "^3.0.2", "ssri": "^9.0.0", "tar": "^6.1.11", "unique-filename": "^2.0.0" } }, "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ=="],
@@ -919,8 +871,6 @@
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
-
-    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
@@ -1438,8 +1388,6 @@
 
     "rollup": ["rollup@4.46.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.46.2", "@rollup/rollup-android-arm64": "4.46.2", "@rollup/rollup-darwin-arm64": "4.46.2", "@rollup/rollup-darwin-x64": "4.46.2", "@rollup/rollup-freebsd-arm64": "4.46.2", "@rollup/rollup-freebsd-x64": "4.46.2", "@rollup/rollup-linux-arm-gnueabihf": "4.46.2", "@rollup/rollup-linux-arm-musleabihf": "4.46.2", "@rollup/rollup-linux-arm64-gnu": "4.46.2", "@rollup/rollup-linux-arm64-musl": "4.46.2", "@rollup/rollup-linux-loongarch64-gnu": "4.46.2", "@rollup/rollup-linux-ppc64-gnu": "4.46.2", "@rollup/rollup-linux-riscv64-gnu": "4.46.2", "@rollup/rollup-linux-riscv64-musl": "4.46.2", "@rollup/rollup-linux-s390x-gnu": "4.46.2", "@rollup/rollup-linux-x64-gnu": "4.46.2", "@rollup/rollup-linux-x64-musl": "4.46.2", "@rollup/rollup-win32-arm64-msvc": "4.46.2", "@rollup/rollup-win32-ia32-msvc": "4.46.2", "@rollup/rollup-win32-x64-msvc": "4.46.2", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg=="],
 
-    "rollup-plugin-esbuild": ["rollup-plugin-esbuild@6.2.1", "", { "dependencies": { "debug": "^4.4.0", "es-module-lexer": "^1.6.0", "get-tsconfig": "^4.10.0", "unplugin-utils": "^0.2.4" }, "peerDependencies": { "esbuild": ">=0.18.0", "rollup": "^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0" } }, "sha512-jTNOMGoMRhs0JuueJrJqbW8tOwxumaWYq+V5i+PD+8ecSCVkuX27tGW7BXqDgoULQ55rO7IdNxPcnsWtshz3AA=="],
-
     "rpc-websockets": ["rpc-websockets@9.3.5", "", { "dependencies": { "@swc/helpers": "^0.5.11", "@types/uuid": "^10.0.0", "@types/ws": "^8.2.2", "buffer": "^6.0.3", "eventemitter3": "^5.0.1", "uuid": "^11.0.0", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^6.0.0" } }, "sha512-4mAmr+AEhPYJ9TmDtxF3r3ZcbWy7W8kvZ4PoZYw/Xgp2J7WixjwTgiQZsoTDvch5nimmg3Ay6/0Kuh9oIvVs9A=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
@@ -1576,8 +1524,6 @@
 
     "unique-slug": ["unique-slug@3.0.0", "", { "dependencies": { "imurmurhash": "^0.1.4" } }, "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w=="],
 
-    "unplugin-utils": ["unplugin-utils@0.2.5", "", { "dependencies": { "pathe": "^2.0.3", "picomatch": "^4.0.3" } }, "sha512-gwXJnPRewT4rT7sBi/IvxKTjsms7jX7QIDLOClApuZwR49SXbrB1z2NLUZ+vDHyqCj/n58OzRRqaW+B8OZi8vg=="],
-
     "unstorage": ["unstorage@1.17.4", "", { "dependencies": { "anymatch": "^3.1.3", "chokidar": "^5.0.0", "destr": "^2.0.5", "h3": "^1.15.5", "lru-cache": "^11.2.0", "node-fetch-native": "^1.6.7", "ofetch": "^1.5.1", "ufo": "^1.6.3" }, "peerDependencies": { "@azure/app-configuration": "^1.8.0", "@azure/cosmos": "^4.2.0", "@azure/data-tables": "^13.3.0", "@azure/identity": "^4.6.0", "@azure/keyvault-secrets": "^4.9.0", "@azure/storage-blob": "^12.26.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.9.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.34.3", "@vercel/blob": ">=0.27.1", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1 || ^2 || ^3", "aws4fetch": "^1.0.20", "db0": ">=0.2.1", "idb-keyval": "^6.2.1", "ioredis": "^5.4.2", "uploadthing": "^7.4.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "db0", "idb-keyval", "ioredis", "uploadthing"] }, "sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
@@ -1677,10 +1623,6 @@
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
-
-    "@lifi/intent/@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
-
-    "@lifi/intent/rollup": ["rollup@4.62.4", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@napi-rs/lzma-linux-x64-gnu": "1.5.1", "@rollup/rollup-android-arm-eabi": "4.62.4", "@rollup/rollup-android-arm64": "4.62.4", "@rollup/rollup-darwin-arm64": "4.62.4", "@rollup/rollup-darwin-x64": "4.62.4", "@rollup/rollup-freebsd-arm64": "4.62.4", "@rollup/rollup-freebsd-x64": "4.62.4", "@rollup/rollup-linux-arm-gnueabihf": "4.62.4", "@rollup/rollup-linux-arm-musleabihf": "4.62.4", "@rollup/rollup-linux-arm64-gnu": "4.62.4", "@rollup/rollup-linux-arm64-musl": "4.62.4", "@rollup/rollup-linux-loong64-gnu": "4.62.4", "@rollup/rollup-linux-loong64-musl": "4.62.4", "@rollup/rollup-linux-ppc64-gnu": "4.62.4", "@rollup/rollup-linux-ppc64-musl": "4.62.4", "@rollup/rollup-linux-riscv64-gnu": "4.62.4", "@rollup/rollup-linux-riscv64-musl": "4.62.4", "@rollup/rollup-linux-s390x-gnu": "4.62.4", "@rollup/rollup-linux-x64-gnu": "4.62.4", "@rollup/rollup-linux-x64-musl": "4.62.4", "@rollup/rollup-openbsd-x64": "4.62.4", "@rollup/rollup-openharmony-arm64": "4.62.4", "@rollup/rollup-win32-arm64-msvc": "4.62.4", "@rollup/rollup-win32-ia32-msvc": "4.62.4", "@rollup/rollup-win32-x64-gnu": "4.62.4", "@rollup/rollup-win32-x64-msvc": "4.62.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg=="],
 
     "@metamask/rpc-errors/@metamask/utils": ["@metamask/utils@9.3.0", "", { "dependencies": { "@ethereumjs/tx": "^4.2.0", "@metamask/superstruct": "^3.1.0", "@noble/hashes": "^1.3.1", "@scure/base": "^1.1.3", "@types/debug": "^4.1.7", "debug": "^4.3.4", "pony-cause": "^2.1.10", "semver": "^7.5.4", "uuid": "^9.0.1" } }, "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g=="],
 
@@ -2077,46 +2019,6 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.4", "", { "os": "android", "cpu": "arm" }, "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.4", "", { "os": "android", "cpu": "arm64" }, "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.4", "", { "os": "linux", "cpu": "arm" }, "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.4", "", { "os": "linux", "cpu": "arm" }, "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.4", "", { "os": "linux", "cpu": "x64" }, "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.4", "", { "os": "linux", "cpu": "x64" }, "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ=="],
-
-    "@lifi/intent/rollup/@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.4", "", { "os": "win32", "cpu": "x64" }, "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q=="],
-
-    "@lifi/intent/rollup/@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@metamask/rpc-errors/@metamask/utils/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@base-org/account": "^2.5.1",
         "@coinbase/wallet-sdk": "^4.3.6",
         "@electric-sql/pglite": "^0.3.15",
-        "@lifi/intent": "0.2.1",
+        "@lifi/intent": "file:../intent.ts",
         "@metamask/sdk": "^0.34.0",
         "@safe-global/safe-apps-provider": "~0.18.6",
         "@safe-global/safe-apps-sdk": "^9.1.0",
@@ -232,7 +232,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.29", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="],
 
-    "@lifi/intent": ["@lifi/intent@0.2.1", "", { "dependencies": { "@scure/base": "^2.2.0", "borsh": "^2.0.0", "ky": "^1.12.0", "viem": "~2.45.1" } }, "sha512-ZtD5SVXzxOugc5l2/JDWH3K+vawKExFA7Q2coK9DXmKQ3GCcSiU0yi+tBPHz5/0XhjgDZBl54MMid3nA4gxR/g=="],
+    "@lifi/intent": ["@lifi/intent@file:../intent.ts", { "dependencies": { "@scure/base": "^2.2.0", "borsh": "^2.0.0", "ky": "^1.12.0", "viem": "~2.45.1" }, "devDependencies": { "@types/bun": "^1.3.8", "bun": "^1.3.5", "husky": "9.1.7", "lint-staged": "16.1.0", "prettier": "3.4.2", "rollup": "^4.61.0", "rollup-plugin-esbuild": "^6.2.1", "typescript": "^5.6.3" } }],
 
     "@lit-labs/ssr-dom-shim": ["@lit-labs/ssr-dom-shim@1.5.1", "", {}, "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA=="],
 
@@ -268,6 +268,8 @@
 
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
+    "@napi-rs/lzma-linux-x64-gnu": ["@napi-rs/lzma-linux-x64-gnu@1.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ=="],
+
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
@@ -279,6 +281,38 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A=="],
+
+    "@oven/bun-darwin-x64": ["@oven/bun-darwin-x64@1.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-FFj3QdU/OhlDyZOJ8CWfN5eWLpRlT4qjZg7lMQi7jA6GuoY5ajlO1zWLP/MuHYRSbXQUvV52RejNi8DVnAp13w=="],
+
+    "@oven/bun-darwin-x64-baseline": ["@oven/bun-darwin-x64-baseline@1.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-OSfsTZstc898HHElhU4NccaBGOSSDn5VfahiVTnidZ9B/+wb7WTyfZJaBeJcfjwJ9H2W9uTh2TGtl3UfcXgV9g=="],
+
+    "@oven/bun-freebsd-aarch64": ["@oven/bun-freebsd-aarch64@1.3.14", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-LIKrXaFxAHybVO5Pf+9XP2FHUj/5APvXTUKk9dqHm5iFz4oH+W24cmhjkJirNujh9hKeTyrpWSe3no9JZKowIw=="],
+
+    "@oven/bun-freebsd-x64": ["@oven/bun-freebsd-x64@1.3.14", "", { "os": "freebsd", "cpu": "x64" }, "sha512-uwD+fGUH1ADpIF3B1U2jWzzb20QwRLZfj5QZ28GUCGrAJ/nTmWrD6YYGsblCY1wuhldRez3lU40AyuvSCyLYmw=="],
+
+    "@oven/bun-linux-aarch64": ["@oven/bun-linux-aarch64@1.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-X5SsPZHs+iYO8R/efIcRtc7gT2Q2DgPfliCxEkx4cXBumwkw0c/EsHMNwH3EgGpCDaZ7IYVPhpCG/xBOQHEwZw=="],
+
+    "@oven/bun-linux-aarch64-android": ["@oven/bun-linux-aarch64-android@1.3.14", "", { "os": "android", "cpu": "arm64" }, "sha512-y4kq5b85lsrmFb9Xvi4w9mA5IEFJkLMrSmYn06q24KjL9rUWDWO3VFZEtteZxUN5+ec3Zm5S8OnJw1umaCbVjA=="],
+
+    "@oven/bun-linux-aarch64-musl": ["@oven/bun-linux-aarch64-musl@1.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-jmqOA92Cd1NL/1XBd4bFkJLxQ86K0RW7ohxS2qzzAvuitO4JiIxjjTeCspoU44zCozH72HpfZfUE2On31OjnWA=="],
+
+    "@oven/bun-linux-x64": ["@oven/bun-linux-x64@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-7OVTAKvwfPmSbIV1HpdOoVVx5VRc427GuPPne93N6vk4eQBPId9nXmZDh9/zGaKPdbVjVtQSZafWQoUjx38Utw=="],
+
+    "@oven/bun-linux-x64-android": ["@oven/bun-linux-x64-android@1.3.14", "", { "os": "android", "cpu": "x64" }, "sha512-qe9e1d+3VAEU7nAA2ol9Jvmy/o99PVMSgZhHn7Q/9O3YcDrfEqyQ8zm4zoe5qTEo8HZH0dN03Le0Ys2eQPs7eg=="],
+
+    "@oven/bun-linux-x64-baseline": ["@oven/bun-linux-x64-baseline@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-q/8EdOC0yUE8FPeoOVq8/Pw5I9/tJaYmUfO/uDUAREx8IUnOJH1RJ5A3BjFqre8pvJoiZA9AovPJq5FnNNjSxA=="],
+
+    "@oven/bun-linux-x64-musl": ["@oven/bun-linux-x64-musl@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-GBCB/k/sIqcr06eTNgg7g46qiUv35Jasx4XiccJ/n7RGqrE4RWUD/XJBbWFprVPjvqd59+QtSnS99XGqvftHfg=="],
+
+    "@oven/bun-linux-x64-musl-baseline": ["@oven/bun-linux-x64-musl-baseline@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-n6iE71G4lQE4XkrZhQQcL5YUlxDbnq6nqV7zeQi33PMsLT/0kYE+RvHOtBWZ3w0wMdXZfINmp63hIb9ijUBGtw=="],
+
+    "@oven/bun-windows-aarch64": ["@oven/bun-windows-aarch64@1.3.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-T7s3x/BsVKQObGU6QDkZeI6wKynzqGbBH1yI77jrrj5siElclxr3DQrDIk8CV4G5/SJq2HHq4kpLyYY2DKCSmA=="],
+
+    "@oven/bun-windows-x64": ["@oven/bun-windows-x64@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-mUFWL3BoYkNpjd8e9PqROiFF/1Xeotq20mABJsiQH62jM1g5zqWh4khw1RZ6bX8Q8fWvlPaxG1PjofkmjUi3vg=="],
+
+    "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw=="],
 
     "@paulmillr/qr": ["@paulmillr/qr@0.2.1", "", {}, "sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ=="],
 
@@ -332,9 +366,15 @@
 
     "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.46.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg=="],
 
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ=="],
+
     "@rollup/rollup-linux-loongarch64-gnu": ["@rollup/rollup-linux-loongarch64-gnu@4.46.2", "", { "os": "linux", "cpu": "none" }, "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA=="],
 
     "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.46.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w=="],
 
     "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.46.2", "", { "os": "linux", "cpu": "none" }, "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ=="],
 
@@ -346,9 +386,15 @@
 
     "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.46.2", "", { "os": "linux", "cpu": "x64" }, "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA=="],
 
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.4", "", { "os": "none", "cpu": "arm64" }, "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ=="],
+
     "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.46.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g=="],
 
     "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.46.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.4", "", { "os": "win32", "cpu": "x64" }, "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.46.2", "", { "os": "win32", "cpu": "x64" }, "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg=="],
 
@@ -674,6 +720,8 @@
 
     "bufferutil": ["bufferutil@4.1.0", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw=="],
 
+    "bun": ["bun@1.3.14", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.3.14", "@oven/bun-darwin-x64": "1.3.14", "@oven/bun-darwin-x64-baseline": "1.3.14", "@oven/bun-freebsd-aarch64": "1.3.14", "@oven/bun-freebsd-x64": "1.3.14", "@oven/bun-linux-aarch64": "1.3.14", "@oven/bun-linux-aarch64-android": "1.3.14", "@oven/bun-linux-aarch64-musl": "1.3.14", "@oven/bun-linux-x64": "1.3.14", "@oven/bun-linux-x64-android": "1.3.14", "@oven/bun-linux-x64-baseline": "1.3.14", "@oven/bun-linux-x64-musl": "1.3.14", "@oven/bun-linux-x64-musl-baseline": "1.3.14", "@oven/bun-windows-aarch64": "1.3.14", "@oven/bun-windows-x64": "1.3.14", "@oven/bun-windows-x64-baseline": "1.3.14" }, "os": [ "!aix", "!sunos", "!openbsd", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bunx.exe" } }, "sha512-aB6GVd42x1Y5ie1K16SF+oLGtgSkwX9hgoDdIW88pjvfTccU8F1vfpoOt34QLv0dZ1v3XimtaxPlZUG81Gx9Zg=="],
+
     "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
@@ -797,6 +845,8 @@
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
@@ -1246,6 +1296,8 @@
 
     "rollup": ["rollup@4.46.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.46.2", "@rollup/rollup-android-arm64": "4.46.2", "@rollup/rollup-darwin-arm64": "4.46.2", "@rollup/rollup-darwin-x64": "4.46.2", "@rollup/rollup-freebsd-arm64": "4.46.2", "@rollup/rollup-freebsd-x64": "4.46.2", "@rollup/rollup-linux-arm-gnueabihf": "4.46.2", "@rollup/rollup-linux-arm-musleabihf": "4.46.2", "@rollup/rollup-linux-arm64-gnu": "4.46.2", "@rollup/rollup-linux-arm64-musl": "4.46.2", "@rollup/rollup-linux-loongarch64-gnu": "4.46.2", "@rollup/rollup-linux-ppc64-gnu": "4.46.2", "@rollup/rollup-linux-riscv64-gnu": "4.46.2", "@rollup/rollup-linux-riscv64-musl": "4.46.2", "@rollup/rollup-linux-s390x-gnu": "4.46.2", "@rollup/rollup-linux-x64-gnu": "4.46.2", "@rollup/rollup-linux-x64-musl": "4.46.2", "@rollup/rollup-win32-arm64-msvc": "4.46.2", "@rollup/rollup-win32-ia32-msvc": "4.46.2", "@rollup/rollup-win32-x64-msvc": "4.46.2", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg=="],
 
+    "rollup-plugin-esbuild": ["rollup-plugin-esbuild@6.2.1", "", { "dependencies": { "debug": "^4.4.0", "es-module-lexer": "^1.6.0", "get-tsconfig": "^4.10.0", "unplugin-utils": "^0.2.4" }, "peerDependencies": { "esbuild": ">=0.18.0", "rollup": "^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0" } }, "sha512-jTNOMGoMRhs0JuueJrJqbW8tOwxumaWYq+V5i+PD+8ecSCVkuX27tGW7BXqDgoULQ55rO7IdNxPcnsWtshz3AA=="],
+
     "rpc-websockets": ["rpc-websockets@9.3.5", "", { "dependencies": { "@swc/helpers": "^0.5.11", "@types/uuid": "^10.0.0", "@types/ws": "^8.2.2", "buffer": "^6.0.3", "eventemitter3": "^5.0.1", "uuid": "^11.0.0", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^6.0.0" } }, "sha512-4mAmr+AEhPYJ9TmDtxF3r3ZcbWy7W8kvZ4PoZYw/Xgp2J7WixjwTgiQZsoTDvch5nimmg3Ay6/0Kuh9oIvVs9A=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
@@ -1366,6 +1418,8 @@
 
     "unenv": ["unenv@2.0.0-rc.19", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.7", "ohash": "^2.0.11", "pathe": "^2.0.3", "ufo": "^1.6.1" } }, "sha512-t/OMHBNAkknVCI7bVB9OWjUUAwhVv9vsPIAGnNUxnu3FxPQN11rjh0sksLMzc3g7IlTgvHmOTl4JM7JHpcv5wA=="],
 
+    "unplugin-utils": ["unplugin-utils@0.2.5", "", { "dependencies": { "pathe": "^2.0.3", "picomatch": "^4.0.3" } }, "sha512-gwXJnPRewT4rT7sBi/IvxKTjsms7jX7QIDLOClApuZwR49SXbrB1z2NLUZ+vDHyqCj/n58OzRRqaW+B8OZi8vg=="],
+
     "unstorage": ["unstorage@1.17.4", "", { "dependencies": { "anymatch": "^3.1.3", "chokidar": "^5.0.0", "destr": "^2.0.5", "h3": "^1.15.5", "lru-cache": "^11.2.0", "node-fetch-native": "^1.6.7", "ofetch": "^1.5.1", "ufo": "^1.6.3" }, "peerDependencies": { "@azure/app-configuration": "^1.8.0", "@azure/cosmos": "^4.2.0", "@azure/data-tables": "^13.3.0", "@azure/identity": "^4.6.0", "@azure/keyvault-secrets": "^4.9.0", "@azure/storage-blob": "^12.26.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.9.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.34.3", "@vercel/blob": ">=0.27.1", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1 || ^2 || ^3", "aws4fetch": "^1.0.20", "db0": ">=0.2.1", "idb-keyval": "^6.2.1", "ioredis": "^5.4.2", "uploadthing": "^7.4.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "db0", "idb-keyval", "ioredis", "uploadthing"] }, "sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
@@ -1461,6 +1515,8 @@
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
+
+    "@lifi/intent/rollup": ["rollup@4.62.4", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@napi-rs/lzma-linux-x64-gnu": "1.5.1", "@rollup/rollup-android-arm-eabi": "4.62.4", "@rollup/rollup-android-arm64": "4.62.4", "@rollup/rollup-darwin-arm64": "4.62.4", "@rollup/rollup-darwin-x64": "4.62.4", "@rollup/rollup-freebsd-arm64": "4.62.4", "@rollup/rollup-freebsd-x64": "4.62.4", "@rollup/rollup-linux-arm-gnueabihf": "4.62.4", "@rollup/rollup-linux-arm-musleabihf": "4.62.4", "@rollup/rollup-linux-arm64-gnu": "4.62.4", "@rollup/rollup-linux-arm64-musl": "4.62.4", "@rollup/rollup-linux-loong64-gnu": "4.62.4", "@rollup/rollup-linux-loong64-musl": "4.62.4", "@rollup/rollup-linux-ppc64-gnu": "4.62.4", "@rollup/rollup-linux-ppc64-musl": "4.62.4", "@rollup/rollup-linux-riscv64-gnu": "4.62.4", "@rollup/rollup-linux-riscv64-musl": "4.62.4", "@rollup/rollup-linux-s390x-gnu": "4.62.4", "@rollup/rollup-linux-x64-gnu": "4.62.4", "@rollup/rollup-linux-x64-musl": "4.62.4", "@rollup/rollup-openbsd-x64": "4.62.4", "@rollup/rollup-openharmony-arm64": "4.62.4", "@rollup/rollup-win32-arm64-msvc": "4.62.4", "@rollup/rollup-win32-ia32-msvc": "4.62.4", "@rollup/rollup-win32-x64-gnu": "4.62.4", "@rollup/rollup-win32-x64-msvc": "4.62.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg=="],
 
     "@metamask/rpc-errors/@metamask/utils": ["@metamask/utils@9.3.0", "", { "dependencies": { "@ethereumjs/tx": "^4.2.0", "@metamask/superstruct": "^3.1.0", "@noble/hashes": "^1.3.1", "@scure/base": "^1.1.3", "@types/debug": "^4.1.7", "debug": "^4.3.4", "pony-cause": "^2.1.10", "semver": "^7.5.4", "uuid": "^9.0.1" } }, "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g=="],
 
@@ -1707,6 +1763,46 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.4", "", { "os": "android", "cpu": "arm" }, "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.4", "", { "os": "android", "cpu": "arm64" }, "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.4", "", { "os": "linux", "cpu": "arm" }, "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.4", "", { "os": "linux", "cpu": "arm" }, "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.4", "", { "os": "linux", "cpu": "x64" }, "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.4", "", { "os": "linux", "cpu": "x64" }, "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ=="],
+
+    "@lifi/intent/rollup/@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.4", "", { "os": "win32", "cpu": "x64" }, "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q=="],
+
+    "@lifi/intent/rollup/@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@metamask/rpc-errors/@metamask/utils/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,11 +7,18 @@
       "dependencies": {
         "@base-org/account": "^2.5.1",
         "@coinbase/wallet-sdk": "^4.3.6",
+        "@coral-xyz/anchor": "^0.31",
         "@electric-sql/pglite": "^0.3.15",
         "@lifi/intent": "file:../intent.ts",
         "@metamask/sdk": "^0.34.0",
         "@safe-global/safe-apps-provider": "~0.18.6",
         "@safe-global/safe-apps-sdk": "^9.1.0",
+        "@scure/base": "^2.3.0",
+        "@solana/spl-token": "^0.4",
+        "@solana/wallet-adapter-base": "^0.9.27",
+        "@solana/wallet-adapter-phantom": "^0.9.29",
+        "@solana/wallet-adapter-solflare": "^0.6.33",
+        "@solana/web3.js": "^1.98",
         "@sveltejs/adapter-cloudflare": "^7.0.3",
         "@wagmi/connectors": "^7.2.1",
         "@wagmi/core": "^3.4.0",
@@ -53,6 +60,9 @@
       },
     },
   },
+  "overrides": {
+    "bigint-buffer": "npm:bigint-buffer-fixed@^1.1.6",
+  },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.0", "", {}, "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="],
 
@@ -81,6 +91,12 @@
     "@coinbase/cdp-sdk": ["@coinbase/cdp-sdk@1.45.0", "", { "dependencies": { "@solana-program/system": "^0.10.0", "@solana-program/token": "^0.9.0", "@solana/kit": "^5.1.0", "@solana/web3.js": "^1.98.1", "abitype": "1.0.6", "axios": "^1.12.2", "axios-retry": "^4.5.0", "jose": "^6.0.8", "md5": "^2.3.0", "uncrypto": "^0.1.3", "viem": "^2.21.26", "zod": "^3.24.4" } }, "sha512-4fgGOhyN9g/pTDE9NtsKUapwFsubrk9wafz8ltmBqSwWqLZWfWxXkVmzMYYFAf+qeGf/X9JqJtmvDVaHFlXWlw=="],
 
     "@coinbase/wallet-sdk": ["@coinbase/wallet-sdk@4.3.7", "", { "dependencies": { "@noble/hashes": "^1.4.0", "clsx": "^1.2.1", "eventemitter3": "^5.0.1", "preact": "^10.24.2", "viem": "^2.27.2" } }, "sha512-z6e5XDw6EF06RqkeyEa+qD0dZ2ZbLci99vx3zwDY//XO8X7166tqKJrR2XlQnzVmtcUuJtCd5fCvr9Cu6zzX7w=="],
+
+    "@coral-xyz/anchor": ["@coral-xyz/anchor@0.31.1", "", { "dependencies": { "@coral-xyz/anchor-errors": "^0.31.1", "@coral-xyz/borsh": "^0.31.1", "@noble/hashes": "^1.3.1", "@solana/web3.js": "^1.69.0", "bn.js": "^5.1.2", "bs58": "^4.0.1", "buffer-layout": "^1.2.2", "camelcase": "^6.3.0", "cross-fetch": "^3.1.5", "eventemitter3": "^4.0.7", "pako": "^2.0.3", "superstruct": "^0.15.4", "toml": "^3.0.0" } }, "sha512-QUqpoEK+gi2S6nlYc2atgT2r41TT3caWr/cPUEL8n8Md9437trZ68STknq897b82p5mW0XrTBNOzRbmIRJtfsA=="],
+
+    "@coral-xyz/anchor-errors": ["@coral-xyz/anchor-errors@0.31.1", "", {}, "sha512-NhNEku4F3zzUSBtrYz84FzYWm48+9OvmT1Hhnwr6GnPQry2dsEqH/ti/7ASjjpoFTWRnPXrjAIT1qM6Isop+LQ=="],
+
+    "@coral-xyz/borsh": ["@coral-xyz/borsh@0.31.1", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.69.0" } }, "sha512-9N8AU9F0ubriKfNE3g1WF0/4dtlGXoBN/hd1PvbNBamBNwRgHxH4P+o3Zt7rSEloW1HUs6LfZEchlx9fW7POYw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -175,6 +191,8 @@
     "@ethereumjs/tx": ["@ethereumjs/tx@4.2.0", "", { "dependencies": { "@ethereumjs/common": "^3.2.0", "@ethereumjs/rlp": "^4.0.1", "@ethereumjs/util": "^8.1.0", "ethereum-cryptography": "^2.0.0" } }, "sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw=="],
 
     "@ethereumjs/util": ["@ethereumjs/util@8.1.0", "", { "dependencies": { "@ethereumjs/rlp": "^4.0.1", "ethereum-cryptography": "^2.0.0", "micro-ftch": "^0.3.1" } }, "sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA=="],
+
+    "@gar/promisify": ["@gar/promisify@1.1.3", "", {}, "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -272,7 +290,7 @@
 
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
-    "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+    "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -281,6 +299,10 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@npmcli/fs": ["@npmcli/fs@2.1.2", "", { "dependencies": { "@gar/promisify": "^1.1.3", "semver": "^7.3.5" } }, "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ=="],
+
+    "@npmcli/move-file": ["@npmcli/move-file@2.0.1", "", { "dependencies": { "mkdirp": "^1.0.4", "rimraf": "^3.0.2" } }, "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ=="],
 
     "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A=="],
 
@@ -404,7 +426,7 @@
 
     "@safe-global/safe-gateway-typescript-sdk": ["@safe-global/safe-gateway-typescript-sdk@3.23.1", "", {}, "sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw=="],
 
-    "@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
+    "@scure/base": ["@scure/base@2.3.0", "", {}, "sha512-NsG6Y03tY6R5BUis4FdVtHVkur0U6FOzskgs9ZXNl78CUc9fkZ78HmENUle1nSOkCasDmbubmWD9qwB7mm4PZA=="],
 
     "@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
 
@@ -426,17 +448,19 @@
 
     "@solana/buffer-layout": ["@solana/buffer-layout@4.0.1", "", { "dependencies": { "buffer": "~6.0.3" } }, "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA=="],
 
-    "@solana/codecs": ["@solana/codecs@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/options": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g=="],
+    "@solana/buffer-layout-utils": ["@solana/buffer-layout-utils@0.3.0", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/web3.js": "^1.32.0", "bigint-buffer": "^1.1.5", "bignumber.js": "^9.0.1" } }, "sha512-MuQOCC1j0np1xH9yAv0ZWWfwvr7Bt7Sz4LId11Wi4wDdAmJ+lobE+vHg/mZmGcihF0BIkqVBNxGmlv8QE5DrtA=="],
 
-    "@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+    "@solana/codecs": ["@solana/codecs@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/codecs-data-structures": "2.0.0-rc.1", "@solana/codecs-numbers": "2.0.0-rc.1", "@solana/codecs-strings": "2.0.0-rc.1", "@solana/options": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ=="],
 
-    "@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w=="],
+    "@solana/codecs-core": ["@solana/codecs-core@2.3.0", "", { "dependencies": { "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw=="],
+
+    "@solana/codecs-data-structures": ["@solana/codecs-data-structures@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/codecs-numbers": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog=="],
 
     "@solana/codecs-numbers": ["@solana/codecs-numbers@2.3.0", "", { "dependencies": { "@solana/codecs-core": "2.3.0", "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg=="],
 
-    "@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+    "@solana/codecs-strings": ["@solana/codecs-strings@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/codecs-numbers": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5" } }, "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g=="],
 
-    "@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+    "@solana/errors": ["@solana/errors@2.3.0", "", { "dependencies": { "chalk": "^5.4.1", "commander": "^14.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ=="],
 
     "@solana/fast-stable-stringify": ["@solana/fast-stable-stringify@5.5.1", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw=="],
 
@@ -454,7 +478,7 @@
 
     "@solana/offchain-messages": ["@solana/offchain-messages@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/keys": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw=="],
 
-    "@solana/options": ["@solana/options@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A=="],
+    "@solana/options": ["@solana/options@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/codecs-data-structures": "2.0.0-rc.1", "@solana/codecs-numbers": "2.0.0-rc.1", "@solana/codecs-strings": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA=="],
 
     "@solana/plugin-core": ["@solana/plugin-core@5.5.1", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A=="],
 
@@ -488,6 +512,12 @@
 
     "@solana/signers": ["@solana/signers@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1", "@solana/instructions": "5.5.1", "@solana/keys": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/offchain-messages": "5.5.1", "@solana/transaction-messages": "5.5.1", "@solana/transactions": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ=="],
 
+    "@solana/spl-token": ["@solana/spl-token@0.4.15", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.3.0", "@solana/spl-token-group": "^0.0.7", "@solana/spl-token-metadata": "^0.1.6", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.95.5" } }, "sha512-3Lof3mNov8NVQ3PalIWb1Jgr/TZ6lYM+/sexv2TLqdhNFVth2OfWmH3d7QucgMjSbokkjNiNlRr6I8Fd269uaw=="],
+
+    "@solana/spl-token-group": ["@solana/spl-token-group@0.0.7", "", { "dependencies": { "@solana/codecs": "2.0.0-rc.1" }, "peerDependencies": { "@solana/web3.js": "^1.95.3" } }, "sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug=="],
+
+    "@solana/spl-token-metadata": ["@solana/spl-token-metadata@0.1.6", "", { "dependencies": { "@solana/codecs": "2.0.0-rc.1" }, "peerDependencies": { "@solana/web3.js": "^1.95.3" } }, "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA=="],
+
     "@solana/subscribable": ["@solana/subscribable@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ=="],
 
     "@solana/sysvars": ["@solana/sysvars@5.5.1", "", { "dependencies": { "@solana/accounts": "5.5.1", "@solana/codecs": "5.5.1", "@solana/errors": "5.5.1", "@solana/rpc-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA=="],
@@ -498,7 +528,17 @@
 
     "@solana/transactions": ["@solana/transactions@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/functional": "5.5.1", "@solana/instructions": "5.5.1", "@solana/keys": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/rpc-types": "5.5.1", "@solana/transaction-messages": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA=="],
 
+    "@solana/wallet-adapter-base": ["@solana/wallet-adapter-base@0.9.27", "", { "dependencies": { "@solana/wallet-standard-features": "^1.3.0", "@wallet-standard/base": "^1.1.0", "@wallet-standard/features": "^1.1.0", "eventemitter3": "^5.0.1" }, "peerDependencies": { "@solana/web3.js": "^1.98.0" } }, "sha512-kXjeNfNFVs/NE9GPmysBRKQ/nf+foSaq3kfVSeMcO/iVgigyRmB551OjU3WyAolLG/1jeEfKLqF9fKwMCRkUqg=="],
+
+    "@solana/wallet-adapter-phantom": ["@solana/wallet-adapter-phantom@0.9.29", "", { "dependencies": { "@solana/wallet-adapter-base": "^0.9.27" }, "peerDependencies": { "@solana/web3.js": "^1.98.0" } }, "sha512-nAFvjtX2S1aRLzi70CSLajsmixGxev+1O1GzGzety4eyfv2AYxTHEuDIJySugcMTtSTleVpOMhHXjzlUkxuf1w=="],
+
+    "@solana/wallet-adapter-solflare": ["@solana/wallet-adapter-solflare@0.6.33", "", { "dependencies": { "@solana/wallet-adapter-base": "^0.9.27", "@solflare-wallet/sdk": "^1.4.2" }, "peerDependencies": { "@solana/web3.js": "^1.98.0" } }, "sha512-eYDjpXMF+LyfWf5jG89IqJG2ehaEsWvv7P3y3NjPmhCqe0WjfFc2EwED19G4R0JUqdhnY5zFj+gn3pJ3ystGhg=="],
+
+    "@solana/wallet-standard-features": ["@solana/wallet-standard-features@1.4.0", "", { "dependencies": { "@wallet-standard/base": "^1.1.0", "@wallet-standard/features": "^1.1.0" } }, "sha512-f0tAdqwM2aL6CiFbIgt9h5zKFp+mgY/iNGwoxPMTj9VSTeQj7d1GGSmWhZw0XWoZ4N/1tnKTKmYFq+Dyq08jRw=="],
+
     "@solana/web3.js": ["@solana/web3.js@1.98.4", "", { "dependencies": { "@babel/runtime": "^7.25.0", "@noble/curves": "^1.4.2", "@noble/hashes": "^1.4.0", "@solana/buffer-layout": "^4.0.1", "@solana/codecs-numbers": "^2.1.0", "agentkeepalive": "^4.5.0", "bn.js": "^5.2.1", "borsh": "^0.7.0", "bs58": "^4.0.1", "buffer": "6.0.3", "fast-stable-stringify": "^1.0.0", "jayson": "^4.1.1", "node-fetch": "^2.7.0", "rpc-websockets": "^9.0.2", "superstruct": "^2.0.2" } }, "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw=="],
+
+    "@solflare-wallet/sdk": ["@solflare-wallet/sdk@1.4.2", "", { "dependencies": { "bs58": "^5.0.0", "eventemitter3": "^5.0.1", "uuid": "^9.0.0" }, "peerDependencies": { "@solana/web3.js": "*" } }, "sha512-jrseNWipwl9xXZgrzwZF3hhL0eIVxuEtoZOSLmuPuef7FgHjstuTtNJAeT4icA7pzdDV4hZvu54pI2r2f7SmrQ=="],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.7", "", {}, "sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g=="],
 
@@ -550,6 +590,8 @@
 
     "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
 
+    "@tootallnate/once": ["@tootallnate/once@2.0.1", "", {}, "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ=="],
+
     "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
@@ -600,6 +642,8 @@
 
     "@wallet-standard/base": ["@wallet-standard/base@1.1.0", "", {}, "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ=="],
 
+    "@wallet-standard/features": ["@wallet-standard/features@1.1.1", "", { "dependencies": { "@wallet-standard/base": "^1.1.1" } }, "sha512-aCWYmVeSCGViyEU5k7GMoW8zxE4Gs+C1s1Pp2XLesvSNlnZ4PMES9HUnTB3hl0b3RVj7C61yze3IWyrncqg4MA=="],
+
     "@wallet-standard/wallet": ["@wallet-standard/wallet@1.1.0", "", { "dependencies": { "@wallet-standard/base": "^1.1.0" } }, "sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg=="],
 
     "@walletconnect/core": ["@walletconnect/core@2.23.8", "", { "dependencies": { "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/jsonrpc-ws-connection": "1.0.16", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "3.0.2", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.23.8", "@walletconnect/utils": "2.23.8", "@walletconnect/window-getters": "1.0.1", "es-toolkit": "1.44.0", "events": "3.3.0", "uint8arrays": "3.1.1" } }, "sha512-559+fA6Hh9CkEIOtrWKdDWoa3HL47glDF7D75LbqQzv4v325KXq24KEsjzDPBYr7pI49gQo7P2HpPnY1ax+8Aw=="],
@@ -646,6 +690,8 @@
 
     "@walletconnect/window-metadata": ["@walletconnect/window-metadata@1.0.1", "", { "dependencies": { "@walletconnect/window-getters": "^1.0.1", "tslib": "1.14.1" } }, "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA=="],
 
+    "abbrev": ["abbrev@1.1.1", "", {}, "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="],
+
     "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" } }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": "bin/acorn" }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
@@ -660,6 +706,8 @@
 
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
+    "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
+
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
@@ -669,6 +717,10 @@
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "aproba": ["aproba@2.1.0", "", {}, "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew=="],
+
+    "are-we-there-yet": ["are-we-there-yet@3.0.1", "", { "dependencies": { "delegates": "^1.0.0", "readable-stream": "^3.6.0" } }, "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -688,13 +740,17 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
-    "base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
+    "base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "big.js": ["big.js@6.2.2", "", {}, "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ=="],
 
+    "bigint-buffer": ["bigint-buffer-fixed@1.1.6", "", { "dependencies": { "bindings": "^1.5.0", "nan": "^2.14.2", "node-gyp": "^9.4.1" } }, "sha512-BSlDL9PxCwBn+Q3V/mrEr1sZuKNlS2py34gxNno9uVvbp2bBNSa1zkHsK3eCmh/Gv99p82TS6eLUXafoIm+EyQ=="],
+
     "bignumber.js": ["bignumber.js@9.1.2", "", {}, "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
@@ -712,17 +768,21 @@
 
     "brotli-wasm": ["brotli-wasm@3.0.1", "", {}, "sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A=="],
 
-    "bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
+    "bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "buffer-layout": ["buffer-layout@1.2.2", "", {}, "sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA=="],
 
     "bufferutil": ["bufferutil@4.1.0", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw=="],
 
     "bun": ["bun@1.3.14", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.3.14", "@oven/bun-darwin-x64": "1.3.14", "@oven/bun-darwin-x64-baseline": "1.3.14", "@oven/bun-freebsd-aarch64": "1.3.14", "@oven/bun-freebsd-x64": "1.3.14", "@oven/bun-linux-aarch64": "1.3.14", "@oven/bun-linux-aarch64-android": "1.3.14", "@oven/bun-linux-aarch64-musl": "1.3.14", "@oven/bun-linux-x64": "1.3.14", "@oven/bun-linux-x64-android": "1.3.14", "@oven/bun-linux-x64-baseline": "1.3.14", "@oven/bun-linux-x64-musl": "1.3.14", "@oven/bun-linux-x64-musl-baseline": "1.3.14", "@oven/bun-windows-aarch64": "1.3.14", "@oven/bun-windows-x64": "1.3.14", "@oven/bun-windows-x64-baseline": "1.3.14" }, "os": [ "!aix", "!sunos", "!openbsd", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bunx.exe" } }, "sha512-aB6GVd42x1Y5ie1K16SF+oLGtgSkwX9hgoDdIW88pjvfTccU8F1vfpoOt34QLv0dZ1v3XimtaxPlZUG81Gx9Zg=="],
 
     "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
+
+    "cacache": ["cacache@16.1.3", "", { "dependencies": { "@npmcli/fs": "^2.1.0", "@npmcli/move-file": "^2.0.0", "chownr": "^2.0.0", "fs-minipass": "^2.1.0", "glob": "^8.0.1", "infer-owner": "^1.0.4", "lru-cache": "^7.7.1", "minipass": "^3.1.6", "minipass-collect": "^1.0.2", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "mkdirp": "^1.0.4", "p-map": "^4.0.0", "promise-inflight": "^1.0.1", "rimraf": "^3.0.2", "ssri": "^9.0.0", "tar": "^6.1.11", "unique-filename": "^2.0.0" } }, "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
@@ -732,7 +792,7 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
-    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -741,6 +801,8 @@
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
+    "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
 
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
@@ -758,6 +820,8 @@
 
     "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
 
+    "color-support": ["color-support@1.1.3", "", { "bin": { "color-support": "bin.js" } }, "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="],
+
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
@@ -765,6 +829,8 @@
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "console-control-strings": ["console-control-strings@1.1.0", "", {}, "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="],
 
     "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
 
@@ -774,7 +840,7 @@
 
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
-    "cross-fetch": ["cross-fetch@4.1.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw=="],
+    "cross-fetch": ["cross-fetch@3.2.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -806,6 +872,8 @@
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
+    "delegates": ["delegates@1.0.0", "", {}, "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="],
+
     "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
     "detect-browser": ["detect-browser@5.3.0", "", {}, "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="],
@@ -830,6 +898,8 @@
 
     "encode-utf8": ["encode-utf8@1.0.3", "", {}, "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="],
 
+    "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
+
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "engine.io-client": ["engine.io-client@6.6.4", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.18.3", "xmlhttprequest-ssl": "~2.1.1" } }, "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw=="],
@@ -838,7 +908,11 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.18.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww=="],
 
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "err-code": ["err-code@2.0.3", "", {}, "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="],
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
@@ -902,6 +976,8 @@
 
     "exit-hook": ["exit-hook@2.2.1", "", {}, "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="],
 
+    "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
+
     "exsolve": ["exsolve@1.0.7", "", {}, "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw=="],
 
     "extension-port-stream": ["extension-port-stream@3.0.0", "", { "dependencies": { "readable-stream": "^3.6.2 || ^4.4.2", "webextension-polyfill": ">=0.10.0 <1.0" } }, "sha512-an2S5quJMiy5bnZKEf6AkfH/7r8CzHvhchU40gxN+OM6HPhe7Z9T1FUychcf2M9PpPOO0Hf7BAEfJkw2TDIBDw=="],
@@ -920,11 +996,15 @@
 
     "fast-stable-stringify": ["fast-stable-stringify@1.0.0", "", {}, "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="],
 
+    "fastestsmallesttextencoderdecoder": ["fastestsmallesttextencoderdecoder@1.0.22", "", {}, "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="],
+
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
     "fdir": ["fdir@6.4.6", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
@@ -940,9 +1020,15 @@
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
+    "fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gauge": ["gauge@4.0.4", "", { "dependencies": { "aproba": "^1.0.3 || ^2.0.0", "color-support": "^1.1.3", "console-control-strings": "^1.1.0", "has-unicode": "^2.0.1", "signal-exit": "^3.0.7", "string-width": "^4.2.3", "strip-ansi": "^6.0.1", "wide-align": "^1.1.5" } }, "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg=="],
 
     "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 
@@ -955,6 +1041,8 @@
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
+
+    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -980,15 +1068,23 @@
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
+    "has-unicode": ["has-unicode@2.0.1", "", {}, "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="],
+
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hono": ["hono@4.12.7", "", {}, "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw=="],
+
+    "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@5.0.0", "", { "dependencies": { "@tootallnate/once": "2", "agent-base": "6", "debug": "4" } }, "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w=="],
 
     "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "idb-keyval": ["idb-keyval@6.2.1", "", {}, "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="],
 
@@ -1000,7 +1096,15 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "infer-owner": ["infer-owner@1.0.4", "", {}, "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="],
+
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.5.0", "", {}, "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g=="],
 
     "iron-webcrypto": ["iron-webcrypto@1.2.1", "", {}, "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="],
 
@@ -1019,6 +1123,8 @@
     "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-lambda": ["is-lambda@1.0.1", "", {}, "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -1114,6 +1220,8 @@
 
     "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
 
+    "make-fetch-happen": ["make-fetch-happen@10.2.1", "", { "dependencies": { "agentkeepalive": "^4.2.1", "cacache": "^16.1.0", "http-cache-semantics": "^4.1.0", "http-proxy-agent": "^5.0.0", "https-proxy-agent": "^5.0.0", "is-lambda": "^1.0.1", "lru-cache": "^7.7.1", "minipass": "^3.1.6", "minipass-collect": "^1.0.2", "minipass-fetch": "^2.0.3", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^0.6.3", "promise-retry": "^2.0.1", "socks-proxy-agent": "^7.0.0", "ssri": "^9.0.0" } }, "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "md5": ["md5@2.3.0", "", { "dependencies": { "charenc": "0.0.2", "crypt": "0.0.2", "is-buffer": "~1.1.6" } }, "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g=="],
@@ -1138,6 +1246,16 @@
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
+    "minipass-collect": ["minipass-collect@1.0.2", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA=="],
+
+    "minipass-fetch": ["minipass-fetch@2.1.2", "", { "dependencies": { "minipass": "^3.1.6", "minipass-sized": "^1.0.3", "minizlib": "^2.1.2" }, "optionalDependencies": { "encoding": "^0.1.13" } }, "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA=="],
+
+    "minipass-flush": ["minipass-flush@1.0.7", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA=="],
+
+    "minipass-pipeline": ["minipass-pipeline@1.2.4", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A=="],
+
+    "minipass-sized": ["minipass-sized@1.0.3", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g=="],
+
     "minizlib": ["minizlib@3.0.2", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA=="],
 
     "mipd": ["mipd@0.0.7", "", { "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-aAPZPNDQ3uMTdKbuO2YmAw2TxLHO0moa4YKAyETM/DTj5FloZo+a+8tU+iv4GmW+sOxKLSRwcSFuczk+Cpt6fg=="],
@@ -1152,21 +1270,31 @@
 
     "multiformats": ["multiformats@9.9.0", "", {}, "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="],
 
+    "nan": ["nan@2.28.0", "", {}, "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ=="],
+
     "nano-spawn": ["nano-spawn@1.0.3", "", {}, "sha512-jtpsQDetTnvS2Ts1fiRdci5rx0VYws5jGyC+4IYOTnIQ/wwdf6JdomlHBwqC3bJYOvaKu0C2GSZ1A60anrYpaA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
+    "negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
+
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
+
+    "node-gyp": ["node-gyp@9.4.1", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "glob": "^7.1.4", "graceful-fs": "^4.2.6", "make-fetch-happen": "^10.0.3", "nopt": "^6.0.0", "npmlog": "^6.0.0", "rimraf": "^3.0.2", "semver": "^7.3.5", "tar": "^6.1.2", "which": "^2.0.2" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ=="],
 
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
     "node-mock-http": ["node-mock-http@1.0.4", "", {}, "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ=="],
 
+    "nopt": ["nopt@6.0.0", "", { "dependencies": { "abbrev": "^1.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g=="],
+
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "npmlog": ["npmlog@6.0.2", "", { "dependencies": { "are-we-there-yet": "^3.0.0", "console-control-strings": "^1.1.0", "gauge": "^4.0.3", "set-blocking": "^2.0.0" } }, "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg=="],
 
     "obj-multiplex": ["obj-multiplex@1.0.0", "", { "dependencies": { "end-of-stream": "^1.4.0", "once": "^1.4.0", "readable-stream": "^2.3.3" } }, "sha512-0GNJAOsHoBHeNTvl5Vt6IWnpUEcc3uSRxzBri7EDyIcMgYvnY2JL2qdeV5zTMjWQX5OHcD5amcW2HFfDh0gjIA=="],
 
@@ -1192,11 +1320,17 @@
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
+    "p-map": ["p-map@4.0.0", "", { "dependencies": { "aggregate-error": "^3.0.0" } }, "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ=="],
+
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "pako": ["pako@2.2.0", "", {}, "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -1252,6 +1386,10 @@
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
+    "promise-inflight": ["promise-inflight@1.0.1", "", {}, "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g=="],
+
+    "promise-retry": ["promise-retry@2.0.1", "", { "dependencies": { "err-code": "^2.0.2", "retry": "^0.12.0" } }, "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g=="],
+
     "proxy-compare": ["proxy-compare@3.0.1", "", {}, "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
@@ -1290,9 +1428,13 @@
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "rollup": ["rollup@4.46.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.46.2", "@rollup/rollup-android-arm64": "4.46.2", "@rollup/rollup-darwin-arm64": "4.46.2", "@rollup/rollup-darwin-x64": "4.46.2", "@rollup/rollup-freebsd-arm64": "4.46.2", "@rollup/rollup-freebsd-x64": "4.46.2", "@rollup/rollup-linux-arm-gnueabihf": "4.46.2", "@rollup/rollup-linux-arm-musleabihf": "4.46.2", "@rollup/rollup-linux-arm64-gnu": "4.46.2", "@rollup/rollup-linux-arm64-musl": "4.46.2", "@rollup/rollup-linux-loongarch64-gnu": "4.46.2", "@rollup/rollup-linux-ppc64-gnu": "4.46.2", "@rollup/rollup-linux-riscv64-gnu": "4.46.2", "@rollup/rollup-linux-riscv64-musl": "4.46.2", "@rollup/rollup-linux-s390x-gnu": "4.46.2", "@rollup/rollup-linux-x64-gnu": "4.46.2", "@rollup/rollup-linux-x64-musl": "4.46.2", "@rollup/rollup-win32-arm64-msvc": "4.46.2", "@rollup/rollup-win32-ia32-msvc": "4.46.2", "@rollup/rollup-win32-x64-msvc": "4.46.2", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg=="],
 
@@ -1306,11 +1448,13 @@
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
-    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "semver": ["semver@7.7.2", "", { "bin": "bin/semver.js" }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
@@ -1336,9 +1480,15 @@
 
     "slow-redact": ["slow-redact@0.3.2", "", {}, "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw=="],
 
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
     "socket.io-client": ["socket.io-client@4.8.3", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-client": "~6.6.1", "socket.io-parser": "~4.2.4" } }, "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g=="],
 
     "socket.io-parser": ["socket.io-parser@4.2.5", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1" } }, "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ=="],
+
+    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@7.0.0", "", { "dependencies": { "agent-base": "^6.0.2", "debug": "^4.3.3", "socks": "^2.6.2" } }, "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww=="],
 
     "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
 
@@ -1349,6 +1499,8 @@
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "ssri": ["ssri@9.0.1", "", { "dependencies": { "minipass": "^3.1.1" } }, "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q=="],
 
     "stoppable": ["stoppable@1.1.0", "", {}, "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="],
 
@@ -1366,7 +1518,7 @@
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
-    "superstruct": ["superstruct@2.0.2", "", {}, "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="],
+    "superstruct": ["superstruct@0.15.5", "", {}, "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -1389,6 +1541,8 @@
     "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "toml": ["toml@3.0.0", "", {}, "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="],
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
@@ -1417,6 +1571,10 @@
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unenv": ["unenv@2.0.0-rc.19", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.7", "ohash": "^2.0.11", "pathe": "^2.0.3", "ufo": "^1.6.1" } }, "sha512-t/OMHBNAkknVCI7bVB9OWjUUAwhVv9vsPIAGnNUxnu3FxPQN11rjh0sksLMzc3g7IlTgvHmOTl4JM7JHpcv5wA=="],
+
+    "unique-filename": ["unique-filename@2.0.1", "", { "dependencies": { "unique-slug": "^3.0.0" } }, "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A=="],
+
+    "unique-slug": ["unique-slug@3.0.0", "", { "dependencies": { "imurmurhash": "^0.1.4" } }, "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w=="],
 
     "unplugin-utils": ["unplugin-utils@0.2.5", "", { "dependencies": { "pathe": "^2.0.3", "picomatch": "^4.0.3" } }, "sha512-gwXJnPRewT4rT7sBi/IvxKTjsms7jX7QIDLOClApuZwR49SXbrB1z2NLUZ+vDHyqCj/n58OzRRqaW+B8OZi8vg=="],
 
@@ -1457,6 +1615,8 @@
     "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
 
     "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
+
+    "wide-align": ["wide-align@1.1.5", "", { "dependencies": { "string-width": "^1.0.2 || 2 || 3 || 4" } }, "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -1506,6 +1666,8 @@
 
     "@coinbase/wallet-sdk/preact": ["preact@10.28.4", "", {}, "sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ=="],
 
+    "@coral-xyz/anchor/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
@@ -1516,11 +1678,17 @@
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
+    "@lifi/intent/@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
+
     "@lifi/intent/rollup": ["rollup@4.62.4", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@napi-rs/lzma-linux-x64-gnu": "1.5.1", "@rollup/rollup-android-arm-eabi": "4.62.4", "@rollup/rollup-android-arm64": "4.62.4", "@rollup/rollup-darwin-arm64": "4.62.4", "@rollup/rollup-darwin-x64": "4.62.4", "@rollup/rollup-freebsd-arm64": "4.62.4", "@rollup/rollup-freebsd-x64": "4.62.4", "@rollup/rollup-linux-arm-gnueabihf": "4.62.4", "@rollup/rollup-linux-arm-musleabihf": "4.62.4", "@rollup/rollup-linux-arm64-gnu": "4.62.4", "@rollup/rollup-linux-arm64-musl": "4.62.4", "@rollup/rollup-linux-loong64-gnu": "4.62.4", "@rollup/rollup-linux-loong64-musl": "4.62.4", "@rollup/rollup-linux-ppc64-gnu": "4.62.4", "@rollup/rollup-linux-ppc64-musl": "4.62.4", "@rollup/rollup-linux-riscv64-gnu": "4.62.4", "@rollup/rollup-linux-riscv64-musl": "4.62.4", "@rollup/rollup-linux-s390x-gnu": "4.62.4", "@rollup/rollup-linux-x64-gnu": "4.62.4", "@rollup/rollup-linux-x64-musl": "4.62.4", "@rollup/rollup-openbsd-x64": "4.62.4", "@rollup/rollup-openharmony-arm64": "4.62.4", "@rollup/rollup-win32-arm64-msvc": "4.62.4", "@rollup/rollup-win32-ia32-msvc": "4.62.4", "@rollup/rollup-win32-x64-gnu": "4.62.4", "@rollup/rollup-win32-x64-msvc": "4.62.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg=="],
 
     "@metamask/rpc-errors/@metamask/utils": ["@metamask/utils@9.3.0", "", { "dependencies": { "@ethereumjs/tx": "^4.2.0", "@metamask/superstruct": "^3.1.0", "@noble/hashes": "^1.3.1", "@scure/base": "^1.1.3", "@types/debug": "^4.1.7", "debug": "^4.3.4", "pony-cause": "^2.1.10", "semver": "^7.5.4", "uuid": "^9.0.1" } }, "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g=="],
 
+    "@metamask/sdk/cross-fetch": ["cross-fetch@4.1.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw=="],
+
     "@metamask/sdk/debug": ["debug@4.3.4", "", { "dependencies": { "ms": "2.1.2" } }, "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ=="],
+
+    "@metamask/sdk-communication-layer/cross-fetch": ["cross-fetch@4.1.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw=="],
 
     "@metamask/sdk-communication-layer/debug": ["debug@4.3.4", "", { "dependencies": { "ms": "2.1.2" } }, "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ=="],
 
@@ -1528,9 +1696,13 @@
 
     "@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
+    "@npmcli/move-file/mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
+
     "@poppinss/dumper/supports-color": ["supports-color@10.1.0", "", {}, "sha512-GBuewsPrhJPftT+fqDa9oI/zc5HNsG9nREqwzoSFDOIqf0NggOZbHQj2TE1P1CDJK8ZogFnlZY9hWoUiur7I/A=="],
 
     "@reown/appkit/@walletconnect/universal-provider": ["@walletconnect/universal-provider@2.23.2", "", { "dependencies": { "@walletconnect/events": "1.0.1", "@walletconnect/jsonrpc-http-connection": "1.0.8", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "3.0.2", "@walletconnect/sign-client": "2.23.2", "@walletconnect/types": "2.23.2", "@walletconnect/utils": "2.23.2", "es-toolkit": "1.39.3", "events": "3.3.0" } }, "sha512-vs9iorPUAiVesFJ95O6XvLjmRgF+B2TspxJNL90ZULbrkRw4JFsmaRdb965PZKc+s182k1MkS/MQ0o964xRcEw=="],
+
+    "@reown/appkit/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider": ["@walletconnect/universal-provider@2.23.2", "", { "dependencies": { "@walletconnect/events": "1.0.1", "@walletconnect/jsonrpc-http-connection": "1.0.8", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "3.0.2", "@walletconnect/sign-client": "2.23.2", "@walletconnect/types": "2.23.2", "@walletconnect/utils": "2.23.2", "es-toolkit": "1.39.3", "events": "3.3.0" } }, "sha512-vs9iorPUAiVesFJ95O6XvLjmRgF+B2TspxJNL90ZULbrkRw4JFsmaRdb965PZKc+s182k1MkS/MQ0o964xRcEw=="],
 
@@ -1546,39 +1718,143 @@
 
     "@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
-    "@solana/codecs/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+    "@solana/accounts/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
-    "@solana/codecs-data-structures/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+    "@solana/accounts/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
 
-    "@solana/codecs-numbers/@solana/codecs-core": ["@solana/codecs-core@2.3.0", "", { "dependencies": { "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw=="],
+    "@solana/accounts/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
-    "@solana/codecs-numbers/@solana/errors": ["@solana/errors@2.3.0", "", { "dependencies": { "chalk": "^5.4.1", "commander": "^14.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ=="],
+    "@solana/addresses/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
-    "@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+    "@solana/addresses/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
+    "@solana/addresses/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/assertions/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/codecs/@solana/codecs-core": ["@solana/codecs-core@2.0.0-rc.1", "", { "dependencies": { "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ=="],
+
+    "@solana/codecs/@solana/codecs-numbers": ["@solana/codecs-numbers@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ=="],
+
+    "@solana/codecs-data-structures/@solana/codecs-core": ["@solana/codecs-core@2.0.0-rc.1", "", { "dependencies": { "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ=="],
+
+    "@solana/codecs-data-structures/@solana/codecs-numbers": ["@solana/codecs-numbers@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ=="],
+
+    "@solana/codecs-data-structures/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
+
+    "@solana/codecs-strings/@solana/codecs-core": ["@solana/codecs-core@2.0.0-rc.1", "", { "dependencies": { "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ=="],
+
+    "@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ=="],
+
+    "@solana/codecs-strings/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
 
     "@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+    "@solana/instruction-plans/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/instructions/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/instructions/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/keys/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/keys/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
+    "@solana/keys/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/kit/@solana/codecs": ["@solana/codecs@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/options": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g=="],
+
+    "@solana/kit/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/offchain-messages/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/offchain-messages/@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w=="],
 
     "@solana/offchain-messages/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
 
-    "@solana/options/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+    "@solana/offchain-messages/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
+    "@solana/offchain-messages/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/options/@solana/codecs-core": ["@solana/codecs-core@2.0.0-rc.1", "", { "dependencies": { "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ=="],
+
+    "@solana/options/@solana/codecs-numbers": ["@solana/codecs-numbers@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ=="],
+
+    "@solana/options/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
+
+    "@solana/programs/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/rpc/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/rpc-api/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/rpc-api/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
+    "@solana/rpc-api/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/rpc-spec/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/rpc-subscriptions/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/rpc-subscriptions-channel-websocket/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
     "@solana/rpc-subscriptions-channel-websocket/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
+    "@solana/rpc-subscriptions-spec/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/rpc-transformers/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/rpc-transport-http/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
     "@solana/rpc-transport-http/undici-types": ["undici-types@7.22.0", "", {}, "sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw=="],
+
+    "@solana/rpc-types/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
     "@solana/rpc-types/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
 
+    "@solana/rpc-types/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
+    "@solana/rpc-types/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/signers/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/signers/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/subscribable/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/sysvars/@solana/codecs": ["@solana/codecs@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/options": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g=="],
+
+    "@solana/sysvars/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/transaction-confirmation/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
+    "@solana/transaction-confirmation/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/transaction-messages/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/transaction-messages/@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w=="],
+
     "@solana/transaction-messages/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/transaction-messages/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/transactions/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/transactions/@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w=="],
 
     "@solana/transactions/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
 
-    "@solana/web3.js/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
+    "@solana/transactions/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
+    "@solana/transactions/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
     "@solana/web3.js/borsh": ["borsh@0.7.0", "", { "dependencies": { "bn.js": "^5.2.0", "bs58": "^4.0.0", "text-encoding-utf-8": "^1.0.2" } }, "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA=="],
 
-    "@solana/web3.js/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+    "@solana/web3.js/superstruct": ["superstruct@2.0.2", "", {}, "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="],
+
+    "@solflare-wallet/sdk/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
+
+    "@solflare-wallet/sdk/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -1588,11 +1864,11 @@
 
     "@wagmi/core/zustand": ["zustand@5.0.0", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-LE+VcmbartOPM+auOjCCLQOsQ05zUTp8RkgwRzefUk+2jISdMMFnxvyTjA4YNWr5ZGXYbVsEMZosttuxUBkojQ=="],
 
+    "@wallet-standard/features/@wallet-standard/base": ["@wallet-standard/base@1.1.1", "", {}, "sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ=="],
+
     "@walletconnect/environment/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "@walletconnect/events/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
-
-    "@walletconnect/jsonrpc-http-connection/cross-fetch": ["cross-fetch@3.2.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q=="],
 
     "@walletconnect/jsonrpc-utils/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
@@ -1608,8 +1884,6 @@
 
     "@walletconnect/time/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
-    "@walletconnect/utils/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
-
     "@walletconnect/utils/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@walletconnect/utils/ox": ["ox@0.9.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg=="],
@@ -1620,13 +1894,23 @@
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "cacache/chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
+
+    "cacache/glob": ["glob@8.1.0", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^5.0.1", "once": "^1.3.0" } }, "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ=="],
+
+    "cacache/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "cacache/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "cacache/mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
+
+    "cacache/tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
+
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
-
-    "eciesjs/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "ethereum-cryptography/@noble/curves": ["@noble/curves@1.4.2", "", { "dependencies": { "@noble/hashes": "1.4.0" } }, "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw=="],
 
@@ -1650,6 +1934,14 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "gauge/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "gauge/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "gauge/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "h3/ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
     "jayson/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
@@ -1662,6 +1954,10 @@
 
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
+    "make-fetch-happen/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "make-fetch-happen/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "miniflare/acorn": ["acorn@8.14.0", "", { "bin": "bin/acorn" }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
@@ -1670,11 +1966,23 @@
 
     "miniflare/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
 
+    "minipass-collect/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-fetch/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-fetch/minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
+
+    "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-sized/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "node-gyp/tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
+
     "obj-multiplex/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "ofetch/ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
-
-    "ox/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
@@ -1696,7 +2004,7 @@
 
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+    "ssri/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "tronweb/@babel/runtime": ["@babel/runtime@7.26.10", "", { "dependencies": { "regenerator-runtime": "^0.14.0" } }, "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw=="],
 
@@ -1708,7 +2016,11 @@
 
     "unstorage/ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
+    "viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "viem/ox": ["ox@0.11.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" } }, "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw=="],
+
+    "wide-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "wrangler/esbuild": ["esbuild@0.25.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.4", "@esbuild/android-arm": "0.25.4", "@esbuild/android-arm64": "0.25.4", "@esbuild/android-x64": "0.25.4", "@esbuild/darwin-arm64": "0.25.4", "@esbuild/darwin-x64": "0.25.4", "@esbuild/freebsd-arm64": "0.25.4", "@esbuild/freebsd-x64": "0.25.4", "@esbuild/linux-arm": "0.25.4", "@esbuild/linux-arm64": "0.25.4", "@esbuild/linux-ia32": "0.25.4", "@esbuild/linux-loong64": "0.25.4", "@esbuild/linux-mips64el": "0.25.4", "@esbuild/linux-ppc64": "0.25.4", "@esbuild/linux-riscv64": "0.25.4", "@esbuild/linux-s390x": "0.25.4", "@esbuild/linux-x64": "0.25.4", "@esbuild/netbsd-arm64": "0.25.4", "@esbuild/netbsd-x64": "0.25.4", "@esbuild/openbsd-arm64": "0.25.4", "@esbuild/openbsd-x64": "0.25.4", "@esbuild/sunos-x64": "0.25.4", "@esbuild/win32-arm64": "0.25.4", "@esbuild/win32-ia32": "0.25.4", "@esbuild/win32-x64": "0.25.4" }, "bin": "bin/esbuild" }, "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q=="],
 
@@ -1717,6 +2029,8 @@
     "yargs/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "youch/cookie": ["cookie@1.0.2", "", {}, "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="],
 
@@ -1840,13 +2154,169 @@
 
     "@reown/appkit/@walletconnect/universal-provider/es-toolkit": ["es-toolkit@1.39.3", "", {}, "sha512-Qb/TCFCldgOy8lZ5uC7nLGdqJwSabkQiYQShmw4jyiPk1pZzaYWTwaYKYP7EgLccWYgZocMrtItrwh683voaww=="],
 
-    "@solana/codecs-numbers/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+    "@reown/appkit/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
-    "@solana/web3.js/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+    "@solana/accounts/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/accounts/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/accounts/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/addresses/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/addresses/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/addresses/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/assertions/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/assertions/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/codecs-data-structures/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/codecs-data-structures/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "@solana/codecs-strings/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/codecs-strings/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "@solana/codecs/@solana/codecs-core/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
+
+    "@solana/codecs/@solana/codecs-numbers/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
+
+    "@solana/instruction-plans/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/instruction-plans/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/instructions/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/instructions/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/keys/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/keys/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/keys/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/kit/@solana/codecs/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/kit/@solana/codecs/@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w=="],
+
+    "@solana/kit/@solana/codecs/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/kit/@solana/codecs/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
+    "@solana/kit/@solana/codecs/@solana/options": ["@solana/options@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A=="],
+
+    "@solana/kit/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/kit/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/offchain-messages/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/offchain-messages/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/options/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/options/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "@solana/programs/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/programs/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-api/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/rpc-api/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/rpc-api/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-spec/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/rpc-spec/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-subscriptions-channel-websocket/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/rpc-subscriptions-channel-websocket/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-subscriptions-spec/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/rpc-subscriptions-spec/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-subscriptions/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/rpc-subscriptions/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-transformers/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/rpc-transformers/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-transport-http/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/rpc-transport-http/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-types/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/rpc-types/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/rpc/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/signers/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/signers/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/subscribable/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/subscribable/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/sysvars/@solana/codecs/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/sysvars/@solana/codecs/@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w=="],
+
+    "@solana/sysvars/@solana/codecs/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/sysvars/@solana/codecs/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
+    "@solana/sysvars/@solana/codecs/@solana/options": ["@solana/options@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A=="],
+
+    "@solana/sysvars/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/sysvars/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/transaction-confirmation/@solana/codecs-strings/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/transaction-confirmation/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/transaction-confirmation/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/transaction-confirmation/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/transaction-messages/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/transaction-messages/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/transactions/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/transactions/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solflare-wallet/sdk/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
+    "@wagmi/core/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "@walletconnect/utils/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
+    "cacache/glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+
+    "cacache/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "cacache/tar/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
+
+    "cacache/tar/minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
+
+    "cacache/tar/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -1860,17 +2330,61 @@
 
     "ethers/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
+    "fs-minipass/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "gauge/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "gauge/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "gauge/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "log-update/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
+    "make-fetch-happen/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-collect/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-fetch/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-fetch/minizlib/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-flush/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-pipeline/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-sized/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "node-gyp/tar/chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
+
+    "node-gyp/tar/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
+
+    "node-gyp/tar/minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
+
+    "node-gyp/tar/mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
+
+    "node-gyp/tar/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "obj-multiplex/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
     "obj-multiplex/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "porto/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
+    "ssri/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "tronweb/axios/follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
     "tronweb/axios/proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "wide-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wide-align/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "wide-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q=="],
 
@@ -1934,9 +2448,9 @@
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/@msgpack/msgpack": ["@msgpack/msgpack@3.1.2", "", {}, "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ=="],
 
-    "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
-
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/ox": ["ox@0.9.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg=="],
 
@@ -1944,9 +2458,9 @@
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/@msgpack/msgpack": ["@msgpack/msgpack@3.1.2", "", {}, "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ=="],
 
-    "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
-
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/ox": ["ox@0.9.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg=="],
 
@@ -1954,19 +2468,35 @@
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/@msgpack/msgpack": ["@msgpack/msgpack@3.1.2", "", {}, "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ=="],
 
-    "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
-
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/ox": ["ox@0.9.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg=="],
 
-    "@solana/web3.js/bs58/base-x/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+    "@solana/codecs/@solana/codecs-core/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/codecs/@solana/codecs-core/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "@solana/codecs/@solana/codecs-numbers/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@solana/codecs/@solana/codecs-numbers/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "cacache/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "cacache/tar/minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "node-gyp/tar/minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "wide-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
+
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
+    "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 

--- a/package.json
+++ b/package.json
@@ -52,11 +52,18 @@
   "dependencies": {
     "@base-org/account": "^2.5.1",
     "@coinbase/wallet-sdk": "^4.3.6",
+    "@coral-xyz/anchor": "^0.31",
     "@electric-sql/pglite": "^0.3.15",
     "@lifi/intent": "file:../intent.ts",
     "@metamask/sdk": "^0.34.0",
     "@safe-global/safe-apps-provider": "~0.18.6",
     "@safe-global/safe-apps-sdk": "^9.1.0",
+    "@scure/base": "^2.3.0",
+    "@solana/spl-token": "^0.4",
+    "@solana/wallet-adapter-base": "^0.9.27",
+    "@solana/wallet-adapter-phantom": "^0.9.29",
+    "@solana/wallet-adapter-solflare": "^0.6.33",
+    "@solana/web3.js": "^1.98",
     "@sveltejs/adapter-cloudflare": "^7.0.3",
     "@wagmi/connectors": "^7.2.1",
     "@wagmi/core": "^3.4.0",
@@ -69,5 +76,8 @@
     "tronweb": "^6.4.0",
     "viem": "~2.45.1",
     "wagmi": "^3.5.0"
+  },
+  "overrides": {
+    "bigint-buffer": "npm:bigint-buffer-fixed@^1.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@base-org/account": "^2.5.1",
     "@coinbase/wallet-sdk": "^4.3.6",
     "@electric-sql/pglite": "^0.3.15",
-    "@lifi/intent": "0.2.1",
+    "@lifi/intent": "file:../intent.ts",
     "@metamask/sdk": "^0.34.0",
     "@safe-global/safe-apps-provider": "~0.18.6",
     "@safe-global/safe-apps-sdk": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@coinbase/wallet-sdk": "^4.3.6",
     "@coral-xyz/anchor": "^0.31",
     "@electric-sql/pglite": "^0.3.15",
-    "@lifi/intent": "file:../intent.ts",
+    "@lifi/intent": "0.4.0",
     "@metamask/sdk": "^0.34.0",
     "@safe-global/safe-apps-provider": "~0.18.6",
     "@safe-global/safe-apps-sdk": "^9.1.0",

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,0 +1,11 @@
+import { Buffer } from "buffer";
+
+// @solana/web3.js, Anchor's borsh coder and the wallet adapters all assume a
+// global `Buffer`. Browsers have none, and the failure is a bare
+// "Buffer is not defined" from deep inside a dependency at signing time, so
+// install it before any of them load.
+//
+// Client-only on purpose: the Cloudflare Worker runs with `nodejs_compat`
+// (wrangler.toml) and already has Buffer, and `+page.ts` sets `ssr = false`,
+// so no server hook is needed.
+globalThis.Buffer ??= Buffer;

--- a/src/lib/abi/polymeroracle.ts
+++ b/src/lib/abi/polymeroracle.ts
@@ -83,6 +83,41 @@ export const POLYMER_ORACLE_ABI = [
     outputs: [],
     stateMutability: "nonpayable"
   },
+  // A Solana proof MUST go here, not to receiveMessage: the two decode
+  // different things. receiveMessage calls ICrossL2ProverV2.validateEvent,
+  // which parses an EVM event log; this one calls validateSolLogs. Feeding a
+  // Solana proof to the EVM entry point reverts with no reason string.
+  //
+  // They also key the attestation differently. The EVM path stores under the
+  // local oracle's own identifier; this one stores under Polymer's
+  // `returnedProgramId` — which is why a Solana output must carry the Polymer
+  // PROGRAM ID in `output.oracle` for isProven to find it.
+  {
+    type: "function",
+    name: "receiveSolanaMessage",
+    inputs: [
+      {
+        name: "proof",
+        type: "bytes",
+        internalType: "bytes"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "receiveSolanaMessage",
+    inputs: [
+      {
+        name: "proofs",
+        type: "bytes[]",
+        internalType: "bytes[]"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
   {
     type: "event",
     name: "OutputProven",

--- a/src/lib/components/GetQuote.svelte
+++ b/src/lib/components/GetQuote.svelte
@@ -2,6 +2,7 @@
   import { IntentApi } from "@lifi/intent";
   import type { AppTokenContext } from "$lib/appTypes";
   import { resolveDemoQuoteParams } from "$lib/libraries/demoQuote";
+  import { namespaceForChain } from "$lib/utils/chainType";
   import { interval } from "rxjs";
 
   let {
@@ -11,7 +12,8 @@
     integratorKey = "",
     inputTokens,
     outputTokens = $bindable(),
-    account,
+    accountForChain,
+    outputRecipient,
     mainnet,
     useProductionApi
   }: {
@@ -21,14 +23,46 @@
     integratorKey?: string;
     inputTokens: AppTokenContext[];
     outputTokens: AppTokenContext[];
-    account: () => `0x${string}`;
+    /**
+     * The acting account on a chain, or undefined when no wallet for that
+     * chain's namespace is connected. Deliberately not the screen's single
+     * `account()`: every party in a quote is named in its own chain's
+     * namespace, so an EVM -> Solana quote needs both wallets (or an explicit
+     * recipient) before it can be requested at all.
+     */
+    accountForChain: (chainId: number | bigint) => `0x${string}` | undefined;
+    /** The issuance form's recipient override, when set. */
+    outputRecipient?: `0x${string}`;
     mainnet: boolean;
     useProductionApi: boolean | null;
   } = $props();
 
   const intentApi = $derived(new IntentApi(useProductionApi ?? mainnet));
 
+  /**
+   * Raised when a party in the quote has no address in its own namespace. It is
+   * caught below and shown as "No Quote" rather than a broken request: asking
+   * for a cross-namespace quote without a destination identity is a state the
+   * user resolves by connecting a wallet or naming a recipient.
+   */
+  class MissingQuoteAddress extends Error {}
+
+  function requireAccount(chainId: number | bigint): `0x${string}` {
+    const resolved = accountForChain(chainId);
+    if (!resolved) {
+      throw new MissingQuoteAddress(`No connected account for chain ${chainId}`);
+    }
+    return resolved;
+  }
+
+  // Only the newest request may write back. Editing the recipient or switching
+  // a destination wallet starts a new quote while an older one is in flight;
+  // without this the slower response wins and the displayed output amount stops
+  // matching what issuance would encode.
+  let requestSeq = 0;
+
   async function getQuoteAndSet() {
+    const seq = ++requestSeq;
     try {
       const { exclusiveFor: requestedExclusiveFor, integratorKey: requestedIntegratorKey } =
         resolveDemoQuoteParams({
@@ -38,28 +72,40 @@
           exclusiveFor
         });
 
+      const userChainId = inputTokens[0].token.chainId;
+
+      // Every chain, address and asset is declared in its own CAIP-2 namespace.
+      // `@lifi/intent` re-encodes the address fields to match the namespace it
+      // is given, so the internal hex form is passed through unchanged here and
+      // a Solana mint reaches the API as base58.
       const response = await intentApi.getQuotes({
-        user: account(),
-        userChainId: inputTokens[0].token.chainId,
+        user: requireAccount(userChainId),
+        userChainId,
+        userNamespace: namespaceForChain(userChainId),
         exclusiveFor: requestedExclusiveFor,
         integratorKey: requestedIntegratorKey,
         inputs: inputTokens.map(({ token, amount }) => {
           return {
-            sender: account(),
+            sender: requireAccount(token.chainId),
             asset: token.address,
             chainId: token.chainId,
+            namespace: namespaceForChain(token.chainId),
             amount: amount
           };
         }),
         outputs: outputTokens.map(({ token }) => {
           return {
-            receiver: account(),
+            // The recipient override wins when set, matching what issuance will
+            // actually encode; otherwise the destination chain's own wallet.
+            receiver: outputRecipient ?? requireAccount(token.chainId),
             asset: token.address,
             chainId: token.chainId,
+            namespace: namespaceForChain(token.chainId),
             amount: 0n
           };
         })
       });
+      if (seq !== requestSeq) return;
       if (response?.quotes?.length ?? 0) {
         const quote = response.quotes[0];
         quoteExpires = new Date().getTime() + 30 * 1000;
@@ -73,6 +119,12 @@
         quoteExpires = 0;
       }
     } catch (e) {
+      if (seq !== requestSeq) return;
+      // A missing counterparty wallet is an ordinary UI state, not a failure:
+      // show "No Quote" and stop, rather than leaving the previous quote's
+      // countdown running against a request that was never sent.
+      quoteExpires = 0;
+      if (e instanceof MissingQuoteAddress) return;
       console.log("Could not fetch a quote", e);
       return;
     }
@@ -94,11 +146,42 @@
     quoteRequest = getQuoteAndSet();
   }
 
+  /**
+   * Everything the request is built from, as a comparable value.
+   *
+   * Each party is now named in its own namespace, so a quote depends on the
+   * destination wallet and the recipient override as much as on the tokens.
+   * Tracking only `mainnet` left a stale quote — and a stale output amount —
+   * on screen after either changed, while issuance already used the new one.
+   *
+   * The output amount is deliberately absent: this component writes it back
+   * from the response, so including it would re-trigger on its own result.
+   */
+  const quoteInputs = $derived(
+    JSON.stringify({
+      mainnet,
+      useProductionApi,
+      outputRecipient: outputRecipient ?? null,
+      inputs: inputTokens.map(({ token, amount }) => [
+        String(token.chainId),
+        token.address,
+        amount.toString(),
+        accountForChain(token.chainId) ?? null
+      ]),
+      outputs: outputTokens.map(({ token }) => [
+        String(token.chainId),
+        token.address,
+        accountForChain(token.chainId) ?? null
+      ])
+    })
+  );
+
   $effect(() => {
-    mainnet;
-    setTimeout(() => {
-      updateQuote();
-    }, 1000);
+    quoteInputs;
+    // Debounced, and cancelled on change, so typing an amount or a recipient
+    // sends one request rather than one per keystroke.
+    const handle = setTimeout(() => updateQuote(), 1000);
+    return () => clearTimeout(handle);
   });
 
   $effect(() => {

--- a/src/lib/components/WalletStatus.svelte
+++ b/src/lib/components/WalletStatus.svelte
@@ -97,4 +97,14 @@
   {:else}
     <span class="rounded bg-gray-50 px-2 py-0.5 text-gray-400"> Tron: No wallet </span>
   {/if}
+
+  <span class="text-gray-300">|</span>
+
+  {#if store.solanaConnectedAccount}
+    <span class="rounded bg-green-50 px-2 py-0.5 text-green-700">
+      Solana: {truncate(store.solanaConnectedAccount.base58Address)}
+    </span>
+  {:else}
+    <span class="rounded bg-gray-50 px-2 py-0.5 text-gray-400"> Solana: Not connected </span>
+  {/if}
 </div>

--- a/src/lib/components/WalletStatus.svelte
+++ b/src/lib/components/WalletStatus.svelte
@@ -1,13 +1,28 @@
 <script lang="ts">
   import store from "$lib/state.svelte";
-  import { connectWith, listWalletConnectors, disconnectWallet } from "$lib/utils/wagmi";
+  import { connectWith, listWalletConnectors } from "$lib/utils/wagmi";
   import { isTronLinkAvailable, connectTronLink } from "$lib/tron/signer";
+  import type { SolanaWalletOption } from "$lib/solana/wallet";
+  import {
+    connectSolanaWallet,
+    isSolanaWalletDetected,
+    watchSolanaWallets
+  } from "$lib/solana/wallet";
 
   let connectingEvm = $state(false);
   let connectingTron = $state(false);
+  let connectingSolana = $state(false);
   let showEvmDropdown = $state(false);
+  let showSolanaDropdown = $state(false);
 
   const connectors = listWalletConnectors();
+
+  // Subscribed rather than read once: see watchSolanaWallets. Returning the
+  // unsubscribe makes Svelte tear the listeners down with the component.
+  let solanaWallets = $state<SolanaWalletOption[]>([]);
+  $effect(() => watchSolanaWallets((wallets) => (solanaWallets = wallets)));
+
+  const availableSolanaWallets = $derived(solanaWallets.filter(isSolanaWalletDetected));
 
   async function onConnectEvm(connectorId: string) {
     try {
@@ -30,6 +45,18 @@
       console.warn("TronLink connect failed", error);
     } finally {
       connectingTron = false;
+    }
+  }
+
+  async function onConnectSolana(name: string) {
+    try {
+      connectingSolana = true;
+      showSolanaDropdown = false;
+      store.solanaWalletConnection = await connectSolanaWallet(name);
+    } catch (error) {
+      console.warn(`Solana connect failed for ${name}`, error);
+    } finally {
+      connectingSolana = false;
     }
   }
 
@@ -104,7 +131,39 @@
     <span class="rounded bg-green-50 px-2 py-0.5 text-green-700">
       Solana: {truncate(store.solanaConnectedAccount.base58Address)}
     </span>
+  {:else if availableSolanaWallets.length === 1}
+    <button
+      class="cursor-pointer rounded bg-sky-50 px-2 py-0.5 text-sky-700 hover:bg-sky-100 disabled:cursor-not-allowed disabled:opacity-50"
+      disabled={connectingSolana}
+      onclick={() => onConnectSolana(availableSolanaWallets[0].name)}
+    >
+      {connectingSolana ? "Connecting..." : "Connect Solana"}
+    </button>
+  {:else if availableSolanaWallets.length > 1}
+    <div class="relative">
+      <button
+        class="cursor-pointer rounded bg-sky-50 px-2 py-0.5 text-sky-700 hover:bg-sky-100 disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={connectingSolana}
+        onclick={() => (showSolanaDropdown = !showSolanaDropdown)}
+      >
+        {connectingSolana ? "Connecting..." : "Connect Solana"}
+      </button>
+      {#if showSolanaDropdown}
+        <div
+          class="absolute top-full left-0 z-50 mt-1 rounded border border-gray-200 bg-white shadow-md"
+        >
+          {#each availableSolanaWallets as wallet (wallet.name)}
+            <button
+              class="block w-full cursor-pointer px-3 py-1.5 text-left text-xs whitespace-nowrap text-gray-700 hover:bg-sky-50"
+              onclick={() => onConnectSolana(wallet.name)}
+            >
+              {wallet.name}
+            </button>
+          {/each}
+        </div>
+      {/if}
+    </div>
   {:else}
-    <span class="rounded bg-gray-50 px-2 py-0.5 text-gray-400"> Solana: Not connected </span>
+    <span class="rounded bg-gray-50 px-2 py-0.5 text-gray-400"> Solana: No wallet </span>
   {/if}
 </div>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -171,10 +171,9 @@ export const chainList = (mainnet: boolean) => {
 export const chainIdList = (mainnet: boolean) => {
   const evm = chainList(mainnet).map((name) => chainMap[name].id);
   // Solana is not in `chainMap` (see the ChainMeta note below), so it is
-  // appended here. Devnet only until the live verification in
-  // tests/fixtures/solana/PREFLIGHT.md has been completed on mainnet.
-  if (mainnet) return evm;
-  return [...evm, Number(SOLANA_DEVNET_CHAIN_ID)];
+  // appended here. Both clusters run the same deployment, verified on chain:
+  // see the "Verified on chain" table in tests/fixtures/solana/PREFLIGHT.md.
+  return [...evm, Number(mainnet ? SOLANA_MAINNET_CHAIN_ID : SOLANA_DEVNET_CHAIN_ID)];
 };
 
 const chainEntries = chains.map((name) => [chainMap[name].id, chainMap[name]] as const);
@@ -319,6 +318,35 @@ export const coinList = (mainnet: boolean) => {
         name: "usdc",
         chainId: pharos.id,
         decimals: 6
+      },
+      // Solana mainnet. Mints stored as 32-byte hex, like the devnet entries
+      // below — `Token.address` is the app's internal identity, and `getCoin`
+      // compares Solana addresses whole rather than truncating to 20 bytes.
+      //
+      // Decimals and owning program read from mainnet on 2026-08-13: all three
+      // are legacy SPL Token (not Token-2022).
+      {
+        // EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+        address: solanaBase58ToBytes32("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),
+        name: "usdc",
+        chainId: Number(SOLANA_MAINNET_CHAIN_ID),
+        decimals: 6
+      },
+      {
+        // Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB
+        address: solanaBase58ToBytes32("Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"),
+        name: "usdt",
+        chainId: Number(SOLANA_MAINNET_CHAIN_ID),
+        decimals: 6
+      },
+      {
+        // Wrapped SOL. Native SOL is a valid OUTPUT via `native_fill` but never
+        // an input — the escrow's `open` has no native path — so wSOL is what
+        // an order can actually deposit.
+        address: solanaBase58ToBytes32("So11111111111111111111111111111111111111112"),
+        name: "wsol",
+        chainId: Number(SOLANA_MAINNET_CHAIN_ID),
+        decimals: 9
       }
     ] as const;
   else

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -169,7 +169,12 @@ export const chainList = (mainnet: boolean) => {
 };
 
 export const chainIdList = (mainnet: boolean) => {
-  return chainList(mainnet).map((name) => chainMap[name].id);
+  const evm = chainList(mainnet).map((name) => chainMap[name].id);
+  // Solana is not in `chainMap` (see the ChainMeta note below), so it is
+  // appended here. Devnet only until the live verification in
+  // tests/fixtures/solana/PREFLIGHT.md has been completed on mainnet.
+  if (mainnet) return evm;
+  return [...evm, Number(SOLANA_DEVNET_CHAIN_ID)];
 };
 
 const chainEntries = chains.map((name) => [chainMap[name].id, chainMap[name]] as const);
@@ -395,6 +400,30 @@ export const coinList = (mainnet: boolean) => {
         name: "usdc",
         chainId: arcTestnet.id,
         decimals: 6
+      },
+      // Solana devnet. Mints are stored as 32-byte hex, not base58, because
+      // `Token.address` is the app's internal identity everywhere — `getCoin`
+      // compares Solana addresses whole rather than truncating to 20 bytes.
+      //
+      // Devnet only for now: mainnet Solana is deliberately absent from
+      // `coinList` and `chainIdList` until the live checks in
+      // tests/fixtures/solana/PREFLIGHT.md pass and a small-value canary has
+      // settled end to end.
+      {
+        // 4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU
+        address: solanaBase58ToBytes32("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
+        name: "usdc",
+        chainId: Number(SOLANA_DEVNET_CHAIN_ID),
+        decimals: 6
+      },
+      {
+        // Wrapped SOL. Native SOL (the zero mint) is a valid OUTPUT via
+        // `native_fill`, but never an input: the escrow's `open` has no
+        // native path, so wSOL is what an order can actually deposit.
+        address: solanaBase58ToBytes32("So11111111111111111111111111111111111111112"),
+        name: "wsol",
+        chainId: Number(SOLANA_DEVNET_CHAIN_ID),
+        decimals: 9
       }
     ] as const;
 };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -17,11 +17,19 @@ import {
   tron
 } from "viem/chains";
 import {
+  SOLANA_DEVNET_CHAIN_ID,
+  SOLANA_MAINNET_CHAIN_ID,
+  SOLANA_OUTPUT_SETTLER_PDA,
+  SOLANA_POLYMER_ORACLE_PDA,
+  SOLANA_POLYMER_ORACLE_PROGRAM,
   TRON_MAINNET_INPUT_SETTLER,
   TRON_MAINNET_OUTPUT_SETTLER,
   TRON_MAINNET_POLYMER_ORACLE,
+  solanaBase58ToBytes32,
   tronBase58ToHex
 } from "@lifi/intent";
+import type { ChainType } from "$lib/utils/chainType";
+import { getChainType, isSolanaChain } from "$lib/utils/chainType";
 const routemeshApiKey: string | undefined =
   import.meta.env?.PUBLIC_ROUTEMESH_API_KEY?.trim() || undefined;
 
@@ -94,6 +102,14 @@ export const POLYMER_ORACLE: Partial<Record<number, `0x${string}`>> = {
   [bsc.id]: "0x008C3800F3Ad9b3B662d002E90Cc00000000eE17",
   [pharos.id]: "0x008C3800F3Ad9b3B662d002E90Cc00000000eE17",
   [tron.id]: TRON_MAINNET_POLYMER_ORACLE,
+  // Solana: this table answers "what is the input oracle for an order
+  // originating on this chain", so it holds the Polymer oracle *PDA*. The
+  // value a Solana *output* carries in `MandateOutput.oracle` is a different
+  // 32 bytes — the Polymer *program id*, exported below as
+  // SOLANA_POLYMER_OUTPUT_ORACLE. Swapping them yields an order that fills and
+  // can then never be proven. See tests/fixtures/solana/PREFLIGHT.md.
+  [Number(SOLANA_MAINNET_CHAIN_ID)]: SOLANA_POLYMER_ORACLE_PDA,
+  [Number(SOLANA_DEVNET_CHAIN_ID)]: SOLANA_POLYMER_ORACLE_PDA,
   // testnet — matches `main` after SOLV-695 (#62), which superseded the 0xC401b533… bucket.
   [sepolia.id]: "0xa70fE63Dd97e8e0Cb37241ed231FCBca87E99B72",
   [baseSepolia.id]: "0xa70fE63Dd97e8e0Cb37241ed231FCBca87E99B72",
@@ -440,9 +456,12 @@ export function getCoin(
 ) {
   const { name = undefined, address = undefined } = args;
   const chainId = normalizeChainId(args.chainId);
-  // ensure the address is ERC20-sized.
-  const concatedAddress =
-    "0x" + address?.replace("0x", "")?.slice(address.length - 42, address.length);
+  // EVM and Tron token ids are uint256-widened 20-byte addresses, so the low
+  // 20 bytes are the address. Solana mints are genuinely 32 bytes — truncating
+  // one would match the wrong token (or nothing) — so compare them whole.
+  const concatedAddress = isSolanaChain(chainId)
+    ? address
+    : "0x" + address?.replace("0x", "")?.slice(address.length - 42, address.length);
   for (const token of coinList(!isChainIdTestnet(chainId))) {
     // check chain first.
     if (token.chainId === chainId) {
@@ -469,16 +488,16 @@ function normalizeChainId(chainId: number | bigint | string) {
 
 export function isChainIdTestnet(chainId: number | bigint | string) {
   const normalized = normalizeChainId(chainId);
-  const chain = chainById[normalized];
-  if (!chain) throw new Error(`Chain is not known: ${normalized}`);
-  return chain.testnet;
+  const meta = chainMetaById[normalized];
+  if (!meta) throw new Error(`Chain is not known: ${normalized}`);
+  return meta.testnet;
 }
 
 export function getChainName(chainId: number | bigint | string) {
   const normalized = normalizeChainId(chainId);
-  const name = chainNameById[normalized];
-  if (!name) throw new Error(`Chain is not known: ${normalized}`);
-  return name;
+  const meta = chainMetaById[normalized];
+  if (!meta) throw new Error(`Chain is not known: ${normalized}`);
+  return meta.name;
 }
 
 export function formatTokenDecimals(
@@ -498,18 +517,30 @@ export function getOracle(verifier: Verifier, chainId: number | bigint | string)
   return undefined;
 }
 
+// Deliberately EVM-only: both return viem values that have no non-EVM
+// analogue. Callers handling a Tron or Solana chain must branch on chain type
+// BEFORE reaching these — the error names the chain type so a missing branch
+// is obvious from the message rather than surfacing as "chain not found".
 export function getChain(chainId: number | bigint | string) {
   const normalized = normalizeChainId(chainId);
   const chain = chainById[normalized];
-  if (!chain) throw new Error(`Could not find chain for chainId ${normalized}`);
+  if (!chain) throw new Error(`${describeNonEvmChain(normalized)} (getChain)`);
   return chain;
 }
 
 export function getClient(chainId: number | bigint | string) {
   const normalized = normalizeChainId(chainId);
   const client = clientsById[normalized];
-  if (!client) throw new Error(`Could not find client for chainId ${normalized}`);
+  if (!client) throw new Error(`${describeNonEvmChain(normalized)} (getClient)`);
   return client;
+}
+
+function describeNonEvmChain(normalized: number) {
+  const type = getChainType(normalized);
+  if (type !== "evm") {
+    return `Chain ${normalized} is a ${type} chain, not an EVM chain — callers must branch on chain type`;
+  }
+  return `Could not find chain for chainId ${normalized}`;
 }
 
 export const clients = {
@@ -639,6 +670,65 @@ export const chainById = Object.fromEntries(chainEntries) as Record<
 >;
 
 export const chainNameById = Object.fromEntries(chainNameEntries) as Record<number, ChainName>;
+
+// Non-EVM chains deliberately stay OUT of `chainMap`. `chainMap` feeds
+// `wagmiChains` in utils/wagmi.ts — a Solana entry there would show up in
+// every wallet's switch-chain menu — and `clientsById`, which would build a
+// viem public client with an EVM JSON-RPC transport pointed at a Solana RPC:
+// a client that type-checks and then fails at runtime. The `pharos` precedent
+// does not apply; Pharos is a real EVM chain with a real JSON-RPC endpoint.
+//
+// Instead, everything that is genuinely chain-agnostic — display name, testnet
+// flag, chain type — lives in this parallel registry, and the viem-only
+// accessors (`getChain`, `getClient`) keep throwing for non-EVM ids so callers
+// are forced to branch.
+/**
+ * The value `MandateOutput.oracle` must hold for a Solana OUTPUT — the Polymer
+ * *program id*, not the oracle PDA in `POLYMER_ORACLE` above.
+ * `oracle_polymer::submit` compares the fill's LocalAttestation consumer
+ * against its own program id.
+ */
+export const SOLANA_POLYMER_OUTPUT_ORACLE = SOLANA_POLYMER_ORACLE_PROGRAM;
+
+/** The value `MandateOutput.settler` must hold for a Solana output. */
+export const SOLANA_OUTPUT_SETTLER = SOLANA_OUTPUT_SETTLER_PDA;
+
+export type ChainMeta = {
+  id: number;
+  name: string;
+  testnet: boolean;
+  type: ChainType;
+};
+
+export const SOLANA_CHAIN_META: readonly ChainMeta[] = [
+  {
+    id: Number(SOLANA_MAINNET_CHAIN_ID),
+    name: "solana",
+    testnet: false,
+    type: "solana"
+  },
+  {
+    id: Number(SOLANA_DEVNET_CHAIN_ID),
+    name: "solanaDevnet",
+    testnet: true,
+    type: "solana"
+  }
+];
+
+export const chainMetaById: Record<number, ChainMeta> = {
+  ...Object.fromEntries(
+    chains.map((name) => [
+      chainMap[name].id,
+      {
+        id: chainMap[name].id,
+        name,
+        testnet: Boolean(chainMap[name].testnet),
+        type: getChainType(chainMap[name].id)
+      } satisfies ChainMeta
+    ])
+  ),
+  ...Object.fromEntries(SOLANA_CHAIN_META.map((meta) => [meta.id, meta]))
+};
 
 export const clientsById = Object.fromEntries(
   chains.map((name) => [chainMap[name].id, clients[name]])

--- a/src/lib/idl/index.ts
+++ b/src/lib/idl/index.ts
@@ -1,0 +1,38 @@
+import type { Idl } from "@coral-xyz/anchor";
+import inputSettlerEscrowIdl from "./input_settler_escrow.json";
+import outputSettlerSimpleIdl from "./output_settler_simple.json";
+import polymerIdl from "./polymer.json";
+import intentsProtocolIdl from "./intents_protocol.json";
+
+// The four IDLs are copied VERBATIM from catalyst-intent-svm/target/idl. Never
+// hand-edit them: `anchor build` regenerates them and any local tweak is lost
+// silently, taking the instruction encoding with it. Re-copy instead.
+//
+// Anchor's generated `Idl` type is stricter than what `resolveJsonModule`
+// infers from the literal (enum-ish fields widen to `string`), so the casts
+// below are unavoidable. They are safe precisely because the files are
+// unmodified compiler output.
+export const INPUT_SETTLER_ESCROW_IDL = inputSettlerEscrowIdl as unknown as Idl;
+export const OUTPUT_SETTLER_SIMPLE_IDL = outputSettlerSimpleIdl as unknown as Idl;
+export const POLYMER_IDL = polymerIdl as unknown as Idl;
+export const INTENTS_PROTOCOL_IDL = intentsProtocolIdl as unknown as Idl;
+
+// Program ids come from the TOP-LEVEL `address` field of each IDL — NOT from
+// `metadata`, which in Anchor >= 0.30 only carries name/version/spec. Reading
+// `metadata.address` yields `undefined` and silently derives every PDA from a
+// garbage program id.
+//
+// Devnet and mainnet share these ids (the programs are deployed to the same
+// vanity keypairs), so there is deliberately no per-chain lookup here.
+export const INPUT_SETTLER_ESCROW_PROGRAM_ID = inputSettlerEscrowIdl.address;
+export const OUTPUT_SETTLER_SIMPLE_PROGRAM_ID = outputSettlerSimpleIdl.address;
+export const POLYMER_PROGRAM_ID = polymerIdl.address;
+export const INTENTS_PROTOCOL_PROGRAM_ID = intentsProtocolIdl.address;
+
+/** Every deployed program id, keyed by the IDL's own `metadata.name`. */
+export const SOLANA_PROGRAM_IDS = {
+  input_settler_escrow: INPUT_SETTLER_ESCROW_PROGRAM_ID,
+  output_settler_simple: OUTPUT_SETTLER_SIMPLE_PROGRAM_ID,
+  polymer: POLYMER_PROGRAM_ID,
+  intents_protocol: INTENTS_PROTOCOL_PROGRAM_ID
+} as const;

--- a/src/lib/idl/input_settler_escrow.json
+++ b/src/lib/idl/input_settler_escrow.json
@@ -1,0 +1,917 @@
+{
+  "address": "LiFiRp8RM7nJUZyUYC9FPPpDr7sAy5XPfBN6ABzBgT7",
+  "metadata": {
+    "name": "input_settler_escrow",
+    "version": "0.0.0",
+    "spec": "0.1.0"
+  },
+  "instructions": [
+    {
+      "name": "finalise",
+      "docs": [
+        "Finalise a filled order and send the order's input funds to the order's solver.",
+        "`order` is the open order to be finalised.",
+        "`solve_params` are the solver parameters that filled each output (one per output). The first solver must be",
+        "the signer."
+      ],
+      "discriminator": [197, 63, 114, 249, 245, 72, 39, 132],
+      "accounts": [
+        {
+          "name": "solver",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "input_settler_escrow",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105, 110, 112, 117, 116, 95, 115, 101, 116, 116, 108, 101, 114, 95, 101, 115, 99,
+                  114, 111, 119
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "user"
+        },
+        {
+          "name": "sponsor",
+          "docs": ["via the `has_one = sponsor` constraint on `order_context`."],
+          "writable": true,
+          "relations": ["order_context"]
+        },
+        {
+          "name": "destination"
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "destination"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+                153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+              ]
+            }
+          }
+        },
+        {
+          "name": "order_context",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 100, 101, 114, 95, 99, 111, 110, 116, 101, 120, 116]
+              },
+              {
+                "kind": "arg",
+                "path": "order"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_pda_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order_context"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+                153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+              ]
+            }
+          }
+        },
+        {
+          "name": "mint",
+          "writable": true
+        },
+        {
+          "name": "intents_protocol_program",
+          "address": "LiFixdGLT5CMdLsHBvaijTXpPy4Uux9Y53SXkuR4HaK"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "order",
+          "type": {
+            "defined": {
+              "name": "StandardOrder"
+            }
+          }
+        },
+        {
+          "name": "solve_params",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "SolveParams"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize",
+      "docs": [
+        "Creates `input settler escrow` PDA.",
+        "`input settler escrow` PDA is used to store the chain identifier."
+      ],
+      "discriminator": [175, 175, 109, 31, 13, 152, 155, 237],
+      "accounts": [
+        {
+          "name": "deployer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "chain_id"
+        },
+        {
+          "name": "input_settler_escrow",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105, 110, 112, 117, 116, 95, 115, 101, 116, 116, 108, 101, 114, 95, 101, 115, 99,
+                  114, 111, 119
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "intents_protocol_program",
+          "address": "LiFixdGLT5CMdLsHBvaijTXpPy4Uux9Y53SXkuR4HaK"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "open",
+      "docs": [
+        "Open the given `StandardOrder`. The order input funds will be pulled from the provided",
+        "user signer account, and will be escrowed until the order is finalised or expired."
+      ],
+      "discriminator": [228, 220, 155, 71, 199, 189, 60, 45],
+      "accounts": [
+        {
+          "name": "sponsor",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user",
+          "signer": true
+        },
+        {
+          "name": "input_settler_escrow",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105, 110, 112, 117, 116, 95, 115, 101, 116, 116, 108, 101, 114, 95, 101, 115, 99,
+                  114, 111, 119
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "user_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "user"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+                153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+              ]
+            }
+          }
+        },
+        {
+          "name": "order_context",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 100, 101, 114, 95, 99, 111, 110, 116, 101, 120, 116]
+              },
+              {
+                "kind": "arg",
+                "path": "order"
+              }
+            ]
+          }
+        },
+        {
+          "name": "consumed_order",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 115, 117, 109, 101, 100, 95, 111, 114, 100, 101, 114]
+              },
+              {
+                "kind": "arg",
+                "path": "order"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_pda_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order_context"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+                153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+              ]
+            }
+          }
+        },
+        {
+          "name": "mint"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "order",
+          "type": {
+            "defined": {
+              "name": "StandardOrder"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "refund",
+      "docs": ["Refund an order and send the order's input funds back to the user."],
+      "discriminator": [2, 96, 183, 251, 63, 208, 46, 46],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user"
+        },
+        {
+          "name": "sponsor",
+          "docs": ["via the `has_one = sponsor` constraint on `order_context`."],
+          "writable": true,
+          "relations": ["order_context"]
+        },
+        {
+          "name": "input_settler_escrow",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105, 110, 112, 117, 116, 95, 115, 101, 116, 116, 108, 101, 114, 95, 101, 115, 99,
+                  114, 111, 119
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_context",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 100, 101, 114, 95, 99, 111, 110, 116, 101, 120, 116]
+              },
+              {
+                "kind": "arg",
+                "path": "order"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_pda_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order_context"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+                153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+              ]
+            }
+          }
+        },
+        {
+          "name": "user_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "user"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+                153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+              ]
+            }
+          }
+        },
+        {
+          "name": "mint",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "order",
+          "type": {
+            "defined": {
+              "name": "StandardOrder"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "refund_on_non_fill",
+      "docs": [
+        "Refund an order as soon as one of its outputs is proven not filled before the fill deadline,",
+        "sending the order's input funds back to the user. Does not require `expires` to have passed.",
+        "`order` is the open order to be refunded.",
+        "`output_index` is the index of the output proven not filled."
+      ],
+      "discriminator": [53, 164, 197, 243, 243, 43, 185, 108],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user"
+        },
+        {
+          "name": "sponsor",
+          "docs": ["via the `has_one = sponsor` constraint on `order_context`."],
+          "writable": true,
+          "relations": ["order_context"]
+        },
+        {
+          "name": "input_settler_escrow",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105, 110, 112, 117, 116, 95, 115, 101, 116, 116, 108, 101, 114, 95, 101, 115, 99,
+                  114, 111, 119
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_context",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 100, 101, 114, 95, 99, 111, 110, 116, 101, 120, 116]
+              },
+              {
+                "kind": "arg",
+                "path": "order"
+              }
+            ]
+          }
+        },
+        {
+          "name": "order_pda_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "order_context"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+                153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+              ]
+            }
+          }
+        },
+        {
+          "name": "user_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "user"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+                153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+              ]
+            }
+          }
+        },
+        {
+          "name": "mint",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "order",
+          "type": {
+            "defined": {
+              "name": "StandardOrder"
+            }
+          }
+        },
+        {
+          "name": "output_index",
+          "type": "u8"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "ChainId",
+      "discriminator": [203, 146, 201, 161, 230, 71, 157, 218]
+    },
+    {
+      "name": "ConsumedOrder",
+      "discriminator": [149, 74, 117, 35, 63, 65, 71, 140]
+    },
+    {
+      "name": "InputSettlerEscrowAccount",
+      "discriminator": [85, 112, 162, 215, 22, 13, 16, 72]
+    },
+    {
+      "name": "OrderContext",
+      "discriminator": [240, 83, 159, 216, 26, 11, 225, 229]
+    }
+  ],
+  "events": [
+    {
+      "name": "RefundedEvent",
+      "discriminator": [220, 3, 153, 244, 133, 189, 73, 119]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "SolversLengthMismatch",
+      "msg": "Solvers length mismatch."
+    },
+    {
+      "code": 6001,
+      "name": "FirstSolverNotInSolvers",
+      "msg": "First solver not in solvers."
+    },
+    {
+      "code": 6002,
+      "name": "FinaliseTxTooLarge",
+      "msg": "Finalise transaction would exceed Solana's max packet size."
+    },
+    {
+      "code": 6003,
+      "name": "OutputIndexOutOfBounds",
+      "msg": "Output index is out of bounds."
+    },
+    {
+      "code": 6004,
+      "name": "WrongAttestationCount",
+      "msg": "Exactly one attestation account is required."
+    }
+  ],
+  "types": [
+    {
+      "name": "ChainId",
+      "docs": ["Type used to store the chain id of the chain."],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "chain_id",
+            "type": "u128"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConsumedOrder",
+      "docs": [
+        "This account should be used to track if an order has already been opened by a user.",
+        "It should be unique to each order for each user.",
+        "This means a user should not be allowed to open the same order twice.",
+        "This account should always live on chain and not be closed."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": []
+      }
+    },
+    {
+      "name": "InputSettlerEscrowAccount",
+      "docs": [
+        "Represents the input settler implementation type.",
+        "Implements the `InputSettlerBaseTrait` trait."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "chain_id",
+            "type": "u128"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MandateInput",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MandateOutput",
+      "docs": [
+        "Defines the output state and where and how it should be filled.",
+        "DEV NOTES:",
+        "`oracle`: the implementation responsible for collecting the proof from settler on output chain",
+        "`settler`: the implementation on the output chain responsible for settling the output payment.",
+        "`callback_data`: the data to be passed to the callback function. MUST be empty if no callback is needed.",
+        "`context`: The output context for the output settlement, encoding order types or other information."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "settler",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "chain_id",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "token",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "amount",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "recipient",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "callback_data",
+            "type": "bytes"
+          },
+          {
+            "name": "context",
+            "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderContext",
+      "docs": [
+        "The context to opened as an account after opening an order.",
+        "`input_token` is the token account of the input \"Mint\".",
+        "`user` is the user who opened the order.",
+        "`sponsor` is the account that paid for the tx and the rent for this account.",
+        "The order_context rent refund is sent back to this account on finalise/refund.",
+        "It can be the user itself or a third party that paid on the user's behalf.",
+        "`bump` is the bump of this account to be reused during finalisation."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "input_token",
+            "type": "pubkey"
+          },
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "sponsor",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RefundedEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "order_id",
+            "type": {
+              "array": ["u8", 32]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SolveParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "solver",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "StandardOrder",
+      "docs": [
+        "Defines the standard order structure.",
+        "DEV NOTES:",
+        "`expires`: the timestamp the order should be filled before. IMPORTANT for solvers to check.",
+        "`fill_deadline`: the timestamp for the funds to be reached to `user` on the output chain. IMPORTANT for solvers to check.",
+        "`input_oracle`: the oracle responsible for collecting the proof from the output chain."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "nonce",
+            "type": "u128"
+          },
+          {
+            "name": "origin_chain_id",
+            "type": "u128"
+          },
+          {
+            "name": "expires",
+            "type": "u32"
+          },
+          {
+            "name": "fill_deadline",
+            "type": "u32"
+          },
+          {
+            "name": "input_oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "input",
+            "type": {
+              "defined": {
+                "name": "MandateInput"
+              }
+            }
+          },
+          {
+            "name": "outputs",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "MandateOutput"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/lib/idl/intents_protocol.json
+++ b/src/lib/idl/intents_protocol.json
@@ -1,0 +1,481 @@
+{
+  "address": "LiFixdGLT5CMdLsHBvaijTXpPy4Uux9Y53SXkuR4HaK",
+  "metadata": {
+    "name": "intents_protocol",
+    "version": "0.0.0",
+    "spec": "0.1.0"
+  },
+  "instructions": [
+    {
+      "name": "create_attestation",
+      "docs": ["Create an attestation for a remote chain."],
+      "discriminator": [49, 24, 67, 80, 12, 249, 96, 239],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "attestator",
+          "signer": true
+        },
+        {
+          "name": "attestation",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [97, 116, 116, 101, 115, 116, 97, 116, 105, 111, 110]
+              },
+              {
+                "kind": "account",
+                "path": "attestator"
+              },
+              {
+                "kind": "arg",
+                "path": "chain_id"
+              },
+              {
+                "kind": "arg",
+                "path": "source"
+              },
+              {
+                "kind": "arg",
+                "path": "application"
+              },
+              {
+                "kind": "arg",
+                "path": "payload_hash"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "chain_id",
+          "type": "u128"
+        },
+        {
+          "name": "source",
+          "type": {
+            "array": ["u8", 32]
+          }
+        },
+        {
+          "name": "application",
+          "type": {
+            "array": ["u8", 32]
+          }
+        },
+        {
+          "name": "payload_hash",
+          "type": {
+            "array": ["u8", 32]
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_local_attestation",
+      "docs": ["Create a local attestation based on the attestation data."],
+      "discriminator": [80, 127, 2, 116, 84, 21, 190, 38],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "attestator",
+          "signer": true
+        },
+        {
+          "name": "local_attestation",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 111, 99, 97, 108, 95, 97, 116, 116, 101, 115, 116, 97, 116, 105, 111, 110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "attestator"
+              },
+              {
+                "kind": "arg",
+                "path": "consumer"
+              },
+              {
+                "kind": "arg",
+                "path": "data_hash"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "consumer",
+          "type": {
+            "array": ["u8", 32]
+          }
+        },
+        {
+          "name": "data_hash",
+          "type": {
+            "array": ["u8", 32]
+          }
+        },
+        {
+          "name": "timestamp",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "set_chain_id",
+      "docs": ["Set the chain id of the chain."],
+      "discriminator": [57, 174, 29, 202, 84, 216, 7, 148],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "chain_id",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 104, 97, 105, 110, 95, 105, 100]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "chain_id",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "set_chain_mapping",
+      "docs": [
+        "Set the real chain id for a protocol chain id.",
+        "Dev:",
+        "`protocol_chain_id` is the protocol chain identifier.",
+        "`chain_id` is the real chain identifier."
+      ],
+      "discriminator": [174, 145, 44, 171, 203, 101, 230, 130],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "oracle",
+          "signer": true
+        },
+        {
+          "name": "chain_mapping",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 104, 97, 105, 110, 95, 109, 97, 112, 112, 105, 110, 103]
+              },
+              {
+                "kind": "account",
+                "path": "oracle"
+              },
+              {
+                "kind": "arg",
+                "path": "protocol_chain_id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "protocol_chain_id",
+          "type": "u128"
+        },
+        {
+          "name": "chain_id",
+          "type": "u128"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Attestation",
+      "discriminator": [152, 125, 183, 86, 36, 146, 121, 73]
+    },
+    {
+      "name": "ChainId",
+      "discriminator": [203, 146, 201, 161, 230, 71, 157, 218]
+    },
+    {
+      "name": "ChainMapping",
+      "discriminator": [81, 78, 77, 209, 44, 206, 85, 169]
+    },
+    {
+      "name": "LocalAttestation",
+      "discriminator": [173, 247, 101, 168, 96, 238, 17, 22]
+    }
+  ],
+  "events": [
+    {
+      "name": "AttestationCreatedEvent",
+      "discriminator": [157, 10, 208, 90, 87, 62, 175, 26]
+    },
+    {
+      "name": "ChainIdConfiguredEvent",
+      "discriminator": [92, 39, 243, 11, 30, 97, 80, 219]
+    },
+    {
+      "name": "ChainMapConfiguredEvent",
+      "discriminator": [157, 35, 137, 206, 200, 100, 92, 171]
+    },
+    {
+      "name": "LocalAttestationCreatedEvent",
+      "discriminator": [173, 59, 45, 101, 206, 241, 125, 25]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidOracle",
+      "msg": "Invalid oracle"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidLocalAttestationTimestamp",
+      "msg": "Invalid local attestation timestamp"
+    },
+    {
+      "code": 6002,
+      "name": "InvalidChainMappingAccount",
+      "msg": "Invalid chain mapping account"
+    },
+    {
+      "code": 6003,
+      "name": "InvalidLocalAttestationAccount",
+      "msg": "Invalid local attestation account"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidAttestationAccount",
+      "msg": "Invalid attestation account"
+    },
+    {
+      "code": 6005,
+      "name": "InvalidChainIdAccount",
+      "msg": "Invalid chain id account"
+    }
+  ],
+  "types": [
+    {
+      "name": "Attestation",
+      "docs": [
+        "Type used to indicate that some data from another chain data has been attested.",
+        "It is derived from the attestation data as seeds"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AttestationCreatedEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "attestator",
+            "type": "pubkey"
+          },
+          {
+            "name": "chain_id",
+            "type": "u128"
+          },
+          {
+            "name": "source",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "application",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "payload_hash",
+            "type": {
+              "array": ["u8", 32]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ChainId",
+      "docs": ["Type used to store the chain id of the chain."],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "chain_id",
+            "type": "u128"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ChainIdConfiguredEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "chain_id_account_address",
+            "type": "pubkey"
+          },
+          {
+            "name": "chain_id",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ChainMapConfiguredEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_chain_id",
+            "type": "u128"
+          },
+          {
+            "name": "chain_id",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ChainMapping",
+      "docs": [
+        "Type used to map a protocol chain identifier to a custom configured chain identifier."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "chain_id",
+            "type": "u128"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LocalAttestation",
+      "docs": [
+        "Type used to indicate that some data has been attested by an attestator.",
+        "It is derived from the local attestation data as seeds",
+        "`timestamp` is the timestamp of the local attestation was created at.",
+        "It is stored within the account since it cannot be known before creation."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "timestamp",
+            "type": "u32"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LocalAttestationCreatedEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "attestator",
+            "type": "pubkey"
+          },
+          {
+            "name": "consumer",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": "u32"
+          },
+          {
+            "name": "data_hash",
+            "type": {
+              "array": ["u8", 32]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/lib/idl/output_settler_simple.json
+++ b/src/lib/idl/output_settler_simple.json
@@ -1,0 +1,538 @@
+{
+  "address": "LiFiEDFjz5x1jJe9gSXNDHQW4dWt4yLXdp2VN4EiQUt",
+  "metadata": {
+    "name": "output_settler_simple",
+    "version": "0.0.0",
+    "spec": "0.1.0"
+  },
+  "instructions": [
+    {
+      "name": "attest_not_filled",
+      "docs": [
+        "Permissionlessly attest that an order output was NOT filled before its fill deadline.",
+        "`order_id` is the input chain order identifier. Is not validated.",
+        "`output` is the output mandate that was not filled. Must target this settler on this chain.",
+        "`fill_deadline` is the fill deadline of the order; the current time must strictly exceed it."
+      ],
+      "discriminator": [93, 101, 204, 135, 226, 64, 5, 137],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": ["Permissionless payer funding the created `LocalAttestation` account."],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "output_settler_simple",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111, 117, 116, 112, 117, 116, 95, 115, 101, 116, 116, 108, 101, 114, 95, 115, 105,
+                  109, 112, 108, 101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "fill_id",
+          "docs": [
+            "The `FillId` PDA for this output. It is created (`init`) during a fill, so it must be",
+            "un-initialised (system-owned, empty) here to prove no fill exists. The seed derivation is",
+            "owned by `output_settler_simple` (same scheme as `fill.rs`). Not `init`'d — only its address",
+            "is asserted so the account existence check inside the base trait is meaningful."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "arg",
+                "path": "order_id"
+              },
+              {
+                "kind": "arg",
+                "path": "output"
+              }
+            ]
+          }
+        },
+        {
+          "name": "local_attestation",
+          "writable": true
+        },
+        {
+          "name": "intents_protocol_program",
+          "address": "LiFixdGLT5CMdLsHBvaijTXpPy4Uux9Y53SXkuR4HaK"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "order_id",
+          "type": {
+            "array": ["u8", 32]
+          }
+        },
+        {
+          "name": "mandate_output",
+          "type": {
+            "defined": {
+              "name": "MandateOutput"
+            }
+          }
+        },
+        {
+          "name": "fill_deadline",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "fill",
+      "docs": [
+        "Fill an order output.",
+        "`order_id` is the input chain order identifier. Is not validated.",
+        "`output` is the output mandate to be filled.",
+        "`fill_deadline` is the maximum time in seconds the fill may be executed at.",
+        "`filler_data` contains the solver identifier sent to the input chain."
+      ],
+      "discriminator": [168, 96, 183, 163, 92, 10, 40, 160],
+      "accounts": [
+        {
+          "name": "filler",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "recipient",
+          "writable": true
+        },
+        {
+          "name": "output_settler_simple",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111, 117, 116, 112, 117, 116, 95, 115, 101, 116, 116, 108, 101, 114, 95, 115, 105,
+                  109, 112, 108, 101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "filler_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "filler"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+                153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+              ]
+            }
+          }
+        },
+        {
+          "name": "recipient_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "recipient"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+                153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+              ]
+            }
+          }
+        },
+        {
+          "name": "mint"
+        },
+        {
+          "name": "fill_id",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "arg",
+                "path": "order_id"
+              },
+              {
+                "kind": "arg",
+                "path": "output"
+              }
+            ]
+          }
+        },
+        {
+          "name": "local_attestation",
+          "writable": true
+        },
+        {
+          "name": "intents_protocol_program",
+          "address": "LiFixdGLT5CMdLsHBvaijTXpPy4Uux9Y53SXkuR4HaK"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "order_id",
+          "type": {
+            "array": ["u8", 32]
+          }
+        },
+        {
+          "name": "mandate_output",
+          "type": {
+            "defined": {
+              "name": "MandateOutput"
+            }
+          }
+        },
+        {
+          "name": "fill_deadline",
+          "type": "u64"
+        },
+        {
+          "name": "filler_data",
+          "type": "bytes"
+        }
+      ],
+      "returns": "pubkey"
+    },
+    {
+      "name": "initialize",
+      "docs": [
+        "Creates `output settler simple` PDA.",
+        "`output settler simple` PDA is used to store the chain identifier."
+      ],
+      "discriminator": [175, 175, 109, 31, 13, 152, 155, 237],
+      "accounts": [
+        {
+          "name": "deployer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "chain_id"
+        },
+        {
+          "name": "output_settler_simple",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111, 117, 116, 112, 117, 116, 95, 115, 101, 116, 116, 108, 101, 114, 95, 115, 105,
+                  109, 112, 108, 101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "intents_protocol_program",
+          "address": "LiFixdGLT5CMdLsHBvaijTXpPy4Uux9Y53SXkuR4HaK"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [],
+      "returns": "pubkey"
+    },
+    {
+      "name": "native_fill",
+      "docs": [
+        "Fill an order output with native SOL.",
+        "`order_id` is the input chain order identifier. Is not validated.",
+        "`output` is the output mandate to be filled.",
+        "`fill_deadline` is the maximum time in seconds the fill may be executed at.",
+        "`filler_data` contains the solver identifier sent to the input chain."
+      ],
+      "discriminator": [49, 10, 255, 151, 120, 148, 73, 30],
+      "accounts": [
+        {
+          "name": "filler",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "recipient",
+          "writable": true
+        },
+        {
+          "name": "output_settler_simple",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111, 117, 116, 112, 117, 116, 95, 115, 101, 116, 116, 108, 101, 114, 95, 115, 105,
+                  109, 112, 108, 101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "fill_id",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "arg",
+                "path": "order_id"
+              },
+              {
+                "kind": "arg",
+                "path": "output"
+              }
+            ]
+          }
+        },
+        {
+          "name": "local_attestation",
+          "writable": true
+        },
+        {
+          "name": "intents_protocol_program",
+          "address": "LiFixdGLT5CMdLsHBvaijTXpPy4Uux9Y53SXkuR4HaK"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "order_id",
+          "type": {
+            "array": ["u8", 32]
+          }
+        },
+        {
+          "name": "mandate_output",
+          "type": {
+            "defined": {
+              "name": "MandateOutput"
+            }
+          }
+        },
+        {
+          "name": "fill_deadline",
+          "type": "u64"
+        },
+        {
+          "name": "filler_data",
+          "type": "bytes"
+        }
+      ],
+      "returns": "pubkey"
+    }
+  ],
+  "accounts": [
+    {
+      "name": "ChainId",
+      "discriminator": [203, 146, 201, 161, 230, 71, 157, 218]
+    },
+    {
+      "name": "FillId",
+      "discriminator": [94, 253, 27, 18, 238, 120, 79, 78]
+    },
+    {
+      "name": "OutputSettlerSimpleAccount",
+      "discriminator": [227, 35, 185, 166, 177, 53, 143, 129]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "NotImplemented",
+      "msg": "Order type not implemented."
+    },
+    {
+      "code": 6001,
+      "name": "AmountTooLarge",
+      "msg": "Amount is too large."
+    },
+    {
+      "code": 6002,
+      "name": "ArithmeticOverflow",
+      "msg": "Arithmetic overflow."
+    },
+    {
+      "code": 6003,
+      "name": "InvalidFillerData",
+      "msg": "Invalid filler data."
+    },
+    {
+      "code": 6004,
+      "name": "InvalidContextDataLength",
+      "msg": "Invalid context data length."
+    },
+    {
+      "code": 6005,
+      "name": "ExclusiveTo",
+      "msg": "Order is exclusive to another solver or time passed."
+    },
+    {
+      "code": 6006,
+      "name": "ZeroValue",
+      "msg": "Zero value is not allowed."
+    }
+  ],
+  "types": [
+    {
+      "name": "ChainId",
+      "docs": ["Type used to store the chain id of the chain."],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "chain_id",
+            "type": "u128"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FillId",
+      "docs": ["Created during fill to ensure no double fill for the same output."],
+      "type": {
+        "kind": "struct",
+        "fields": []
+      }
+    },
+    {
+      "name": "MandateOutput",
+      "docs": [
+        "Defines the output state and where and how it should be filled.",
+        "DEV NOTES:",
+        "`oracle`: the implementation responsible for collecting the proof from settler on output chain",
+        "`settler`: the implementation on the output chain responsible for settling the output payment.",
+        "`callback_data`: the data to be passed to the callback function. MUST be empty if no callback is needed.",
+        "`context`: The output context for the output settlement, encoding order types or other information."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "settler",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "chain_id",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "token",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "amount",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "recipient",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "callback_data",
+            "type": "bytes"
+          },
+          {
+            "name": "context",
+            "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OutputSettlerSimpleAccount",
+      "docs": [
+        "Represents the output settler implementation type.",
+        "Implements the `OutputSettlerBaseTrait` trait."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "chain_id",
+            "type": "u128"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/lib/idl/polymer.json
+++ b/src/lib/idl/polymer.json
@@ -1,0 +1,591 @@
+{
+  "address": "LiFiBtfyPT1DnTHTAeZ2rwr5RgMrThwA5kt7KGT5nBV",
+  "metadata": {
+    "name": "polymer",
+    "version": "0.0.0",
+    "spec": "0.1.0"
+  },
+  "docs": [
+    "There are two ways to receive a remote proof, both ending in",
+    "[`receive_attest`] which reads the validated event data from the prover's",
+    "`result_account` and registers the attestation:",
+    "",
+    "1. **Single step** — call [`receive_load_proof`] with the full proof. It",
+    "runs the prover's `create_accounts`, `load_proof` and `validate_event`",
+    "CPIs in one transaction, then `receive_attest` finalises it. Use this",
+    "when the proof fits within a single Solana transaction.",
+    "",
+    "2. **Three steps** — for proofs too large to fit in a single Solana",
+    "transaction, the load is chunked across multiple transactions:",
+    "1. [`create_polymer_accounts`] — create the prover's `cache`/`result` PDAs.",
+    "2. [`load_proof_chunk`] — append one chunk of the proof; call once per",
+    "chunk until the full proof is loaded (the prover extends the cache).",
+    "3. [`validate_event`] — validate the accumulated proof in the cache.",
+    "Then `receive_attest` finalises it as above."
+  ],
+  "instructions": [
+    {
+      "name": "create_polymer_accounts",
+      "docs": [
+        "Chunked receive step 1: create the polymer prover's `cache` and",
+        "`result` scratch PDAs. Use this path instead of `receive_load_proof`",
+        "when the proof is too large to load in a single transaction."
+      ],
+      "discriminator": [238, 43, 4, 23, 70, 95, 159, 84],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "oracle_polymer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [112, 111, 108, 121, 109, 101, 114]
+              }
+            ]
+          }
+        },
+        {
+          "name": "polymer_prover_program"
+        },
+        {
+          "name": "cache_account",
+          "writable": true
+        },
+        {
+          "name": "result_account",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize",
+      "docs": [
+        "Initializes the `oracle_polymer` account. Creates `oracle_polymer` PDA and sets the `polymer_prover_id`.",
+        "`oracle_polymer` PDA is used to store the chain identifier and the owner address."
+      ],
+      "discriminator": [175, 175, 109, 31, 13, 152, 155, 237],
+      "accounts": [
+        {
+          "name": "deployer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "chain_id"
+        },
+        {
+          "name": "oracle_polymer",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [112, 111, 108, 121, 109, 101, 114]
+              }
+            ]
+          }
+        },
+        {
+          "name": "intents_protocol_program",
+          "address": "LiFixdGLT5CMdLsHBvaijTXpPy4Uux9Y53SXkuR4HaK"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "polymer_prover_id",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "load_proof_chunk",
+      "docs": [
+        "Chunked receive step 2: append a single chunk of the proof into the",
+        "prover's `cache` PDA. Call repeatedly until the full proof is loaded."
+      ],
+      "discriminator": [252, 35, 79, 22, 76, 152, 132, 74],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "oracle_polymer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [112, 111, 108, 121, 109, 101, 114]
+              }
+            ]
+          }
+        },
+        {
+          "name": "polymer_prover_program"
+        },
+        {
+          "name": "cache_account",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "proof_chunk",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "receive_attest",
+      "docs": [
+        "Step 2 of receive: read the validated event data left by",
+        "`receive_load_proof`, register the attestation, and close the polymer",
+        "prover's scratch PDAs."
+      ],
+      "discriminator": [112, 136, 131, 35, 95, 206, 124, 161],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "oracle_polymer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [112, 111, 108, 121, 109, 101, 114]
+              }
+            ]
+          }
+        },
+        {
+          "name": "polymer_prover_program"
+        },
+        {
+          "name": "chain_mapping"
+        },
+        {
+          "name": "cache_account",
+          "writable": true
+        },
+        {
+          "name": "internal",
+          "writable": true
+        },
+        {
+          "name": "result_account",
+          "writable": true
+        },
+        {
+          "name": "attestation",
+          "writable": true
+        },
+        {
+          "name": "intents_protocol_program",
+          "address": "LiFixdGLT5CMdLsHBvaijTXpPy4Uux9Y53SXkuR4HaK"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "receive_load_proof",
+      "docs": [
+        "Step 1 of receive: load and validate a single proof via the polymer",
+        "prover. Leaves the validated event data in `result_account` for",
+        "`receive_attest` to consume in a follow-up tx."
+      ],
+      "discriminator": [220, 77, 15, 159, 191, 141, 155, 51],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "oracle_polymer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [112, 111, 108, 121, 109, 101, 114]
+              }
+            ]
+          }
+        },
+        {
+          "name": "polymer_prover_program"
+        },
+        {
+          "name": "cache_account",
+          "writable": true
+        },
+        {
+          "name": "internal",
+          "writable": true
+        },
+        {
+          "name": "result_account",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "proof",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "set_chain_mapping",
+      "docs": [
+        "Maps polymer chain id to a configured custom chain id.",
+        "Can only be called by the owner of the `oracle_polymer` account.",
+        "Each mapping may only be set once."
+      ],
+      "discriminator": [174, 145, 44, 171, 203, 101, 230, 130],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "oracle_polymer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [112, 111, 108, 121, 109, 101, 114]
+              }
+            ]
+          }
+        },
+        {
+          "name": "chain_mapping",
+          "writable": true
+        },
+        {
+          "name": "intents_protocol_program",
+          "address": "LiFixdGLT5CMdLsHBvaijTXpPy4Uux9Y53SXkuR4HaK"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "protocol_chain_id",
+          "type": "u128"
+        },
+        {
+          "name": "chain_id",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "submit",
+      "docs": [
+        "Validates the proofs and emits logs in the form of `Prove: program: {0x...}, {0x...}`."
+      ],
+      "discriminator": [88, 166, 102, 181, 162, 127, 170, 48],
+      "accounts": [
+        {
+          "name": "submitter",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "oracle_polymer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [112, 111, 108, 121, 109, 101, 114]
+              }
+            ]
+          }
+        },
+        {
+          "name": "intents_protocol_program",
+          "address": "LiFixdGLT5CMdLsHBvaijTXpPy4Uux9Y53SXkuR4HaK"
+        }
+      ],
+      "args": [
+        {
+          "name": "source",
+          "type": "pubkey"
+        },
+        {
+          "name": "fill_descriptions",
+          "type": {
+            "vec": "bytes"
+          }
+        }
+      ]
+    },
+    {
+      "name": "validate_event",
+      "docs": [
+        "Chunked receive step 3: validate the proof accumulated in the `cache`",
+        "PDA, leaving the validated event data in `result_account` for",
+        "`receive_attest` to consume in a follow-up tx."
+      ],
+      "discriminator": [66, 249, 207, 221, 30, 87, 27, 129],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "oracle_polymer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [112, 111, 108, 121, 109, 101, 114]
+              }
+            ]
+          }
+        },
+        {
+          "name": "polymer_prover_program"
+        },
+        {
+          "name": "cache_account",
+          "writable": true
+        },
+        {
+          "name": "internal",
+          "writable": true
+        },
+        {
+          "name": "result_account",
+          "writable": true
+        }
+      ],
+      "args": []
+    }
+  ],
+  "accounts": [
+    {
+      "name": "ChainId",
+      "discriminator": [203, 146, 201, 161, 230, 71, 157, 218]
+    },
+    {
+      "name": "ChainMapping",
+      "discriminator": [81, 78, 77, 209, 44, 206, 85, 169]
+    },
+    {
+      "name": "OraclePolymer",
+      "discriminator": [30, 219, 153, 176, 126, 163, 80, 138]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidChainId",
+      "msg": "Invalid chain id"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidProof",
+      "msg": "Invalid proof"
+    },
+    {
+      "code": 6002,
+      "name": "InvalidOutputChainId",
+      "msg": "Invalid output chain id"
+    },
+    {
+      "code": 6003,
+      "name": "Unauthorized",
+      "msg": "Unauthorized mapping creation"
+    },
+    {
+      "code": 6004,
+      "name": "CouldNotDecodeSolver",
+      "msg": "Could not decode solver"
+    },
+    {
+      "code": 6005,
+      "name": "CouldNotDecodeTimestamp",
+      "msg": "Could not decode timestamp"
+    },
+    {
+      "code": 6006,
+      "name": "CouldNotDecodeMandateOutputFieldsTuple",
+      "msg": "Could not decode mandate output fields tuple"
+    },
+    {
+      "code": 6007,
+      "name": "CouldNotDecodeOracle",
+      "msg": "Could not decode oracle"
+    },
+    {
+      "code": 6008,
+      "name": "CouldNotDecodeSettler",
+      "msg": "Could not decode settler"
+    },
+    {
+      "code": 6009,
+      "name": "CouldNotDecodeChainId",
+      "msg": "Could not decode chain id"
+    },
+    {
+      "code": 6010,
+      "name": "CouldNotDecodeToken",
+      "msg": "Could not decode token"
+    },
+    {
+      "code": 6011,
+      "name": "CouldNotDecodeAmount",
+      "msg": "Could not decode amount"
+    },
+    {
+      "code": 6012,
+      "name": "CouldNotDecodeRecipient",
+      "msg": "Could not decode recipient"
+    },
+    {
+      "code": 6013,
+      "name": "CouldNotDecodeCallbackData",
+      "msg": "Could not decode callback data"
+    },
+    {
+      "code": 6014,
+      "name": "CouldNotDecodeContext",
+      "msg": "Could not decode context"
+    },
+    {
+      "code": 6015,
+      "name": "CouldNotDecodeFinalAmount",
+      "msg": "Could not decode final amount"
+    },
+    {
+      "code": 6016,
+      "name": "CouldNotConvertU256ToU64",
+      "msg": "Could not convert u128 to u64"
+    },
+    {
+      "code": 6017,
+      "name": "CouldNotConvertU256ToU128",
+      "msg": "Could not convert u256 to u128"
+    },
+    {
+      "code": 6018,
+      "name": "CouldNotConvertU256ToU32",
+      "msg": "Could not convert u256 to u32"
+    },
+    {
+      "code": 6019,
+      "name": "NoAttestationsProvided",
+      "msg": "No attestations provided"
+    },
+    {
+      "code": 6020,
+      "name": "NotCorrectEncodedTypes",
+      "msg": "Not correct encoded types"
+    },
+    {
+      "code": 6021,
+      "name": "WrongEventSignature",
+      "msg": "Event signature topic does not match OutputFilled or OutputNotFilled"
+    }
+  ],
+  "types": [
+    {
+      "name": "ChainId",
+      "docs": ["Type used to store the chain id of the chain."],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "chain_id",
+            "type": "u128"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ChainMapping",
+      "docs": [
+        "Type used to map a protocol chain identifier to a custom configured chain identifier."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "chain_id",
+            "type": "u128"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OraclePolymer",
+      "docs": [
+        "Represents the `Polymer` oracle implementation type.",
+        "Implements the `OracleBaseTrait`, `InputOracleBaseTrait` and `OutputOracleBaseTrait` traits.",
+        "`polymer_prover_id` is the program id of the polymer prover program.",
+        "`owner` is the owner of the PolymerOracle. The only address to create mappings."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "polymer_prover_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "chain_id",
+            "type": "u128"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/lib/libraries/coreDeps.ts
+++ b/src/lib/libraries/coreDeps.ts
@@ -3,10 +3,12 @@ import {
   INPUT_SETTLER_COMPACT_LIFI,
   MULTICHAIN_INPUT_SETTLER_COMPACT,
   POLYMER_ORACLE,
+  SOLANA_OUTPUT_SETTLER,
+  SOLANA_POLYMER_OUTPUT_ORACLE,
   TRON_MAINNET_OUTPUT_SETTLER,
   WORMHOLE_ORACLE
 } from "$lib/config";
-import { isTronChain } from "$lib/utils/chainType";
+import { isSolanaChain, isTronChain } from "$lib/utils/chainType";
 import type { IntentDeps, OrderContainerValidationDeps } from "@lifi/intent";
 import { TRON_LEGACY_OUTPUT_SETTLERS, TRON_LEGACY_POLYMER_ORACLES } from "@lifi/intent";
 
@@ -48,6 +50,8 @@ export const orderValidationDeps: OrderContainerValidationDeps = {
           TRON_MAINNET_OUTPUT_SETTLER,
           ...(TRON_LEGACY_OUTPUT_SETTLERS[chainId.toString()] ?? [])
         );
+      } else if (isSolanaChain(chainId)) {
+        allowed.push(SOLANA_OUTPUT_SETTLER);
       } else {
         allowed.push(COIN_FILLER);
       }
@@ -63,12 +67,21 @@ export const orderValidationDeps: OrderContainerValidationDeps = {
     if (sameChainFill) {
       // output.oracle is the output settler; the library no longer accepts
       // COIN_FILLER implicitly, so the EVM case must return it explicitly.
-      return isTronChain(outputChainId)
-        ? [
-            TRON_MAINNET_OUTPUT_SETTLER,
-            ...(TRON_LEGACY_OUTPUT_SETTLERS[outputChainId.toString()] ?? [])
-          ]
-        : [COIN_FILLER];
+      if (isTronChain(outputChainId)) {
+        return [
+          TRON_MAINNET_OUTPUT_SETTLER,
+          ...(TRON_LEGACY_OUTPUT_SETTLERS[outputChainId.toString()] ?? [])
+        ];
+      }
+      return isSolanaChain(outputChainId) ? [SOLANA_OUTPUT_SETTLER] : [COIN_FILLER];
+    }
+    // A Solana OUTPUT is identified to Polymer by the oracle PROGRAM ID, not
+    // by the input chain's oracle. The rule below only holds because
+    // PolymerOracle is CREATE2-identical across EVM chains; on Solana,
+    // oracle_polymer::submit compares against its own program id, so an order
+    // built the EVM way fills and can then never be proven.
+    if (isSolanaChain(outputChainId)) {
+      return [SOLANA_POLYMER_OUTPUT_ORACLE];
     }
     const allowed: `0x${string}`[] = [];
     // Polymer stores proofs under the INPUT chain's oracle, so output.oracle
@@ -94,11 +107,14 @@ export const orderValidationDeps: OrderContainerValidationDeps = {
         ...(TRON_LEGACY_OUTPUT_SETTLERS[chainId.toString()] ?? [])
       ];
     }
+    if (isSolanaChain(chainId)) return [SOLANA_OUTPUT_SETTLER];
     return [COIN_FILLER];
   },
   supportsNativeOutput(chainId) {
-    // Native (zero-token) outputs are only enabled for Tron in this release;
-    // the deployed Tron output settler's fillOrderOutputs is payable.
-    return isTronChain(chainId);
+    // Tron's deployed fillOrderOutputs is payable; Solana has a dedicated
+    // `native_fill` for zero-token outputs. Note this covers native OUTPUTS
+    // only — a Solana order still cannot take a native SOL *input*, because
+    // `open` has no such path, and that is rejected at issuance instead.
+    return isTronChain(chainId) || isSolanaChain(chainId);
   }
 };

--- a/src/lib/libraries/fillEvent.ts
+++ b/src/lib/libraries/fillEvent.ts
@@ -4,6 +4,7 @@ import { bytes32ToAddress } from "@lifi/intent";
 import { getClient } from "$lib/config";
 import { COIN_FILLER_ABI } from "$lib/abi/outputsettler";
 import { isSolanaChain, isTronChain } from "$lib/utils/chainType";
+import type { TxRef } from "$lib/utils/txRef";
 import { OUTPUT_SETTLER_SIMPLE_PROGRAM_ID } from "$lib/idl";
 import { getSolanaReads } from "$lib/solana/client";
 import { findOutputFilledLog } from "$lib/solana/events";
@@ -35,7 +36,7 @@ const FILL_DETAILS_TTL_MS = 300_000; // immutable once mined — cache generousl
 export async function getFillDetails(
   orderId: `0x${string}`,
   output: MandateOutput,
-  fillTransactionHash: `0x${string}`
+  fillTransactionHash: TxRef
 ): Promise<FillDetails> {
   const cacheKey = `fill-details:${orderId}:${outputStructHash(output)}:${fillTransactionHash}`;
   return getOrFetchRpc(
@@ -76,8 +77,9 @@ export async function getFillDetails(
         return { solver, timestamp };
       }
 
+      // Reached only on the EVM branch, where a TxRef is a 0x hash.
       const receipt = await getClient(output.chainId).getTransactionReceipt({
-        hash: fillTransactionHash
+        hash: fillTransactionHash as `0x${string}`
       });
       if (receipt.status !== "success") {
         throw new Error(`Fill transaction ${fillTransactionHash} reverted`);

--- a/src/lib/libraries/fillEvent.ts
+++ b/src/lib/libraries/fillEvent.ts
@@ -3,7 +3,10 @@ import type { MandateOutput } from "@lifi/intent";
 import { bytes32ToAddress } from "@lifi/intent";
 import { getClient } from "$lib/config";
 import { COIN_FILLER_ABI } from "$lib/abi/outputsettler";
-import { isTronChain } from "$lib/utils/chainType";
+import { isSolanaChain, isTronChain } from "$lib/utils/chainType";
+import { OUTPUT_SETTLER_SIMPLE_PROGRAM_ID } from "$lib/idl";
+import { getSolanaReads } from "$lib/solana/client";
+import { findOutputFilledLog } from "$lib/solana/events";
 import { getTronReads } from "$lib/tron/client";
 import {
   decodeOutputFilledFromTronLogs,
@@ -38,6 +41,25 @@ export async function getFillDetails(
   return getOrFetchRpc(
     cacheKey,
     async () => {
+      if (isSolanaChain(output.chainId)) {
+        const reads = await getSolanaReads(output.chainId);
+        // "finalized", not "confirmed": this result is cached as immutable, so
+        // it must never come from a slot that can still be dropped.
+        const tx = await reads.getTransaction(fillTransactionHash, { commitment: "finalized" });
+        if (!tx?.meta) {
+          throw new Error("Solana fill is not finalized yet — retry in a few seconds");
+        }
+        if (tx.meta.err) {
+          throw new Error(`Solana fill transaction reverted: ${JSON.stringify(tx.meta.err)}`);
+        }
+        const { solver, timestamp } = findOutputFilledLog(tx.meta.logMessages ?? [], {
+          programId: OUTPUT_SETTLER_SIMPLE_PROGRAM_ID,
+          orderId,
+          output
+        });
+        return { solver, timestamp };
+      }
+
       if (isTronChain(output.chainId)) {
         const reads = await getTronReads();
         // Deliberately the solidity node: this result is cached as immutable,

--- a/src/lib/libraries/fillEvent.ts
+++ b/src/lib/libraries/fillEvent.ts
@@ -44,11 +44,26 @@ export async function getFillDetails(
     async () => {
       if (isSolanaChain(output.chainId)) {
         const reads = await getSolanaReads(output.chainId);
-        // "finalized", not "confirmed": this result is cached as immutable, so
-        // it must never come from a slot that can still be dropped.
-        const tx = await reads.getTransaction(fillTransactionHash, { commitment: "finalized" });
+        // "confirmed", deliberately: `signAndSend` has already waited for this
+        // commitment and read the transaction back, so by the time we get here
+        // the read costs nothing. Waiting for "finalized" instead added ~13s
+        // (about 32 slots) to every fill before the proof could even be built.
+        //
+        // What that trades away: a confirmed slot can in principle still be
+        // dropped, and the result below is memoised for the session. If that
+        // ever happened the cached timestamp would be stale and every retry
+        // would fail with InvalidLocalAttestationTimestamp until a reload. It
+        // cannot mint a false proof — `validate_payload` compares against the
+        // on-chain LocalAttestation — so the failure is loud, not silent.
+        const tx = await reads.getTransaction(fillTransactionHash, { commitment: "confirmed" });
         if (!tx?.meta) {
-          throw new Error("Solana fill is not finalized yet — retry in a few seconds");
+          // Deliberately does not blame finality. An empty result means "this
+          // RPC does not have the transaction", which is just as often a
+          // pruned history or a load-balanced node that has not caught up as
+          // it is a fill that has not landed.
+          throw new Error(
+            `Solana RPC returned no transaction for ${fillTransactionHash}. It may not have landed yet, or this endpoint may not carry it — retry, and if it persists check the fill signature.`
+          );
         }
         if (tx.meta.err) {
           throw new Error(`Solana fill transaction reverted: ${JSON.stringify(tx.meta.err)}`);

--- a/src/lib/libraries/fillStatus.ts
+++ b/src/lib/libraries/fillStatus.ts
@@ -1,0 +1,41 @@
+// One chain-aware "has this output been filled?" check.
+//
+// This existed in three shapes before: flowProgress had EVM and Tron branches,
+// while FillIntent.svelte called `getClient` unconditionally — which throws for
+// Tron and would throw for Solana too. Routing both through here means the two
+// cannot drift, which is the whole reason the duplicate was a problem.
+
+import { getOutputHash } from "@lifi/intent";
+import type { MandateOutput } from "@lifi/intent";
+import { BYTES32_ZERO, getClient } from "$lib/config";
+import { COIN_FILLER_ABI } from "$lib/abi/outputsettler";
+import { bytes32ToAddress } from "@lifi/intent";
+import { isSolanaChain, isTronChain } from "$lib/utils/chainType";
+import { getSolanaReads } from "$lib/solana/client";
+import { readIsOutputFilled as readIsSolanaOutputFilled } from "$lib/solana/reads";
+import { getTronReads } from "$lib/tron/client";
+import { readIsOutputFilled as readIsTronOutputFilled } from "$lib/tron/reads";
+
+export async function isOutputFilled(
+  orderId: `0x${string}`,
+  output: MandateOutput
+): Promise<boolean> {
+  const outputHash = getOutputHash(output);
+
+  if (isSolanaChain(output.chainId)) {
+    const reads = await getSolanaReads(output.chainId);
+    return readIsSolanaOutputFilled(reads, { orderId, output });
+  }
+
+  if (isTronChain(output.chainId)) {
+    return readIsTronOutputFilled(await getTronReads(), output.settler, orderId, outputHash);
+  }
+
+  const record = await getClient(output.chainId).readContract({
+    address: bytes32ToAddress(output.settler),
+    abi: COIN_FILLER_ABI,
+    functionName: "getFillRecord",
+    args: [orderId, outputHash]
+  });
+  return record !== BYTES32_ZERO;
+}

--- a/src/lib/libraries/flowProgress.ts
+++ b/src/lib/libraries/flowProgress.ts
@@ -19,7 +19,7 @@ import { containerToIntent } from "$lib/utils/intent";
 import { getOrFetchRpc } from "$lib/libraries/rpcCache";
 import type { MandateOutput, OrderContainer } from "@lifi/intent";
 import { isSolanaChain, isTronChain } from "$lib/utils/chainType";
-import type { TxRef } from "$lib/utils/txRef";
+import { isValidTxRef, type TxRef } from "$lib/utils/txRef";
 import { getSolanaReads } from "$lib/solana/client";
 import {
   readIsLocallyAttested,
@@ -47,10 +47,6 @@ export function getOutputStorageKey(output: MandateOutput) {
     types: compactTypes,
     primaryType: "MandateOutput"
   });
-}
-
-function isValidHash(hash: string | undefined): hash is `0x${string}` {
-  return !!hash && hash.startsWith("0x") && hash.length === 66;
 }
 
 async function isOutputFilled(orderId: `0x${string}`, output: MandateOutput) {
@@ -92,7 +88,7 @@ async function isOutputValidatedOnChain(
   inputChain: bigint,
   orderContainer: OrderContainer,
   output: MandateOutput,
-  fillTransactionHash: `0x${string}`
+  fillTransactionHash: TxRef
 ) {
   const outputKey = getOutputStorageKey(output);
 
@@ -264,7 +260,10 @@ export async function getOrderProgressChecks(
         inputChains.flatMap((inputChain) =>
           outputs.map(async (output) => {
             const fillHash = fillTransactions[getOutputStorageKey(output)];
-            if (!isValidHash(fillHash)) return false;
+            // Validated against the OUTPUT chain: a Solana fill is base58, so
+            // a 0x-only check would discard it here and the order could never
+            // report as validated.
+            if (!isValidTxRef(fillHash, output.chainId)) return false;
             return isOutputValidatedOnChain(orderId, inputChain, orderContainer, output, fillHash);
           })
         )

--- a/src/lib/libraries/flowProgress.ts
+++ b/src/lib/libraries/flowProgress.ts
@@ -18,7 +18,15 @@ import { bytes32ToAddress } from "@lifi/intent";
 import { containerToIntent } from "$lib/utils/intent";
 import { getOrFetchRpc } from "$lib/libraries/rpcCache";
 import type { MandateOutput, OrderContainer } from "@lifi/intent";
-import { isTronChain } from "$lib/utils/chainType";
+import { isSolanaChain, isTronChain } from "$lib/utils/chainType";
+import type { TxRef } from "$lib/utils/txRef";
+import { getSolanaReads } from "$lib/solana/client";
+import {
+  readIsLocallyAttested,
+  readIsOrderFinalised,
+  readIsOutputFilled as readIsSolanaOutputFilled,
+  readIsProvenOnSolana
+} from "$lib/solana/reads";
 import { getFillDetails } from "$lib/libraries/fillEvent";
 import { getTronReads } from "$lib/tron/client";
 import { readIsOutputFilled, readIsProven, readOrderStatus } from "$lib/tron/reads";
@@ -48,6 +56,14 @@ function isValidHash(hash: string | undefined): hash is `0x${string}` {
 async function isOutputFilled(orderId: `0x${string}`, output: MandateOutput) {
   const outputKey = getOutputStorageKey(output);
   const outputHash = getOutputHash(output);
+  if (isSolanaChain(output.chainId)) {
+    return getOrFetchRpc(
+      `progress:filled:${orderId}:${outputKey}`,
+      async () =>
+        readIsSolanaOutputFilled(await getSolanaReads(output.chainId), { orderId, output }),
+      { ttlMs: PROGRESS_TTL_MS }
+    );
+  }
   if (isTronChain(output.chainId)) {
     return getOrFetchRpc(
       `progress:filled:${orderId}:${outputKey}`,
@@ -94,6 +110,27 @@ async function isOutputValidatedOnChain(
   const outputHash = keccak256(encodedOutput);
 
   const provenCacheKey = `progress:proven:${orderId}:${inputChain.toString()}:${outputKey}:${fillTransactionHash}`;
+  if (isSolanaChain(inputChain)) {
+    // On Solana "proven" is not a mapping lookup — the oracle CREATES an
+    // attestation account, so its existence is the proof. Same-chain fills
+    // never reach an oracle at all: the fill itself writes a LocalAttestation.
+    const sameChain = output.chainId === inputChain;
+    return getOrFetchRpc(
+      provenCacheKey,
+      async () => {
+        const reads = await getSolanaReads(inputChain);
+        if (sameChain) {
+          return readIsLocallyAttested(reads, { orderId, output, solver });
+        }
+        return readIsProvenOnSolana(reads, {
+          inputOracle: orderContainer.order.inputOracle,
+          output,
+          payloadHash: outputHash
+        });
+      },
+      { ttlMs: PROGRESS_TTL_MS }
+    );
+  }
   if (isTronChain(inputChain)) {
     return getOrFetchRpc(
       provenCacheKey,
@@ -129,6 +166,18 @@ async function isInputChainFinalised(chainId: bigint, container: OrderContainer)
   const { order, inputSettler } = container;
   const intent = containerToIntent(container);
   const orderId = intent.orderId();
+
+  if (isSolanaChain(chainId)) {
+    // No status enum on Solana: finalise and refund both close order_context,
+    // so "context gone, consumed_order still present" is the terminal signal.
+    // That folds Claimed and Refunded into one state, exactly as the EVM and
+    // Tron branches below already do.
+    return getOrFetchRpc(
+      `progress:finalised:solana:${orderId}`,
+      async () => readIsOrderFinalised(await getSolanaReads(chainId), orderId),
+      { ttlMs: PROGRESS_TTL_MS }
+    );
+  }
 
   if (isTronChain(chainId)) {
     return getOrFetchRpc(
@@ -196,7 +245,7 @@ async function isInputChainFinalised(chainId: bigint, container: OrderContainer)
 
 export async function getOrderProgressChecks(
   orderContainer: OrderContainer,
-  fillTransactions: Record<string, `0x${string}`>
+  fillTransactions: Record<string, TxRef>
 ): Promise<FlowCheckState> {
   try {
     const intent = containerToIntent(orderContainer);

--- a/src/lib/libraries/flowProgress.ts
+++ b/src/lib/libraries/flowProgress.ts
@@ -110,7 +110,10 @@ async function isOutputValidatedOnChain(
     // On Solana "proven" is not a mapping lookup — the oracle CREATES an
     // attestation account, so its existence is the proof. Same-chain fills
     // never reach an oracle at all: the fill itself writes a LocalAttestation.
-    const sameChain = output.chainId === inputChain;
+    // BigInt() on both sides: a DB-rehydrated container carries chain ids as
+    // decimal strings, and a string/bigint pair is never strictly equal — which
+    // silently classified a same-chain fill as remote.
+    const sameChain = BigInt(output.chainId) === BigInt(inputChain);
     return getOrFetchRpc(
       provenCacheKey,
       async () => {

--- a/src/lib/libraries/intentExecution.ts
+++ b/src/lib/libraries/intentExecution.ts
@@ -16,13 +16,23 @@ import {
 import { compact_type_hash } from "@lifi/intent";
 import { addressToBytes32 } from "@lifi/intent";
 import { signMultichainCompact, signStandardCompact } from "@lifi/intent";
-import { MultichainOrderIntent, StandardEVMIntent } from "@lifi/intent";
+import { MultichainOrderIntent, StandardEVMIntent, StandardSolanaIntent } from "@lifi/intent";
 import type { NoSignature, Signature } from "@lifi/intent";
 import type { TypedDataSigner } from "@lifi/intent";
 import { switchWalletChain } from "$lib/utils/walletClientRuntime";
 import { isTronChain } from "$lib/utils/chainType";
+import type { TxRef } from "$lib/utils/txRef";
 import { getTronReads, getTronSigner } from "$lib/tron/client";
 import { openEscrow as openTronEscrow } from "$lib/tron/writes";
+import { getSolanaReads } from "$lib/solana/client";
+import { createSolanaPrograms } from "$lib/solana/program";
+import { getSolanaSigner } from "$lib/solana/wallet";
+import { openEscrow as openSolanaEscrow } from "$lib/solana/writes";
+
+/** The connected Solana wallet, needed so Anchor can populate signer accounts. */
+async function solanaAccount(chainId: bigint): Promise<string> {
+  return (await getSolanaSigner(chainId)).publicKey;
+}
 
 function combineSignatures(signatures: {
   sponsorSignature: Signature | NoSignature;
@@ -81,10 +91,26 @@ export async function depositAndRegisterCompact(
 }
 
 export async function openEscrowIntent(
-  intent: StandardEVMIntent | MultichainOrderIntent,
+  intent: StandardEVMIntent | StandardSolanaIntent | MultichainOrderIntent,
   account: `0x${string}`,
   walletClient: WC
-): Promise<`0x${string}`[]> {
+): Promise<TxRef[]> {
+  // Solana signatures are base58, not 0x-hashes, which is why this returns
+  // TxRef rather than `0x${string}`.
+  if (intent instanceof StandardSolanaIntent) {
+    const order = intent.asOrder();
+    const chainId = order.originChainId;
+    const [reads, programs] = await Promise.all([
+      getSolanaReads(chainId),
+      createSolanaPrograms({ chainId, publicKey: await solanaAccount(chainId) })
+    ]);
+    const signer = await getSolanaSigner(chainId);
+    const signature = await openSolanaEscrow(
+      { chainId, reads, signer, programs },
+      { order, orderId: intent.orderId() }
+    );
+    return [signature];
+  }
   if (intent instanceof StandardEVMIntent) {
     const order = intent.asOrder();
     if (isTronChain(order.originChainId)) {

--- a/src/lib/libraries/intentFactory.ts
+++ b/src/lib/libraries/intentFactory.ts
@@ -30,7 +30,10 @@ import { approveToken } from "$lib/tron/writes";
 import { intentDeps } from "./coreDeps";
 
 const FILL_DEADLINE_SECONDS = 10 * 60; // 10 minutes
-const SAME_CHAIN_DURATION_SECONDS = 10 * 60; // 10 minutes
+// Must stay strictly greater than FILL_DEADLINE_SECONDS: the Solana input
+// settler requires `fill_deadline < expires` (EVM only rejects `>`), so equal
+// deadlines fail `open` with FillDeadlineAfterExpiry on same-chain Solana.
+const SAME_CHAIN_DURATION_SECONDS = 20 * 60; // 20 minutes
 const SAME_CHAIN_EXCLUSIVITY_SECONDS = 12 * 3; // 36 seconds
 // SOLV-544 widened the exclusivity window to 5 minutes so solvers have time to
 // fill before exclusivity ends. @lifi/intent 0.2.1 still encodes ONE_MINUTE in

--- a/src/lib/libraries/intentFactory.ts
+++ b/src/lib/libraries/intentFactory.ts
@@ -18,8 +18,7 @@ import type {
   StandardOrder
 } from "@lifi/intent";
 import { Intent, IntentApi, StandardSolanaIntent } from "@lifi/intent";
-import type { ChainType } from "$lib/utils/chainType";
-import { getChainType, isSolanaChain, isTronChain } from "$lib/utils/chainType";
+import { isSolanaChain, isTronChain, namespaceForChain } from "$lib/utils/chainType";
 import type { AppCreateIntentOptions, AppTokenContext } from "$lib/appTypes";
 import { ERC20_ABI } from "$lib/abi/erc20";
 import { store } from "$lib/state.svelte";
@@ -29,12 +28,6 @@ import { getTronReads, getTronSigner } from "$lib/tron/client";
 import { getTrc20Allowance } from "$lib/tron/reads";
 import { approveToken } from "$lib/tron/writes";
 import { intentDeps } from "./coreDeps";
-
-const NAMESPACE_BY_CHAIN_TYPE = {
-  evm: "eip155",
-  tron: "tron",
-  solana: "solana"
-} as const satisfies Record<ChainType, TokenContext["token"]["chainNamespace"]>;
 
 const FILL_DEADLINE_SECONDS = 10 * 60; // 10 minutes
 const SAME_CHAIN_DURATION_SECONDS = 10 * 60; // 10 minutes
@@ -88,7 +81,7 @@ function toCoreTokenContext(input: AppTokenContext): TokenContext {
       name: input.token.name,
       chainId,
       decimals: input.token.decimals,
-      chainNamespace: NAMESPACE_BY_CHAIN_TYPE[getChainType(chainId)]
+      chainNamespace: namespaceForChain(chainId)
     },
     amount: input.amount
   };

--- a/src/lib/libraries/intentFactory.ts
+++ b/src/lib/libraries/intentFactory.ts
@@ -19,7 +19,7 @@ import type {
 } from "@lifi/intent";
 import { Intent, IntentApi, StandardSolanaIntent } from "@lifi/intent";
 import type { ChainType } from "$lib/utils/chainType";
-import { getChainType, isTronChain } from "$lib/utils/chainType";
+import { getChainType, isSolanaChain, isTronChain } from "$lib/utils/chainType";
 import type { AppCreateIntentOptions, AppTokenContext } from "$lib/appTypes";
 import { ERC20_ABI } from "$lib/abi/erc20";
 import { store } from "$lib/state.svelte";
@@ -286,8 +286,6 @@ export class IntentFactory {
       applyIntentTimings(intentInstance3);
       const sameChain3 = intentInstance3.isSameChain();
       const intent = intentInstance3.order();
-      if (intent instanceof StandardSolanaIntent)
-        throw new Error("openEscrowIntent is not supported for Solana intents.");
       applyExclusivityOverride(intent, opts.exclusiveFor, sameChain3);
 
       const inputChain = inputTokens[0].token.chainId;
@@ -331,6 +329,11 @@ export function escrowApprove(
     for (let i = 0; i < inputTokens.length; ++i) {
       const { token, amount } = inputTokens[i];
       if (preHook) await preHook(token.chainId);
+
+      // Solana has no approval step at all: `open` debits the user's ATA under
+      // the user's own signature, so there is nothing corresponding to an
+      // ERC-20 allowance to set.
+      if (isSolanaChain(token.chainId)) continue;
 
       if (isTronChain(token.chainId)) {
         // Native TRX inputs are attached as callValue on open — no approval.

--- a/src/lib/libraries/intentFactory.ts
+++ b/src/lib/libraries/intentFactory.ts
@@ -17,15 +17,9 @@ import type {
   Signature,
   StandardOrder
 } from "@lifi/intent";
-import {
-  Intent,
-  IntentApi,
-  StandardSolanaIntent,
-  SOLANA_MAINNET_CHAIN_ID,
-  SOLANA_TESTNET_CHAIN_ID,
-  SOLANA_DEVNET_CHAIN_ID
-} from "@lifi/intent";
-import { isTronChain } from "$lib/utils/chainType";
+import { Intent, IntentApi, StandardSolanaIntent } from "@lifi/intent";
+import type { ChainType } from "$lib/utils/chainType";
+import { getChainType, isTronChain } from "$lib/utils/chainType";
 import type { AppCreateIntentOptions, AppTokenContext } from "$lib/appTypes";
 import { ERC20_ABI } from "$lib/abi/erc20";
 import { store } from "$lib/state.svelte";
@@ -36,11 +30,11 @@ import { getTrc20Allowance } from "$lib/tron/reads";
 import { approveToken } from "$lib/tron/writes";
 import { intentDeps } from "./coreDeps";
 
-const SOLANA_CHAIN_IDS = new Set([
-  SOLANA_MAINNET_CHAIN_ID,
-  SOLANA_TESTNET_CHAIN_ID,
-  SOLANA_DEVNET_CHAIN_ID
-]);
+const NAMESPACE_BY_CHAIN_TYPE = {
+  evm: "eip155",
+  tron: "tron",
+  solana: "solana"
+} as const satisfies Record<ChainType, TokenContext["token"]["chainNamespace"]>;
 
 const FILL_DEADLINE_SECONDS = 10 * 60; // 10 minutes
 const SAME_CHAIN_DURATION_SECONDS = 10 * 60; // 10 minutes
@@ -94,11 +88,7 @@ function toCoreTokenContext(input: AppTokenContext): TokenContext {
       name: input.token.name,
       chainId,
       decimals: input.token.decimals,
-      chainNamespace: SOLANA_CHAIN_IDS.has(chainId)
-        ? "solana"
-        : isTronChain(chainId)
-          ? "tron"
-          : "eip155"
+      chainNamespace: NAMESPACE_BY_CHAIN_TYPE[getChainType(chainId)]
     },
     amount: input.amount
   };

--- a/src/lib/libraries/polymerReceive.ts
+++ b/src/lib/libraries/polymerReceive.ts
@@ -1,0 +1,31 @@
+import { isSolanaChain } from "$lib/utils/chainType";
+
+/**
+ * Which PolymerOracle entry point accepts a proof from `outputChainId`.
+ *
+ * The oracle exposes two, and they decode different things:
+ *
+ * - `receiveMessage`       -> ICrossL2ProverV2.validateEvent   (an EVM event log)
+ * - `receiveSolanaMessage` -> ICrossL2ProverV2.validateSolLogs (Solana program logs)
+ *
+ * Handing a Solana proof to the EVM entry point reverts with no reason string,
+ * which is indistinguishable from a malformed proof and sends you looking in
+ * the wrong place. Verified against the deployed Base oracle
+ * (0x008C3800F3Ad9b3B662d002E90Cc00000000eE17) with a real Solana proof:
+ * `receiveMessage` reverts, `receiveSolanaMessage` succeeds.
+ *
+ * Note the argument is the chain the proof came FROM — the output chain — not
+ * the chain the call is made on.
+ *
+ * The two also key the attestation differently, which is why this is not merely
+ * cosmetic: the EVM path stores under the local oracle's own identifier, the
+ * Solana path under Polymer's authenticated `returnedProgramId`. That is the
+ * reason a Solana output must carry the Polymer PROGRAM ID in `output.oracle`
+ * rather than the oracle PDA — otherwise `isProven` looks in a slot nothing
+ * ever wrote.
+ */
+export function polymerReceiveFunction(
+  outputChainId: number | bigint
+): "receiveMessage" | "receiveSolanaMessage" {
+  return isSolanaChain(outputChainId) ? "receiveSolanaMessage" : "receiveMessage";
+}

--- a/src/lib/libraries/provableEvents.ts
+++ b/src/lib/libraries/provableEvents.ts
@@ -29,23 +29,23 @@ export type ProvableEventName = (typeof PROVABLE_EVENT_NAMES)[number];
  * runtime bytecode on Base, Arbitrum One and OP Mainnet.
  */
 export const EXPECTED_TOPIC0: Record<ProvableEventName, `0x${string}`> = {
-	OutputFilled: "0xfef24569acf839f2b5cb23fd59d8a9bcc21650ff711ac1961ca3c5d4681ffe12",
-	OutputNotFilled: "0xf73516bd5d6277333b9b4d2830f5dab6de8d2f496097f7738b6e2e233119a2c7"
+  OutputFilled: "0xfef24569acf839f2b5cb23fd59d8a9bcc21650ff711ac1961ca3c5d4681ffe12",
+  OutputNotFilled: "0xf73516bd5d6277333b9b4d2830f5dab6de8d2f496097f7738b6e2e233119a2c7"
 };
 
 /** Resolve one allowlisted event from the ABI, failing loudly rather than silently. */
 function provableEvent(name: ProvableEventName): AbiEvent {
-	const event = COIN_FILLER_ABI.find((item) => item.type === "event" && item.name === name);
-	// A cast alone would hide a missing entry: `.find` returns undefined, viem receives an
-	// undefined event, and the filter silently stops matching anything. Throw at import instead.
-	if (!event) throw new Error(`COIN_FILLER_ABI is missing the ${name} event`);
-	const topic0 = toEventSelector(event as AbiEvent);
-	if (topic0 !== EXPECTED_TOPIC0[name]) {
-		throw new Error(
-			`${name} topic0 changed: ABI yields ${topic0}, expected ${EXPECTED_TOPIC0[name]}`
-		);
-	}
-	return event as AbiEvent;
+  const event = COIN_FILLER_ABI.find((item) => item.type === "event" && item.name === name);
+  // A cast alone would hide a missing entry: `.find` returns undefined, viem receives an
+  // undefined event, and the filter silently stops matching anything. Throw at import instead.
+  if (!event) throw new Error(`COIN_FILLER_ABI is missing the ${name} event`);
+  const topic0 = toEventSelector(event as AbiEvent);
+  if (topic0 !== EXPECTED_TOPIC0[name]) {
+    throw new Error(
+      `${name} topic0 changed: ABI yields ${topic0}, expected ${EXPECTED_TOPIC0[name]}`
+    );
+  }
+  return event as AbiEvent;
 }
 
 export const PROVABLE_EVENTS: AbiEvent[] = PROVABLE_EVENT_NAMES.map(provableEvent);

--- a/src/lib/libraries/provableLogVerify.ts
+++ b/src/lib/libraries/provableLogVerify.ts
@@ -12,30 +12,30 @@ export type ProvableLogVerification = "match" | "mismatch" | "unknown";
  * never blocks the happy path.
  */
 export async function verifyProvableLog(
-	chainId: number,
-	blockNumber: bigint,
-	globalLogIndex: number
+  chainId: number,
+  blockNumber: bigint,
+  globalLogIndex: number
 ): Promise<ProvableLogVerification> {
-	try {
-		const client = createPublicClient({
-			transport: http(`https://lb.routeme.sh/rpc/${chainId}/${PRIVATE_ROUTEMESH_API_KEY}`)
-		});
-		// `events` (plural), not `event`: viem collapses the singular form into an exact
-		// `topics: [topic0]` filter, while the plural form emits `topics: [[topic0a, topic0b]]`
-		// — an OR-set — which is what lets both events through in a single call.
-		const logs = await client.getLogs({
-			fromBlock: blockNumber,
-			toBlock: blockNumber,
-			events: PROVABLE_EVENTS
-		});
-		return logs.some((l) => Number(l.logIndex) === globalLogIndex) ? "match" : "mismatch";
-	} catch (e) {
-		console.warn("routemesh provable-log verification failed", {
-			chainId,
-			blockNumber: blockNumber.toString(),
-			globalLogIndex,
-			error: e instanceof Error ? e.message : String(e)
-		});
-		return "unknown";
-	}
+  try {
+    const client = createPublicClient({
+      transport: http(`https://lb.routeme.sh/rpc/${chainId}/${PRIVATE_ROUTEMESH_API_KEY}`)
+    });
+    // `events` (plural), not `event`: viem collapses the singular form into an exact
+    // `topics: [topic0]` filter, while the plural form emits `topics: [[topic0a, topic0b]]`
+    // — an OR-set — which is what lets both events through in a single call.
+    const logs = await client.getLogs({
+      fromBlock: blockNumber,
+      toBlock: blockNumber,
+      events: PROVABLE_EVENTS
+    });
+    return logs.some((l) => Number(l.logIndex) === globalLogIndex) ? "match" : "mismatch";
+  } catch (e) {
+    console.warn("routemesh provable-log verification failed", {
+      chainId,
+      blockNumber: blockNumber.toString(),
+      globalLogIndex,
+      error: e instanceof Error ? e.message : String(e)
+    });
+    return "unknown";
+  }
 }

--- a/src/lib/libraries/provableSolanaLogVerify.ts
+++ b/src/lib/libraries/provableSolanaLogVerify.ts
@@ -1,0 +1,104 @@
+// `$env/dynamic/private`, not `$env/static/private`: this variable is optional
+// (there is a public fallback below), and the static form fails the module
+// import outright when the key is absent from .env — which would take the
+// whole /polymer route down, not just Solana verification.
+import { env } from "$env/dynamic/private";
+import { isSolanaMainnet } from "$lib/utils/chainType";
+
+/**
+ * The Solana program `/polymer` will mint a proof for.
+ *
+ * This is a pin, not a convenience: the endpoint spends the org's Polymer API key on behalf of an
+ * unauthenticated caller, so it must not become a general-purpose proof oracle for arbitrary
+ * Solana programs — the same reasoning as the event allowlist in `provableEvents.ts`. Widening it
+ * widens what anyone can get proved.
+ *
+ * Confirmed against `declare_id!` in
+ * `catalyst-intent-svm/programs/oracles/oracle_polymer/src/lib.rs`. Polymer authenticates this
+ * value as `returnedProgramId`, parsed out of the `program: {program_id}` field of the log line
+ * that `oracle_polymer::submit` emits.
+ */
+export const POLYMER_SOLANA_PROGRAM_ID = "LiFiBtfyPT1DnTHTAeZ2rwr5RgMrThwA5kt7KGT5nBV";
+
+export type ProvableSolanaLogVerification = "match" | "mismatch" | "unknown";
+
+// A Cloudflare Worker request is short-lived, so a hung Solana RPC must not hold the proof
+// request open behind it.
+const RPC_TIMEOUT_MS = 5_000;
+
+// Public fallbacks, used only when no private endpoint is configured. `PRIVATE_SOLANA_RPC_URL` is
+// a single endpoint by design: a deployment talks to one Solana network, and pointing it at the
+// wrong one simply yields "unknown" (transaction not found) rather than a false "match".
+const DEFAULT_MAINNET_RPC_URL = "https://api.mainnet-beta.solana.com";
+const DEFAULT_DEVNET_RPC_URL = "https://api.devnet.solana.com";
+
+function getSolanaRpcUrl(chainId: number): string {
+  const configured = env.PRIVATE_SOLANA_RPC_URL?.trim();
+  if (configured) return configured;
+  return isSolanaMainnet(chainId) ? DEFAULT_MAINNET_RPC_URL : DEFAULT_DEVNET_RPC_URL;
+}
+
+type GetTransactionResponse = {
+  result?: { meta?: { logMessages?: string[] | null } | null } | null;
+  error?: { message?: string };
+};
+
+/**
+ * Pre-flight check that `txSignature` really is a transaction in which the pinned Polymer oracle
+ * program logged a proof, so a proof request cannot be aimed at an unrelated Solana transaction.
+ *
+ * The marker is the log line `oracle_polymer::submit` emits via `msg!`:
+ *     `Prove: program: {program_id}, {base64(source || payload)}`
+ * which Solana surfaces in `meta.logMessages` prefixed with `Program log: `. Matching on
+ * `Prove: program: <programId>,` therefore checks both the marker and the program identity that
+ * Polymer will authenticate as `returnedProgramId`.
+ *
+ * Advisory by design, exactly like `verifyProvableLog`: an RPC failure — or a transaction the RPC
+ * has not indexed yet — returns "unknown" and the caller proceeds, so an infra blip never blocks
+ * the happy path.
+ */
+export async function verifyProvableSolanaLog(
+  chainId: number,
+  txSignature: string,
+  programId: string
+): Promise<ProvableSolanaLogVerification> {
+  try {
+    const response = await fetch(getSolanaRpcUrl(chainId), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getTransaction",
+        params: [
+          txSignature,
+          {
+            encoding: "json",
+            commitment: "confirmed",
+            maxSupportedTransactionVersion: 0
+          }
+        ]
+      }),
+      signal: AbortSignal.timeout(RPC_TIMEOUT_MS)
+    });
+    if (!response.ok) throw new Error(`solana rpc responded ${response.status}`);
+
+    const body = (await response.json()) as GetTransactionResponse;
+    if (body.error) throw new Error(body.error.message ?? "solana rpc error");
+
+    // Null result means "not indexed here (yet)", not "not a Prove transaction" — a freshly
+    // landed fill is the common case — so it stays inconclusive rather than becoming a rejection.
+    const logMessages = body.result?.meta?.logMessages;
+    if (!body.result || !logMessages) return "unknown";
+
+    const marker = `Prove: program: ${programId},`;
+    return logMessages.some((line) => line.includes(marker)) ? "match" : "mismatch";
+  } catch (e) {
+    console.warn("solana provable-log verification failed", {
+      chainId,
+      txSignature,
+      error: e instanceof Error ? e.message : String(e)
+    });
+    return "unknown";
+  }
+}

--- a/src/lib/libraries/solver.ts
+++ b/src/lib/libraries/solver.ts
@@ -584,7 +584,15 @@ export class Solver {
       }
 
       if (isTronChain(sourceChainId)) {
-        const txId = await submitTronReceiveMessage(await tronDeps(), order.inputOracle, proof);
+        // Entry point selected by the chain the proof came FROM, mirroring the
+        // EVM branch below: a Solana fill's proof is only decodable by
+        // receiveSolanaMessage, and receiveMessage reverts on it reasonless.
+        const txId = await submitTronReceiveMessage(
+          await tronDeps(),
+          order.inputOracle,
+          proof,
+          polymerReceiveFunction(output.chainId)
+        );
         if (postHook) await postHook();
         return { transactionHash: `0x${txId.replace("0x", "")}` };
       }

--- a/src/lib/libraries/solver.ts
+++ b/src/lib/libraries/solver.ts
@@ -18,10 +18,15 @@ import store from "$lib/state.svelte";
 import { finaliseIntent } from "./intentExecution";
 import { getFillDetails } from "./fillEvent";
 import { isSolanaChain, isTronChain } from "$lib/utils/chainType";
+import { isValidTxRef } from "$lib/utils/txRef";
 import { getSolanaReads } from "$lib/solana/client";
 import { createSolanaPrograms } from "$lib/solana/program";
 import { getSolanaSigner } from "$lib/solana/wallet";
-import { fillOutputs as fillSolanaOutputs, finalise as finaliseSolana } from "$lib/solana/writes";
+import {
+  fillOutputs as fillSolanaOutputs,
+  finalise as finaliseSolana,
+  submitFillProof as submitSolanaFillProof
+} from "$lib/solana/writes";
 import type { SolanaDeps } from "$lib/solana/types";
 import { getTronReads, getTronSigner } from "$lib/tron/client";
 import {
@@ -239,15 +244,39 @@ export class Solver {
       if (existingValidation) return existingValidation;
 
       const validationPromise = (async () => {
-        if (
-          !fillTransactionHash ||
-          !fillTransactionHash.startsWith("0x") ||
-          fillTransactionHash.length !== 66
-        ) {
+        // Validated against the OUTPUT chain: a Solana fill is a base58
+        // signature even when the order's source chain is EVM.
+        if (!isValidTxRef(fillTransactionHash, output.chainId)) {
           throw new Error(`Invalid fill transaction hash: ${fillTransactionHash}`);
         }
 
         const orderId = containerToIntent(args.orderContainer).orderId();
+
+        // A Solana OUTPUT is proven by submitting the fill to Polymer, which
+        // reads the `Prove:` log the submit instruction writes. A same-chain
+        // Solana fill needs nothing at all: `fill` already created the
+        // LocalAttestation that `finalise` reads, so there is no separate
+        // attestation step to mirror Tron's `setAttestation`.
+        if (isSolanaChain(output.chainId)) {
+          const { solver, timestamp } = await getFillDetails(orderId, output, fillTransactionHash);
+          if (output.chainId === BigInt(sourceChainId)) {
+            if (postHook) await postHook();
+            return;
+          }
+          const signature = await submitSolanaFillProof(await solanaDeps(output.chainId), {
+            orderId,
+            output,
+            solverBytes32: solver,
+            timestamp
+          });
+          if (postHook) await postHook();
+          return signature;
+        }
+
+        // A Solana INPUT chain receives the proof instead: the oracle writes
+        // the attestation account that `finalise` looks for. Everything up to
+        // the proof request is the shared EVM path below, so this branch is
+        // handled after the proof has been fetched.
         const sameChainAttestation =
           order.inputOracle.toLowerCase() === bytes32ToAddress(output.settler).toLowerCase() ||
           order.inputOracle === COIN_FILLER;
@@ -381,6 +410,23 @@ export class Solver {
         if (!proof) {
           throw new Error(
             `Polymer proof unavailable for output on ${output.chainId.toString()}. Try again after the fill attestation is indexed.`
+          );
+        }
+
+        if (isSolanaChain(sourceChainId)) {
+          // Receiving a proof ON Solana needs two things this app cannot yet
+          // determine: the Polymer prover's program id (readable from the
+          // OraclePolymer account) and the seeds of its cache/result/internal
+          // scratch PDAs, which are only documented in a stale reference test.
+          // `receiveProof` in $lib/solana/writes is written and tested against
+          // the DI seam; it is deliberately not called with guessed accounts.
+          //
+          // Failing here — rather than falling through to the EVM path, which
+          // would call getClient() on a Solana chain id — keeps the blocker
+          // legible. See the unverified list in
+          // tests/fixtures/solana/PREFLIGHT.md.
+          throw new Error(
+            `Receiving a Polymer proof on Solana is not wired up yet: the prover program id and its scratch-PDA seeds must be confirmed on chain first (see tests/fixtures/solana/PREFLIGHT.md). The proof itself was fetched successfully for chain ${Number(sourceChainId)}.`
           );
         }
 

--- a/src/lib/libraries/solver.ts
+++ b/src/lib/libraries/solver.ts
@@ -4,6 +4,7 @@ import type { MandateOutput, OrderContainer } from "@lifi/intent";
 import {
   addressToBytes32,
   bytes32ToAddress,
+  bytes32ToSolanaBase58,
   StandardSolanaIntent,
   TRON_LEGACY_POLYMER_ORACLES
 } from "@lifi/intent";
@@ -20,7 +21,7 @@ import { isSolanaChain, isTronChain } from "$lib/utils/chainType";
 import { getSolanaReads } from "$lib/solana/client";
 import { createSolanaPrograms } from "$lib/solana/program";
 import { getSolanaSigner } from "$lib/solana/wallet";
-import { fillOutput as fillSolanaOutput, finalise as finaliseSolana } from "$lib/solana/writes";
+import { fillOutputs as fillSolanaOutputs, finalise as finaliseSolana } from "$lib/solana/writes";
 import type { SolanaDeps } from "$lib/solana/types";
 import { getTronReads, getTronSigner } from "$lib/tron/client";
 import {
@@ -117,24 +118,18 @@ export class Solver {
       const outputChainId = Number(outputs[0].chainId);
 
       if (isSolanaChain(outputChainId)) {
-        // The Solana settler fills ONE output per instruction — there is no
-        // batch equivalent of fillOrderOutputs — so a multi-output fill on the
-        // same chain is several transactions, and only the first signature is
-        // returned as the fill reference for this group.
-        const deps = await solanaDeps(BigInt(outputChainId));
-        const signatures: string[] = [];
-        for (const output of outputs) {
-          signatures.push(
-            await fillSolanaOutput(deps, {
-              orderId,
-              output,
-              fillDeadline: Number(order.fillDeadline),
-              solverBytes32: addressToBytes32(solverAddress)
-            })
-          );
-        }
+        // One instruction per output, but ONE transaction: the caller stores a
+        // single reference for the whole group, and each output's solver and
+        // timestamp are later recovered from that transaction's logs. Separate
+        // transactions would leave outputs 2..N filled but unprovable.
+        const signature = await fillSolanaOutputs(await solanaDeps(BigInt(outputChainId)), {
+          orderId,
+          outputs,
+          fillDeadline: Number(order.fillDeadline),
+          solverBytes32: addressToBytes32(solverAddress)
+        });
         if (postHook) await postHook();
-        return signatures[0]!;
+        return signature;
       }
 
       if (isTronChain(outputChainId)) {
@@ -489,11 +484,25 @@ export class Solver {
       );
 
       // The input settler derives the order owner from solveParams[0].solver
-      // and requires msg.sender to be that owner.
-      const owner = bytes32ToAddress(solveParams[0].solver);
-      if (owner.toLowerCase() !== account().toLowerCase()) {
+      // and requires the caller to be that owner.
+      //
+      // Compared as bytes32 on Solana: a Solana solver identity IS 32 bytes, so
+      // truncating it to the low 20 (as the EVM comparison does) would never
+      // match the connected wallet and would reject the rightful solver.
+      const solverBytes32 = solveParams[0].solver;
+      const connected = account();
+      const ownerMatches = isSolanaChain(sourceChainId)
+        ? solverBytes32.toLowerCase() === connected.toLowerCase()
+        : bytes32ToAddress(solverBytes32).toLowerCase() === connected.toLowerCase();
+      if (!ownerMatches) {
+        const owner = isSolanaChain(sourceChainId)
+          ? bytes32ToSolanaBase58(solverBytes32)
+          : bytes32ToAddress(solverBytes32);
+        const connectedDisplay = isSolanaChain(sourceChainId)
+          ? bytes32ToSolanaBase58(connected)
+          : connected;
         throw new Error(
-          `This order was filled for solver ${owner} — connect that wallet to claim (connected: ${account()}).`
+          `This order was filled for solver ${owner} — connect that wallet to claim (connected: ${connectedDisplay}).`
         );
       }
 

--- a/src/lib/libraries/solver.ts
+++ b/src/lib/libraries/solver.ts
@@ -18,7 +18,7 @@ import store from "$lib/state.svelte";
 import { finaliseIntent } from "./intentExecution";
 import { getFillDetails } from "./fillEvent";
 import { isSolanaChain, isTronChain } from "$lib/utils/chainType";
-import { isValidTxRef } from "$lib/utils/txRef";
+import { isValidTxRef, type TxRef } from "$lib/utils/txRef";
 import { getSolanaReads } from "$lib/solana/client";
 import { createSolanaPrograms } from "$lib/solana/program";
 import { getSolanaSigner } from "$lib/solana/wallet";
@@ -29,6 +29,7 @@ import {
   submitFillProof as submitSolanaFillProof
 } from "$lib/solana/writes";
 import { polymerScratchPdas } from "$lib/solana/pda";
+import { POLYMER_PROGRAM_ID } from "$lib/idl";
 import { readPolymerProverId } from "$lib/solana/reads";
 import type { SolanaDeps } from "$lib/solana/types";
 import { getTronReads, getTronSigner } from "$lib/tron/client";
@@ -65,9 +66,84 @@ async function solanaDeps(chainId: bigint): Promise<SolanaDeps> {
 export class Solver {
   private static validationInflight = new Map<string, Promise<unknown>>();
   private static polymerRequestIndexByLog = new Map<string, number>();
+  /**
+   * Solana `submit` signatures, keyed by output.
+   *
+   * Proving a Solana output takes two transactions on two chains, and the
+   * proof for the first is rarely ready by the time the user gets impatient.
+   * Without this, every retry re-runs `submit` — which succeeds, costs a
+   * signature and a fee, and gets no closer to a proof.
+   */
+  private static solanaSubmitByOutput = new Map<string, string>();
 
   private static sleep(ms: number) {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /** Serialises Solana proof receives; see the call site for why. */
+  private static solanaReceiveQueue: Promise<unknown> = Promise.resolve();
+
+  private static queueSolanaReceive<T>(run: () => Promise<T>): Promise<T> {
+    // Settle either way before starting the next: one failed receive must not
+    // wedge the queue for every remaining output.
+    const next = Solver.solanaReceiveQueue.then(run, run);
+    Solver.solanaReceiveQueue = next.catch(() => undefined);
+    return next;
+  }
+
+  /**
+   * Asks the `/polymer` route for a proof, retrying while it is still being
+   * generated.
+   *
+   * `polymerIndex` is threaded through and cached because it identifies an
+   * already-placed request: dropping it makes each retry a fresh request
+   * against the org's Polymer quota rather than a poll of the existing one.
+   */
+  private static async pollPolymerProof(
+    cacheKey: string,
+    body: Record<string, unknown>
+  ): Promise<string | undefined> {
+    let polymerIndex: number | undefined = Solver.polymerRequestIndexByLog.get(cacheKey);
+    for (const waitMs of [1000, 2000, 4000, 8000]) {
+      const response = await axios.post(`/polymer`, { ...body, polymerIndex }, { timeout: 15_000 });
+      const dat = response.data as {
+        proof: undefined | string;
+        polymerIndex: number;
+        status?: "initialized" | "complete" | "error";
+      };
+      polymerIndex = dat.polymerIndex;
+      if (polymerIndex !== undefined) {
+        Solver.polymerRequestIndexByLog.set(cacheKey, polymerIndex);
+      }
+      if (dat.proof) return dat.proof;
+      if (dat.status === "error") {
+        // Terminal. Keeping the index cached would make every future attempt
+        // poll the same dead job for the rest of the session, so drop it —
+        // the next attempt then places a fresh request.
+        Solver.polymerRequestIndexByLog.delete(cacheKey);
+        throw new Error(
+          `Polymer could not generate a proof for request ${polymerIndex} (job failed). Retrying will start a new request.`
+        );
+      }
+      await Solver.sleep(waitMs);
+    }
+    return undefined;
+  }
+
+  /**
+   * The oracle addresses a chain's input side will accept a Polymer proof
+   * from, lower-cased.
+   *
+   * Includes known legacy deployments alongside the current one: an order
+   * opened before an address rotation must stay provable, or its inputs are
+   * stranded until the deadline.
+   */
+  private static polymerOraclesFor(chainId: number | bigint): Set<string> {
+    return new Set(
+      [getOracle("polymer", chainId), ...(TRON_LEGACY_POLYMER_ORACLES[chainId.toString()] ?? [])]
+        .filter((oracle): oracle is `0x${string}` => !!oracle)
+        .map((oracle) => oracle.toLowerCase())
+    );
   }
 
   private static extractRevertReason(error: unknown): string {
@@ -260,20 +336,78 @@ export class Solver {
         // Solana fill needs nothing at all: `fill` already created the
         // LocalAttestation that `finalise` reads, so there is no separate
         // attestation step to mirror Tron's `setAttestation`.
+        const deliverProofToInputChain = (proof: string) =>
+          Solver.deliverProof(proof, {
+            order,
+            orderId,
+            output,
+            fillTransactionHash,
+            sourceChainId,
+            walletClient,
+            account,
+            preHook,
+            postHook
+          });
+
         if (isSolanaChain(output.chainId)) {
           const { solver, timestamp } = await getFillDetails(orderId, output, fillTransactionHash);
           if (output.chainId === BigInt(sourceChainId)) {
             if (postHook) await postHook();
             return;
           }
-          const signature = await submitSolanaFillProof(await solanaDeps(output.chainId), {
-            orderId,
-            output,
-            solverBytes32: solver,
-            timestamp
-          });
-          if (postHook) await postHook();
-          return signature;
+
+          // Three steps, not one. `submit` writes the `Prove:` log on Solana;
+          // Polymer then proves THAT transaction (not the fill); the input
+          // chain receives the proof. Stopping after `submit` leaves the
+          // output filled and unprovable, with the button never turning green
+          // and every retry paying for another `submit`.
+          // Before spending a signature and a fee on `submit`, check the input
+          // chain can actually accept the resulting proof. Otherwise the
+          // submit succeeds and the failure only surfaces at delivery.
+          if (!Solver.polymerOraclesFor(sourceChainId).has(order.inputOracle.toLowerCase())) {
+            throw new Error(
+              `Input oracle ${order.inputOracle} on chain ${Number(sourceChainId)} is not a Polymer oracle, so a Solana output cannot be proven to it.`
+            );
+          }
+
+          // The submitted payload commits to the fill's solver and timestamp,
+          // both read from `fillTransactionHash` — so the fill reference is
+          // part of the identity. The manual fill-tx field lets that reference
+          // change for the same output, and without it here a corrected hash
+          // would silently reuse the submit made for the previous one.
+          const submitKey = `${Number(output.chainId)}:${orderId}:${expectedOutputHash}:${fillTransactionHash}`;
+          let submitSignature = Solver.solanaSubmitByOutput.get(submitKey);
+          if (!submitSignature) {
+            submitSignature = await submitSolanaFillProof(await solanaDeps(output.chainId), {
+              orderId,
+              output,
+              solverBytes32: solver,
+              timestamp
+            });
+            Solver.solanaSubmitByOutput.set(submitKey, submitSignature);
+          }
+
+          // Keyed on the submit signature: it is what Polymer is asked to
+          // prove, so reusing the fill's key would poll the wrong request.
+          const proof = await Solver.pollPolymerProof(
+            `${Number(output.chainId)}:${submitSignature}`,
+            {
+              srcChainId: Number(output.chainId),
+              txSignature: submitSignature,
+              // From the IDL, not from provableSolanaLogVerify: that module is
+              // server-only, and importing it here would pull
+              // $env/dynamic/private into the browser bundle. The route
+              // re-checks this value against its own copy anyway.
+              programID: POLYMER_PROGRAM_ID,
+              mainnet
+            }
+          );
+          if (!proof) {
+            throw new Error(
+              `Polymer proof unavailable for the Solana fill proof ${submitSignature}. The submit succeeded — click again once Polymer has indexed it.`
+            );
+          }
+          return deliverProofToInputChain(proof);
         }
 
         // A Solana INPUT chain receives the proof instead: the oracle writes
@@ -283,18 +417,9 @@ export class Solver {
         const sameChainAttestation =
           order.inputOracle.toLowerCase() === bytes32ToAddress(output.settler).toLowerCase() ||
           order.inputOracle === COIN_FILLER;
-        // Accept the current oracle AND known legacy deployments — orders
-        // opened before an address rotation must stay provable.
-        const polymerOracles = new Set(
-          [
-            getOracle("polymer", sourceChainId),
-            ...(TRON_LEGACY_POLYMER_ORACLES[sourceChainId.toString()] ?? [])
-          ]
-            .filter((oracle): oracle is `0x${string}` => !!oracle)
-            .map((oracle) => oracle.toLowerCase())
-        );
         const isPolymerPath =
-          !sameChainAttestation && polymerOracles.has(order.inputOracle.toLowerCase());
+          !sameChainAttestation &&
+          Solver.polymerOraclesFor(sourceChainId).has(order.inputOracle.toLowerCase());
 
         if (sameChainAttestation) {
           // Same-chain fills: the output settler doubles as the oracle, but the
@@ -381,42 +506,60 @@ export class Solver {
         }
         const logIndex = matches[0].logIndex;
 
-        let proof: string | undefined;
         const polymerKey = `${Number(output.chainId)}:${Number(transactionReceipt.blockNumber)}:${Number(logIndex)}`;
-        let polymerIndex: number | undefined = Solver.polymerRequestIndexByLog.get(polymerKey);
-        for (const waitMs of [1000, 2000, 4000, 8000]) {
-          const response = await axios.post(
-            `/polymer`,
-            {
-              srcChainId: Number(output.chainId),
-              srcBlockNumber: Number(transactionReceipt.blockNumber),
-              globalLogIndex: Number(logIndex),
-              polymerIndex,
-              mainnet: mainnet
-            },
-            { timeout: 15_000 }
-          );
-          const dat = response.data as {
-            proof: undefined | string;
-            polymerIndex: number;
-          };
-          polymerIndex = dat.polymerIndex;
-          if (polymerIndex !== undefined) {
-            Solver.polymerRequestIndexByLog.set(polymerKey, polymerIndex);
-          }
-          if (dat.proof) {
-            proof = dat.proof;
-            break;
-          }
-          await Solver.sleep(waitMs);
-        }
+        const proof = await Solver.pollPolymerProof(polymerKey, {
+          srcChainId: Number(output.chainId),
+          srcBlockNumber: Number(transactionReceipt.blockNumber),
+          globalLogIndex: Number(logIndex),
+          mainnet
+        });
         if (!proof) {
           throw new Error(
             `Polymer proof unavailable for output on ${output.chainId.toString()}. Try again after the fill attestation is indexed.`
           );
         }
 
-        if (isSolanaChain(sourceChainId)) {
+        return deliverProofToInputChain(proof);
+      })();
+
+      Solver.validationInflight.set(validationKey, validationPromise);
+      try {
+        return await validationPromise;
+      } finally {
+        Solver.validationInflight.delete(validationKey);
+      }
+    };
+  }
+
+  private static deliverProof(
+    proof: string,
+    ctx: {
+      order: OrderContainer["order"];
+      orderId: `0x${string}`;
+      output: MandateOutput;
+      fillTransactionHash: TxRef;
+      sourceChainId: number | bigint;
+      walletClient: WC;
+      account: () => `0x${string}`;
+      // `unknown` rather than the `any` the public entry points use — the
+      // hooks' results are never read, and this is new code with no callers to
+      // keep compatible.
+      preHook?: (chainId: number) => Promise<unknown>;
+      postHook?: () => Promise<unknown>;
+    }
+  ) {
+    return (async () => {
+      const { order, orderId, output, fillTransactionHash, sourceChainId } = ctx;
+      const { walletClient, account, preHook, postHook } = ctx;
+
+      if (isSolanaChain(sourceChainId)) {
+        // Serialised across ALL outputs, not just retries of one. The Polymer
+        // prover's scratch accounts are derived from the signer alone, and
+        // receiveProof spends them across two transactions (load then attest),
+        // so a second output running concurrently overwrites the first's
+        // loaded proof between its own two steps. The per-output inflight key
+        // does not cover this — the collision is between different outputs.
+        return Solver.queueSolanaReceive(async () => {
           const deps = await solanaDeps(BigInt(sourceChainId));
           // The prover program id is pinned but verified against the on-chain
           // OraclePolymer account here: it is external to this protocol, so a
@@ -436,61 +579,54 @@ export class Solver {
           // No signature means the attestation already existed — re-running is
           // a no-op, not a failure.
           return { transactionHash: attestSignature, attestation };
-        }
-
-        if (isTronChain(sourceChainId)) {
-          const txId = await submitTronReceiveMessage(await tronDeps(), order.inputOracle, proof);
-          if (postHook) await postHook();
-          return { transactionHash: `0x${txId.replace("0x", "")}` };
-        }
-
-        if (preHook) await preHook(Number(sourceChainId));
-
-        const proofHex = `0x${proof.replace("0x", "")}` as `0x${string}`;
-        const simCalldata = encodeFunctionData({
-          abi: POLYMER_ORACLE_ABI,
-          functionName: "receiveMessage",
-          args: [proofHex]
         });
-        try {
-          await getClient(sourceChainId).call({
-            to: order.inputOracle,
-            data: simCalldata,
-            account: account()
-          });
-        } catch (simError) {
-          throw new Error(
-            `receiveMessage simulation failed on chain ${Number(sourceChainId)}: ${Solver.extractRevertReason(simError)}`,
-            { cause: simError as Error }
-          );
-        }
-
-        const transactionHash = await walletClient.writeContract({
-          chain: getChain(sourceChainId),
-          account: account(),
-          address: order.inputOracle,
-          abi: POLYMER_ORACLE_ABI,
-          functionName: "receiveMessage",
-          args: [proofHex]
-        });
-
-        const result = await getClient(sourceChainId).waitForTransactionReceipt({
-          hash: transactionHash,
-          timeout: 120_000,
-          pollingInterval: 2_000
-        });
-        await Solver.persistReceipt(sourceChainId, transactionHash, result);
-        if (postHook) await postHook();
-        return result;
-      })();
-
-      Solver.validationInflight.set(validationKey, validationPromise);
-      try {
-        return await validationPromise;
-      } finally {
-        Solver.validationInflight.delete(validationKey);
       }
-    };
+
+      if (isTronChain(sourceChainId)) {
+        const txId = await submitTronReceiveMessage(await tronDeps(), order.inputOracle, proof);
+        if (postHook) await postHook();
+        return { transactionHash: `0x${txId.replace("0x", "")}` };
+      }
+
+      if (preHook) await preHook(Number(sourceChainId));
+
+      const proofHex = `0x${proof.replace("0x", "")}` as `0x${string}`;
+      const simCalldata = encodeFunctionData({
+        abi: POLYMER_ORACLE_ABI,
+        functionName: "receiveMessage",
+        args: [proofHex]
+      });
+      try {
+        await getClient(sourceChainId).call({
+          to: order.inputOracle,
+          data: simCalldata,
+          account: account()
+        });
+      } catch (simError) {
+        throw new Error(
+          `receiveMessage simulation failed on chain ${Number(sourceChainId)}: ${Solver.extractRevertReason(simError)}`,
+          { cause: simError as Error }
+        );
+      }
+
+      const transactionHash = await walletClient.writeContract({
+        chain: getChain(sourceChainId),
+        account: account(),
+        address: order.inputOracle,
+        abi: POLYMER_ORACLE_ABI,
+        functionName: "receiveMessage",
+        args: [proofHex]
+      });
+
+      const result = await getClient(sourceChainId).waitForTransactionReceipt({
+        hash: transactionHash,
+        timeout: 120_000,
+        pollingInterval: 2_000
+      });
+      await Solver.persistReceipt(sourceChainId, transactionHash, result);
+      if (postHook) await postHook();
+      return result;
+    })();
   }
 
   static claim(

--- a/src/lib/libraries/solver.ts
+++ b/src/lib/libraries/solver.ts
@@ -519,7 +519,10 @@ export class Solver {
       }
       for (let i = 0; i < fillTransactionHashes.length; i++) {
         const hash = fillTransactionHashes[i];
-        if (!hash || !hash.startsWith("0x") || hash.length !== 66) {
+        // Checked against the OUTPUT chain, not sourceChainId: a Solana fill
+        // is a base58 signature even when the order's input chain is EVM, and
+        // the reverse holds for an EVM fill of a Solana-input order.
+        if (!isValidTxRef(hash, order.outputs[i]?.chainId)) {
           throw new Error(`Invalid fill tx hash at index ${i}: ${hash}`);
         }
       }
@@ -532,7 +535,7 @@ export class Solver {
       const solveParams = await Promise.all(
         fillTransactionHashes.map(async (fth, i) => {
           const output = order.outputs[i];
-          const { solver, timestamp } = await getFillDetails(orderId, output, fth as `0x${string}`);
+          const { solver, timestamp } = await getFillDetails(orderId, output, fth);
           return { timestamp, solver };
         })
       );

--- a/src/lib/libraries/solver.ts
+++ b/src/lib/libraries/solver.ts
@@ -19,6 +19,7 @@ import { finaliseIntent } from "./intentExecution";
 import { getFillDetails } from "./fillEvent";
 import { isSolanaChain, isTronChain } from "$lib/utils/chainType";
 import { isValidTxRef, type TxRef } from "$lib/utils/txRef";
+import { polymerReceiveFunction } from "./polymerReceive";
 import { getSolanaReads } from "$lib/solana/client";
 import { createSolanaPrograms } from "$lib/solana/program";
 import { getSolanaSigner } from "$lib/solana/wallet";
@@ -591,9 +592,11 @@ export class Solver {
       if (preHook) await preHook(Number(sourceChainId));
 
       const proofHex = `0x${proof.replace("0x", "")}` as `0x${string}`;
+      // Chosen by the chain the proof came FROM, not the chain we are calling.
+      const receiveFn = polymerReceiveFunction(output.chainId);
       const simCalldata = encodeFunctionData({
         abi: POLYMER_ORACLE_ABI,
-        functionName: "receiveMessage",
+        functionName: receiveFn,
         args: [proofHex]
       });
       try {
@@ -604,7 +607,7 @@ export class Solver {
         });
       } catch (simError) {
         throw new Error(
-          `receiveMessage simulation failed on chain ${Number(sourceChainId)}: ${Solver.extractRevertReason(simError)}`,
+          `${receiveFn} simulation failed on chain ${Number(sourceChainId)}: ${Solver.extractRevertReason(simError)}`,
           { cause: simError as Error }
         );
       }
@@ -614,7 +617,7 @@ export class Solver {
         account: account(),
         address: order.inputOracle,
         abi: POLYMER_ORACLE_ABI,
-        functionName: "receiveMessage",
+        functionName: receiveFn,
         args: [proofHex]
       });
 

--- a/src/lib/libraries/solver.ts
+++ b/src/lib/libraries/solver.ts
@@ -16,7 +16,12 @@ import { compactTypes } from "@lifi/intent";
 import store from "$lib/state.svelte";
 import { finaliseIntent } from "./intentExecution";
 import { getFillDetails } from "./fillEvent";
-import { isTronChain } from "$lib/utils/chainType";
+import { isSolanaChain, isTronChain } from "$lib/utils/chainType";
+import { getSolanaReads } from "$lib/solana/client";
+import { createSolanaPrograms } from "$lib/solana/program";
+import { getSolanaSigner } from "$lib/solana/wallet";
+import { fillOutput as fillSolanaOutput, finalise as finaliseSolana } from "$lib/solana/writes";
+import type { SolanaDeps } from "$lib/solana/types";
 import { getTronReads, getTronSigner } from "$lib/tron/client";
 import {
   fillOutputs as fillTronOutputs,
@@ -28,6 +33,21 @@ import type { TronDeps } from "$lib/tron/types";
 
 async function tronDeps(): Promise<TronDeps> {
   return { reads: await getTronReads(), signer: getTronSigner() };
+}
+
+/**
+ * Assembles the Solana dependency bundle for a chain.
+ *
+ * The chain id is always taken from the order — never from the UI's network
+ * toggle — so a devnet order cannot be signed against mainnet.
+ */
+async function solanaDeps(chainId: bigint): Promise<SolanaDeps> {
+  const signer = await getSolanaSigner(chainId);
+  const [reads, programs] = await Promise.all([
+    getSolanaReads(chainId),
+    createSolanaPrograms({ chainId, publicKey: signer.publicKey })
+  ]);
+  return { chainId, reads, signer, programs };
 }
 
 /**
@@ -95,6 +115,27 @@ export class Solver {
       const orderId = containerToIntent(args.orderContainer).orderId();
 
       const outputChainId = Number(outputs[0].chainId);
+
+      if (isSolanaChain(outputChainId)) {
+        // The Solana settler fills ONE output per instruction — there is no
+        // batch equivalent of fillOrderOutputs — so a multi-output fill on the
+        // same chain is several transactions, and only the first signature is
+        // returned as the fill reference for this group.
+        const deps = await solanaDeps(BigInt(outputChainId));
+        const signatures: string[] = [];
+        for (const output of outputs) {
+          signatures.push(
+            await fillSolanaOutput(deps, {
+              orderId,
+              output,
+              fillDeadline: Number(order.fillDeadline),
+              solverBytes32: addressToBytes32(solverAddress)
+            })
+          );
+        }
+        if (postHook) await postHook();
+        return signatures[0]!;
+      }
 
       if (isTronChain(outputChainId)) {
         const txId = await fillTronOutputs(await tronDeps(), {
@@ -421,8 +462,6 @@ export class Solver {
       const { orderContainer, fillTransactionHashes, sourceChainId } = args;
       const { order, inputSettler } = orderContainer;
       const intent = containerToIntent(orderContainer);
-      if (intent instanceof StandardSolanaIntent)
-        throw new Error("Finalise is not supported for Solana input intents.");
 
       if (fillTransactionHashes.length !== order.outputs.length) {
         throw new Error(
@@ -458,6 +497,20 @@ export class Solver {
         );
       }
 
+      if (isSolanaChain(sourceChainId)) {
+        if (!(intent instanceof StandardSolanaIntent)) {
+          throw new Error("A Solana-input order must be a StandardSolanaIntent");
+        }
+        const signature = await finaliseSolana(await solanaDeps(BigInt(sourceChainId)), {
+          order: intent.asOrder(),
+          orderId: intent.orderId(),
+          solveParams,
+          destinationBytes32: addressToBytes32(account())
+        });
+        if (postHook) await postHook();
+        return signature;
+      }
+
       if (isTronChain(sourceChainId)) {
         if (!("originChainId" in order)) {
           throw new Error("Tron claim only supports single-chain (StandardOrder) intents");
@@ -470,6 +523,15 @@ export class Solver {
         });
         if (postHook) await postHook();
         return `0x${txId.replace("0x", "")}`;
+      }
+
+      if (intent instanceof StandardSolanaIntent) {
+        // Reachable only if the order's namespace and its source chain id
+        // disagree, which means the container is malformed rather than that
+        // some path is unimplemented.
+        throw new Error(
+          `Order is a Solana intent but its source chain ${sourceChainId} is not a Solana chain`
+        );
       }
 
       if (preHook) await preHook(Number(sourceChainId));

--- a/src/lib/libraries/solver.ts
+++ b/src/lib/libraries/solver.ts
@@ -1,5 +1,5 @@
 import { BYTES32_ZERO, COIN_FILLER, getChain, getClient, getOracle, type WC } from "$lib/config";
-import { encodeFunctionData, hashStruct, maxUint256, parseEventLogs } from "viem";
+import { encodeFunctionData, hashStruct, hexToBytes, maxUint256, parseEventLogs } from "viem";
 import type { MandateOutput, OrderContainer } from "@lifi/intent";
 import {
   addressToBytes32,
@@ -25,8 +25,11 @@ import { getSolanaSigner } from "$lib/solana/wallet";
 import {
   fillOutputs as fillSolanaOutputs,
   finalise as finaliseSolana,
+  receiveProof as receiveSolanaProof,
   submitFillProof as submitSolanaFillProof
 } from "$lib/solana/writes";
+import { polymerScratchPdas } from "$lib/solana/pda";
+import { readPolymerProverId } from "$lib/solana/reads";
 import type { SolanaDeps } from "$lib/solana/types";
 import { getTronReads, getTronSigner } from "$lib/tron/client";
 import {
@@ -414,20 +417,25 @@ export class Solver {
         }
 
         if (isSolanaChain(sourceChainId)) {
-          // Receiving a proof ON Solana needs two things this app cannot yet
-          // determine: the Polymer prover's program id (readable from the
-          // OraclePolymer account) and the seeds of its cache/result/internal
-          // scratch PDAs, which are only documented in a stale reference test.
-          // `receiveProof` in $lib/solana/writes is written and tested against
-          // the DI seam; it is deliberately not called with guessed accounts.
-          //
-          // Failing here — rather than falling through to the EVM path, which
-          // would call getClient() on a Solana chain id — keeps the blocker
-          // legible. See the unverified list in
-          // tests/fixtures/solana/PREFLIGHT.md.
-          throw new Error(
-            `Receiving a Polymer proof on Solana is not wired up yet: the prover program id and its scratch-PDA seeds must be confirmed on chain first (see tests/fixtures/solana/PREFLIGHT.md). The proof itself was fetched successfully for chain ${Number(sourceChainId)}.`
-          );
+          const deps = await solanaDeps(BigInt(sourceChainId));
+          // The prover program id is pinned but verified against the on-chain
+          // OraclePolymer account here: it is external to this protocol, so a
+          // rotation would otherwise surface as an opaque CPI failure.
+          const proverProgramId = await readPolymerProverId(deps.reads);
+          const { solver, timestamp } = await getFillDetails(orderId, output, fillTransactionHash);
+          const { attestSignature, attestation } = await receiveSolanaProof(deps, {
+            proof: hexToBytes(`0x${proof.replace(/^0x/, "")}`),
+            orderId,
+            output,
+            solverBytes32: solver,
+            timestamp,
+            proverProgramId,
+            proverAccounts: polymerScratchPdas(deps.signer.publicKey, proverProgramId)
+          });
+          if (postHook) await postHook();
+          // No signature means the attestation already existed — re-running is
+          // a no-op, not a failure.
+          return { transactionHash: attestSignature, attestation };
         }
 
         if (isTronChain(sourceChainId)) {

--- a/src/lib/screens/ConnectWallet.svelte
+++ b/src/lib/screens/ConnectWallet.svelte
@@ -3,7 +3,11 @@
   import { connectWith, listWalletConnectors, walletConnectProjectId } from "$lib/utils/wagmi";
   import { isTronLinkAvailable, connectTronLink } from "$lib/tron/signer";
   import type { SolanaWalletOption } from "$lib/solana/wallet";
-  import { connectSolanaWallet, listSolanaWallets } from "$lib/solana/wallet";
+  import {
+    connectSolanaWallet,
+    isSolanaWalletDetected,
+    watchSolanaWallets
+  } from "$lib/solana/wallet";
   import store from "$lib/state.svelte";
 
   const connectors = listWalletConnectors();
@@ -39,13 +43,11 @@
   };
 
   // The adapters report availability asynchronously (they wait for injection),
-  // so this is loaded rather than read synchronously like TronLink's.
+  // so this is subscribed rather than read synchronously like TronLink's — and
+  // subscribed rather than fetched once, because readyState keeps changing
+  // after mount.
   let solanaWallets = $state<SolanaWalletOption[]>([]);
-  $effect(() => {
-    listSolanaWallets()
-      .then((wallets) => (solanaWallets = wallets))
-      .catch((error) => console.warn("listSolanaWallets failed", error));
-  });
+  $effect(() => watchSolanaWallets((wallets) => (solanaWallets = wallets)));
 
   const connectSolana = async (name: string) => {
     try {
@@ -103,14 +105,14 @@
       <button
         type="button"
         class="w-full cursor-pointer rounded border border-gray-300 px-4 py-3 text-base font-semibold text-gray-700 hover:border-sky-500 hover:text-sky-700 disabled:cursor-not-allowed disabled:text-gray-400"
-        disabled={connectingId !== null || wallet.readyState === "NotDetected"}
+        disabled={connectingId !== null || !isSolanaWalletDetected(wallet)}
         onclick={() => connectSolana(wallet.name)}
       >
         {#if connectingId === `solana:${wallet.name}`}
           Connecting {wallet.name}...
-        {:else if store.solanaConnectedAccount && store.solanaWalletConnection.address}
+        {:else if store.solanaConnectedAccount && store.solanaWalletConnection.walletName === wallet.name}
           {wallet.name} Connected ({store.solanaConnectedAccount.base58Address.slice(0, 6)}...)
-        {:else if wallet.readyState === "NotDetected"}
+        {:else if !isSolanaWalletDetected(wallet)}
           {wallet.name} not detected
         {:else}
           Connect {wallet.name}

--- a/src/lib/screens/ConnectWallet.svelte
+++ b/src/lib/screens/ConnectWallet.svelte
@@ -2,6 +2,8 @@
   import ScreenFrame from "$lib/components/ui/ScreenFrame.svelte";
   import { connectWith, listWalletConnectors, walletConnectProjectId } from "$lib/utils/wagmi";
   import { isTronLinkAvailable, connectTronLink } from "$lib/tron/signer";
+  import type { SolanaWalletOption } from "$lib/solana/wallet";
+  import { connectSolanaWallet, listSolanaWallets } from "$lib/solana/wallet";
   import store from "$lib/state.svelte";
 
   const connectors = listWalletConnectors();
@@ -31,6 +33,28 @@
     } catch (error) {
       console.warn("connectTronLink failed", error);
       errorMessage = error instanceof Error ? error.message : "Could not connect TronLink.";
+    } finally {
+      connectingId = null;
+    }
+  };
+
+  // The adapters report availability asynchronously (they wait for injection),
+  // so this is loaded rather than read synchronously like TronLink's.
+  let solanaWallets = $state<SolanaWalletOption[]>([]);
+  $effect(() => {
+    listSolanaWallets()
+      .then((wallets) => (solanaWallets = wallets))
+      .catch((error) => console.warn("listSolanaWallets failed", error));
+  });
+
+  const connectSolana = async (name: string) => {
+    try {
+      connectingId = `solana:${name}`;
+      errorMessage = null;
+      store.solanaWalletConnection = await connectSolanaWallet(name);
+    } catch (error) {
+      console.warn(`connectSolanaWallet failed for ${name}`, error);
+      errorMessage = error instanceof Error ? error.message : `Could not connect ${name}.`;
     } finally {
       connectingId = null;
     }
@@ -74,6 +98,25 @@
         TronLink not detected — install it to use Tron chains.
       </p>
     {/if}
+
+    {#each solanaWallets as wallet (wallet.name)}
+      <button
+        type="button"
+        class="w-full cursor-pointer rounded border border-gray-300 px-4 py-3 text-base font-semibold text-gray-700 hover:border-sky-500 hover:text-sky-700 disabled:cursor-not-allowed disabled:text-gray-400"
+        disabled={connectingId !== null || wallet.readyState === "NotDetected"}
+        onclick={() => connectSolana(wallet.name)}
+      >
+        {#if connectingId === `solana:${wallet.name}`}
+          Connecting {wallet.name}...
+        {:else if store.solanaConnectedAccount && store.solanaWalletConnection.address}
+          {wallet.name} Connected ({store.solanaConnectedAccount.base58Address.slice(0, 6)}...)
+        {:else if wallet.readyState === "NotDetected"}
+          {wallet.name} not detected
+        {:else}
+          Connect {wallet.name}
+        {/if}
+      </button>
+    {/each}
 
     {#if !walletConnectProjectId}
       <p class="text-center text-xs text-gray-500">

--- a/src/lib/screens/FillIntent.svelte
+++ b/src/lib/screens/FillIntent.svelte
@@ -12,7 +12,7 @@
   import { compactTypes } from "@lifi/intent";
   import { hashStruct } from "viem";
   import { isTronBase58Address } from "$lib/utils/chainType";
-  import { isValidTxRef, normalizeTxRef, txRefError } from "$lib/utils/txRef";
+  import { isValidTxRef, normalizeTxRef, txRefError, txRefPlaceholder } from "$lib/utils/txRef";
   import { isOutputFilled } from "$lib/libraries/fillStatus";
   import { tronBase58ToHex } from "@lifi/intent";
 
@@ -207,7 +207,7 @@
             <input
               type="text"
               class="h-7 min-w-0 flex-1 rounded border border-gray-200 bg-white px-2 text-xs text-gray-700 outline-none focus:border-sky-300"
-              placeholder="0x... fill tx hash"
+              placeholder={`${txRefPlaceholder(output.chainId)} fill tx`}
               value={getManualFillTxInputValue(output)}
               oninput={(event) => {
                 const value = (event.currentTarget as HTMLInputElement).value;

--- a/src/lib/screens/FillIntent.svelte
+++ b/src/lib/screens/FillIntent.svelte
@@ -15,6 +15,8 @@
   import { compactTypes } from "@lifi/intent";
   import { hashStruct } from "viem";
   import { isTronChain, isTronBase58Address } from "$lib/utils/chainType";
+  import { isValidTxRef, normalizeTxRef, txRefError } from "$lib/utils/txRef";
+  import { isOutputFilled } from "$lib/libraries/fillStatus";
   import { tronBase58ToHex } from "@lifi/intent";
 
   let {
@@ -38,7 +40,9 @@
   let refreshValidation = $state(0);
   let autoScrolledOrderId = $state<`0x${string}` | null>(null);
   let fillRun = 0;
-  let fillStatuses = $state<Record<string, `0x${string}`>>({});
+  // true = filled. Undefined means "not checked yet", which the UI
+  // distinguishes from "checked and not filled".
+  let fillStatuses = $state<Record<string, boolean>>({});
   let manualFillTxInputs = $state<Record<string, string>>({});
   let manualFillTxSaving = $state<Record<string, boolean>>({});
   let manualFillTxSaved = $state<Record<string, boolean>>({});
@@ -69,18 +73,6 @@
     refreshValidation += 1;
   };
 
-  async function isFilled(orderId: `0x${string}`, output: MandateOutput, _?: any) {
-    const outputHash = getOutputHash(output);
-    const outputClient = getClient(output.chainId);
-    const result = await outputClient.readContract({
-      address: bytes32ToAddress(output.settler),
-      abi: COIN_FILLER_ABI,
-      functionName: "getFillRecord",
-      args: [orderId, outputHash]
-    });
-    return result;
-  }
-
   function sortOutputsByChain(orderContainer: OrderContainer) {
     const outputs = orderContainer.order.outputs;
     const positionMap: { [chainId: string]: number } = {};
@@ -104,16 +96,6 @@
       types: compactTypes,
       primaryType: "MandateOutput"
     });
-  const isValidFillTxHash = (value: string, chainId?: bigint): value is `0x${string}` => {
-    if (value.startsWith("0x") && value.length === 66) return true;
-    if (chainId !== undefined && isTronChain(chainId) && /^[0-9a-fA-F]{64}$/.test(value))
-      return true;
-    return false;
-  };
-  const normalizeTxHash = (value: string, chainId?: bigint): `0x${string}` => {
-    if (value.startsWith("0x")) return value as `0x${string}`;
-    return `0x${value}` as `0x${string}`;
-  };
   const getManualFillTxInputValue = (output: MandateOutput) => {
     const key = outputKey(output);
     return manualFillTxInputs[key] ?? store.fillTransactions[key] ?? "";
@@ -121,17 +103,15 @@
   const saveManualFillTransaction = async (output: MandateOutput) => {
     const key = outputKey(output);
     const txHash = getManualFillTxInputValue(output).trim();
-    if (!isValidFillTxHash(txHash, output.chainId)) {
-      manualFillTxErrors[key] = isTronChain(output.chainId)
-        ? "Use a 64-char hex Tron tx ID or 0x-prefixed hash."
-        : "Use a 0x-prefixed 66-char tx hash.";
+    if (!isValidTxRef(txHash, output.chainId)) {
+      manualFillTxErrors[key] = txRefError(output.chainId);
       manualFillTxSaved[key] = false;
       return;
     }
     manualFillTxSaving[key] = true;
     manualFillTxErrors[key] = "";
     try {
-      const normalizedHash = normalizeTxHash(txHash, output.chainId);
+      const normalizedHash = normalizeTxRef(txHash, output.chainId);
       store.fillTransactions[key] = normalizedHash;
       await store.saveFillTransaction(key, normalizedHash);
       manualFillTxSaved[key] = true;
@@ -156,14 +136,16 @@
 
     const currentRun = ++fillRun;
     Promise.all(
-      outputs.map(async (output) => [outputKey(output), await isFilled(orderId, output)] as const)
+      outputs.map(
+        async (output) => [outputKey(output), await isOutputFilled(orderId, output)] as const
+      )
     )
       .then((entries) => {
         if (currentRun !== fillRun) return;
-        const nextStatuses: Record<string, `0x${string}`> = {};
+        const nextStatuses: Record<string, boolean> = {};
         for (const [key, status] of entries) nextStatuses[key] = status;
         fillStatuses = nextStatuses;
-        if (!entries.every(([, result]) => result !== BYTES32_ZERO)) return;
+        if (!entries.every(([, filled]) => filled)) return;
         autoScrolledOrderId = orderId;
         scroll(4)();
       })
@@ -223,7 +205,7 @@
                 getCoin({ address: output.token, chainId: output.chainId }).decimals
               )}
               symbol={getCoin({ address: output.token, chainId: output.chainId }).name}
-              tone={isValidFillTxHash(currentHash ?? "") ? "success" : "warning"}
+              tone={isValidTxRef(currentHash, output.chainId) ? "success" : "warning"}
             />
             <input
               type="text"
@@ -271,8 +253,8 @@
               </button>
             {:else}
               <AwaitButton
-                variant={chainStatuses.every((v) => v == BYTES32_ZERO) ? "default" : "muted"}
-                buttonFunction={chainStatuses.every((v) => v == BYTES32_ZERO)
+                variant={chainStatuses.every((v) => !v) ? "default" : "muted"}
+                buttonFunction={chainStatuses.every((v) => !v)
                   ? fillWrapper(
                       chainIdAndOutputs[1],
                       Solver.fill(
@@ -312,11 +294,7 @@
                   }).decimals
                 )}
                 symbol={getCoin({ address: output.token, chainId: output.chainId }).name}
-                tone={filled === undefined
-                  ? "muted"
-                  : filled === BYTES32_ZERO
-                    ? "neutral"
-                    : "success"}
+                tone={filled === undefined ? "muted" : filled ? "success" : "neutral"}
               />
             {/each}
           {/snippet}

--- a/src/lib/screens/FillIntent.svelte
+++ b/src/lib/screens/FillIntent.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
-  import { BYTES32_ZERO, formatTokenAmount, getChainName, getClient, getCoin } from "$lib/config";
-  import { bytes32ToAddress } from "@lifi/intent";
-  import { getOutputHash } from "@lifi/intent";
+  import { formatTokenAmount, getChainName, getCoin } from "$lib/config";
   import type { MandateOutput, OrderContainer } from "@lifi/intent";
   import { Solver } from "$lib/libraries/solver";
-  import { COIN_FILLER_ABI } from "$lib/abi/outputsettler";
   import AwaitButton from "$lib/components/AwaitButton.svelte";
   import ScreenFrame from "$lib/components/ui/ScreenFrame.svelte";
   import SectionCard from "$lib/components/ui/SectionCard.svelte";
@@ -14,7 +11,7 @@
   import { containerToIntent } from "$lib/utils/intent";
   import { compactTypes } from "@lifi/intent";
   import { hashStruct } from "viem";
-  import { isTronChain, isTronBase58Address } from "$lib/utils/chainType";
+  import { isTronBase58Address } from "$lib/utils/chainType";
   import { isValidTxRef, normalizeTxRef, txRefError } from "$lib/utils/txRef";
   import { isOutputFilled } from "$lib/libraries/fillStatus";
   import { tronBase58ToHex } from "@lifi/intent";

--- a/src/lib/screens/Finalise.svelte
+++ b/src/lib/screens/Finalise.svelte
@@ -25,7 +25,10 @@
   import { containerToIntent } from "$lib/utils/intent";
   import { hashStruct } from "viem";
   import { compactTypes } from "@lifi/intent";
-  import { isTronChain } from "$lib/utils/chainType";
+  import { isSolanaChain, isTronChain } from "$lib/utils/chainType";
+  import { isValidTxRef } from "$lib/utils/txRef";
+  import { getSolanaReads } from "$lib/solana/client";
+  import { readIsOrderFinalised } from "$lib/solana/reads";
   import { getTronReads } from "$lib/tron/client";
   import { readOrderStatus } from "$lib/tron/reads";
   import { getOrFetchRpc } from "$lib/libraries/rpcCache";
@@ -80,8 +83,22 @@
   const fillTransactionHashesFor = (container: OrderContainer) =>
     container.order.outputs.map((output) => store.fillTransactions[outputKey(output)]);
 
-  const isValidFillTxHash = (hash: unknown): hash is `0x${string}` =>
-    typeof hash === "string" && hash.startsWith("0x") && hash.length === 66;
+  // The fill reference belongs to the OUTPUT chain, not the input chain: a
+  // Solana fill of an EVM-input order is base58 even though the source chain is
+  // EVM, so the output's chain id is what validates it.
+  const isValidFillTxHash = (hash: unknown, chainId?: bigint) =>
+    typeof hash === "string" && isValidTxRef(hash, chainId);
+
+  /**
+   * Whether every output has a usable fill reference.
+   *
+   * Each hash is validated against ITS OWN output's chain, not the order's
+   * source chain — a Solana fill of an EVM-input order is base58.
+   */
+  const hasAllFillTransactions = (container: OrderContainer) =>
+    container.order.outputs.every((output) =>
+      isValidFillTxHash(store.fillTransactions[outputKey(output)], output.chainId)
+    );
 
   // Order status enum
   const OrderStatus_None = 0;
@@ -93,6 +110,17 @@
     const { order, inputSettler } = container;
     const intent = containerToIntent(container);
     const orderId = intent.orderId();
+
+    if (isSolanaChain(chainId)) {
+      // No status enum on Solana: finalise and refund both close order_context,
+      // so its absence (with consumed_order still present) is the terminal
+      // signal — the same Claimed-or-Refunded conflation as the branches below.
+      return getOrFetchRpc(
+        `claim:solana:${orderId}`,
+        async () => readIsOrderFinalised(await getSolanaReads(chainId), orderId),
+        { ttlMs: 30_000 }
+      );
+    }
 
     if (isTronChain(chainId)) {
       const orderStatus = await getOrFetchRpc(
@@ -213,7 +241,7 @@
               </button>
             {:else}
               {@const fillTransactionHashes = fillTransactionHashesFor(orderContainer)}
-              {@const canClaim = fillTransactionHashes.every((hash) => isValidFillTxHash(hash))}
+              {@const canClaim = hasAllFillTransactions(orderContainer)}
               {#if !canClaim}
                 <button
                   type="button"

--- a/src/lib/screens/IssueIntent.svelte
+++ b/src/lib/screens/IssueIntent.svelte
@@ -253,7 +253,8 @@
             useProductionApi={store.useProductionApi}
             inputTokens={store.inputTokens}
             bind:outputTokens={store.outputTokens}
-            {account}
+            accountForChain={(chainId) => store.accountForChain(chainId)}
+            outputRecipient={resolveRecipient(store.recipient)}
           ></GetQuote>
         </div>
       {/snippet}

--- a/src/lib/screens/IssueIntent.svelte
+++ b/src/lib/screens/IssueIntent.svelte
@@ -17,8 +17,8 @@
   import OutputTokenModal from "$lib/components/OutputTokenModal.svelte";
   import { ResetPeriod } from "@lifi/intent";
   import type { AppCreateIntentOptions } from "$lib/appTypes";
-  import { resolveAddress } from "$lib/utils/address";
-  import { getChainType } from "$lib/utils/chainType";
+  import { resolveAddress, resolveAddressForChainType } from "$lib/utils/address";
+  import { formatAddressForChain, getChainType } from "$lib/utils/chainType";
 
   const bigIntSum = (...nums: bigint[]) => nums.reduce((a, b) => a + b, 0n);
   const REQUIRED_INPUT_USDC_RAW = 100n;
@@ -40,8 +40,6 @@
 
   const resolveExclusiveFor = (value: string): `0x${string}` | undefined => resolveAddress(value);
 
-  const resolveRecipient = (value: string): `0x${string}` | undefined => resolveAddress(value);
-
   // Cross-namespace orders (e.g. EVM -> Tron) must name their recipient: the
   // default recipient is the source-chain account, which only a plain EOA key
   // can control on the destination namespace (a Safe or exchange address
@@ -54,6 +52,66 @@
     );
   });
 
+  const outputChainTypes = $derived([
+    ...new Set(store.outputTokens.map((o) => getChainType(o.token.chainId)))
+  ]);
+
+  // Resolved against the OUTPUT chain's namespace, never chain-agnostically:
+  // `@lifi/intent` zero-pads a 20-byte EVM address into a Solana pubkey nobody
+  // controls, and the EVM settler truncates a 32-byte Solana key to its low 20
+  // bytes — either way a wrong-namespace recipient silently burns the output.
+  const resolvedRecipient = $derived.by((): `0x${string}` | undefined => {
+    if (store.recipient.trim().length === 0) return undefined;
+    const resolutions = outputChainTypes.map((chainType) =>
+      resolveAddressForChainType(store.recipient, chainType)
+    );
+    if (resolutions.length === 0 || resolutions.some((r) => r === undefined)) return undefined;
+    // Distinct chain types resolve disjoint formats, so all-defined means
+    // every entry is the same value.
+    return resolutions[0];
+  });
+
+  const RECIPIENT_FORMAT_HINT: Record<ReturnType<typeof getChainType>, string> = {
+    solana:
+      "Recipient must be a base58 Solana address — a 0x address would be padded into a Solana key nobody controls.",
+    tron: "Recipient must be a Tron (T...) or 0x address.",
+    evm: "Recipient must be a 0x or Tron (T...) address — a Solana key would be truncated to 20 bytes on payout."
+  };
+
+  const recipientProblem = $derived.by((): string | undefined => {
+    if (store.recipient.trim().length === 0) {
+      return recipientRequired
+        ? "This order pays out on a different chain type than it is opened on — enter a recipient address for the output chain."
+        : undefined;
+    }
+    if (resolvedRecipient !== undefined) return undefined;
+    if (outputChainTypes.length > 1) {
+      return "No single recipient is valid on every output chain type — use outputs from one chain type.";
+    }
+    return RECIPIENT_FORMAT_HINT[outputChainTypes[0] ?? "evm"];
+  });
+
+  // Solana fills batch all of a chain's outputs into ONE transaction — the fill
+  // reference stored per output must contain every output's OutputFilledEvent
+  // (see fillOutputs in src/lib/solana/writes.ts) — and two exclusive outputs
+  // already exceed Solana's 1232-byte transaction cap. Such an order opens,
+  // escrows the inputs, and then can never be filled, so it is blocked here.
+  const solanaOutputOverflow = $derived.by(() => {
+    const perChain = new Map<number, number>();
+    for (const { token } of store.outputTokens) {
+      if (getChainType(token.chainId) !== "solana") continue;
+      perChain.set(token.chainId, (perChain.get(token.chainId) ?? 0) + 1);
+    }
+    return [...perChain.values()].some((count) => count > 1);
+  });
+
+  const issueBlocker = $derived(
+    recipientProblem ??
+      (solanaOutputOverflow
+        ? "Solana orders support a single output: all outputs must be filled in one Solana transaction, and more than one exceeds the 1232-byte transaction size — the order would open but could never be filled."
+        : undefined)
+  );
+
   const intentOptions = $derived.by(
     (): AppCreateIntentOptions => ({
       // In 1:1 demo mode the quote omits exclusiveFor, but the on-chain intent
@@ -64,7 +122,7 @@
       inputTokens: store.inputTokens,
       outputTokens: store.outputTokens,
       verifier: store.verifier,
-      outputRecipient: resolveRecipient(store.recipient),
+      outputRecipient: resolvedRecipient,
       lock:
         store.intentType === "compact"
           ? {
@@ -254,7 +312,7 @@
             inputTokens={store.inputTokens}
             bind:outputTokens={store.outputTokens}
             accountForChain={(chainId) => store.accountForChain(chainId)}
-            outputRecipient={resolveRecipient(store.recipient)}
+            outputRecipient={resolvedRecipient}
           ></GetQuote>
         </div>
       {/snippet}
@@ -328,13 +386,21 @@
             size="sm"
             className="flex-1"
             placeholder="0x... or T... (optional)"
-            state={(store.recipient.length > 0 && !resolveRecipient(store.recipient)) ||
-            (recipientRequired && store.recipient.length === 0)
-              ? "error"
-              : "default"}
+            state={recipientProblem !== undefined ? "error" : "default"}
             bind:value={store.recipient}
           />
         </div>
+        {#if resolvedRecipient !== undefined}
+          <p class="text-[11px] break-all text-gray-500">
+            Pays out to
+            <span class="font-medium text-gray-600">
+              {formatAddressForChain(resolvedRecipient, store.outputTokens[0].token.chainId)}
+            </span>
+            on {getChainName(store.outputTokens[0].token.chainId)}
+          </p>
+        {:else if recipientProblem !== undefined && store.recipient.trim().length > 0}
+          <p class="text-[11px] text-red-600">{recipientProblem}</p>
+        {/if}
         <div class="flex items-center gap-1">
           <span class="text-[11px] font-semibold text-gray-500">Verifier</span>
           {#if sameChain}
@@ -393,7 +459,17 @@
     </SectionCard>
 
     <div class="mt-2 flex justify-center">
-      {#if !allowanceCheck}
+      {#if issueBlocker !== undefined}
+        <!-- Before the allowance branch: an order that can never be issued
+             must not prompt for an approval transaction first. -->
+        <button
+          type="button"
+          class="h-8 rounded border border-amber-200 bg-amber-50 px-3 text-sm font-semibold text-amber-700"
+          disabled
+        >
+          Cannot Issue
+        </button>
+      {:else if !allowanceCheck}
         <AwaitButton buttonFunction={approveFunction}>
           {#snippet name()}
             Set allowance
@@ -445,6 +521,11 @@
         </div>
       {/if}
     </div>
+    {#if issueBlocker !== undefined}
+      <p class="mx-auto mt-2 w-4/5 text-center text-xs font-medium text-amber-700">
+        {issueBlocker}
+      </p>
+    {/if}
     {#if numInputChains > 1 && store.intentType !== "compact"}
       <p class="mx-auto mt-2 w-4/5 text-center text-xs text-gray-600">
         You'll need to open the order on {numInputChains} chains. Be prepared and do not interrupt the

--- a/src/lib/screens/ReceiveMessage.svelte
+++ b/src/lib/screens/ReceiveMessage.svelte
@@ -15,7 +15,7 @@
   import { containerToIntent } from "$lib/utils/intent";
   import { compactTypes } from "@lifi/intent";
   import { isSolanaChain, isTronChain } from "$lib/utils/chainType";
-  import { isValidTxRef } from "$lib/utils/txRef";
+  import { isValidTxRef, type TxRef } from "$lib/utils/txRef";
   import { getSolanaReads } from "$lib/solana/client";
   import { readIsLocallyAttested, readIsProvenOnSolana } from "$lib/solana/reads";
   import { getFillDetails } from "$lib/libraries/fillEvent";
@@ -60,7 +60,11 @@
     chainId: bigint,
     orderContainer: OrderContainer,
     output: MandateOutput,
-    fillTransactionHash: `0x${string}`,
+    // TxRef, not `0x${string}`: this holds a base58 signature whenever the
+    // output chain is Solana. Note `chainId` above is the INPUT chain — the
+    // two are different chains, and validating against the wrong one silently
+    // rejects every Solana fill.
+    fillTransactionHash: TxRef,
     _?: any
   ) {
     // Validated against the OUTPUT chain: a Solana fill of an EVM-input order
@@ -156,7 +160,7 @@
             inputChain,
             orderContainer,
             output,
-            fillTxHashes[outputIndex] as `0x${string}`,
+            fillTxHashes[outputIndex],
             refreshValidation
           )
       }))
@@ -180,6 +184,22 @@
       scroll(5)();
     });
   });
+
+  /**
+   * Chains this row will actually ask for a signature on, other than the input
+   * chain it is labelled with.
+   *
+   * Proving a Solana output runs `submit` on Solana rather than
+   * `receiveMessage` on the input chain (Solver.validate branches on
+   * `output.chainId` before it looks at the source chain), so a Base-labelled
+   * row can legitimately open a Solana wallet.
+   */
+  function proofChains(inputChain: bigint | number): bigint[] {
+    const elsewhere = orderContainer.order.outputs
+      .filter((output) => isSolanaChain(output.chainId) && output.chainId !== BigInt(inputChain))
+      .map((output) => output.chainId);
+    return [...new Set(elsewhere)];
+  }
 </script>
 
 <ScreenFrame
@@ -192,6 +212,18 @@
         <ChainActionRow chainLabel={getChainName(inputChain)}>
           {#snippet action()}
             <div class="text-[11px] font-semibold text-gray-500 uppercase">Validate outputs</div>
+            <!--
+              The row is grouped by INPUT chain, but validating a Solana output
+              submits the fill to the Solana oracle — so the signature comes
+              from the Solana wallet, not the wallet for the chain named above.
+              Said out loud, because an unexplained Solflare prompt on a row
+              labelled "Base" reads as a bug.
+            -->
+            {#each proofChains(inputChain) as proofChain (proofChain)}
+              <div class="text-[10px] text-gray-400 normal-case">
+                signs on {getChainName(proofChain)}
+              </div>
+            {/each}
           {/snippet}
           {#snippet chips()}
             {#each orderContainer.order.outputs as output}

--- a/src/lib/screens/ReceiveMessage.svelte
+++ b/src/lib/screens/ReceiveMessage.svelte
@@ -14,7 +14,10 @@
   import store from "$lib/state.svelte";
   import { containerToIntent } from "$lib/utils/intent";
   import { compactTypes } from "@lifi/intent";
-  import { isTronChain } from "$lib/utils/chainType";
+  import { isSolanaChain, isTronChain } from "$lib/utils/chainType";
+  import { isValidTxRef } from "$lib/utils/txRef";
+  import { getSolanaReads } from "$lib/solana/client";
+  import { readIsLocallyAttested, readIsProvenOnSolana } from "$lib/solana/reads";
   import { getFillDetails } from "$lib/libraries/fillEvent";
   import { getTronReads } from "$lib/tron/client";
   import { readIsProven } from "$lib/tron/reads";
@@ -60,13 +63,9 @@
     fillTransactionHash: `0x${string}`,
     _?: any
   ) {
-    if (!fillTransactionHash) return false;
-    if (
-      !fillTransactionHash ||
-      !fillTransactionHash.startsWith("0x") ||
-      fillTransactionHash.length != 66
-    )
-      return false;
+    // Validated against the OUTPUT chain: a Solana fill of an EVM-input order
+    // is a base58 signature even though `chainId` here is the input chain.
+    if (!isValidTxRef(fillTransactionHash, output.chainId)) return false;
     const { order } = orderContainer;
     // Solver and timestamp come from the OutputFilled event — the recorded
     // solver may be an override, not the transaction sender.
@@ -78,6 +77,20 @@
       output
     });
     const outputHash = keccak256(encodedOutput);
+    if (isSolanaChain(chainId)) {
+      // On Solana the oracle CREATES an attestation account, so existence is
+      // the proof. A same-chain fill never reaches an oracle at all — the fill
+      // itself writes the LocalAttestation.
+      const reads = await getSolanaReads(chainId);
+      if (output.chainId === chainId) {
+        return readIsLocallyAttested(reads, { orderId, output, solver });
+      }
+      return readIsProvenOnSolana(reads, {
+        inputOracle: order.inputOracle,
+        output,
+        payloadHash: outputHash
+      });
+    }
     if (isTronChain(chainId)) {
       return await readIsProven(
         await getTronReads(),
@@ -129,12 +142,9 @@
       return store.fillTransactions[outputKey(output)];
     });
 
-    if (
-      fillTxHashes.some(
-        (fillTxHash) => !fillTxHash || !fillTxHash.startsWith("0x") || fillTxHash.length !== 66
-      )
-    )
-      return;
+    // Each reference is checked against its own output's chain: a Solana fill
+    // is base58, an EVM or Tron one a 0x hash.
+    if (outputs.some((output, i) => !isValidTxRef(fillTxHashes[i], output.chainId))) return;
 
     const currentRun = ++validationRun;
     const pairs = inputChains.flatMap((inputChain) =>

--- a/src/lib/solana/client.ts
+++ b/src/lib/solana/client.ts
@@ -6,11 +6,19 @@ import type { SolanaConnectionLike } from "./types";
 // module — same reason as src/lib/tron/signer.ts.
 const browser = typeof window !== "undefined";
 
-// Public endpoints rate-limit aggressively against the app's balance polling,
-// so a dedicated RPC is strongly recommended. PUBLIC_ prefix = shipped in the
-// client bundle, which is fine for an RPC URL.
+// NOT api.mainnet-beta.solana.com: Solana Labs' public mainnet endpoint
+// answers application traffic with a flat `403 Access forbidden` — it is
+// reserved for CLI/development use, and no amount of request pacing gets past
+// it. publicnode serves the same cluster (genesis hash asserted below) with
+// `Access-Control-Allow-Origin: *`. Devnet's public endpoint is not restricted
+// this way and works as-is.
+//
+// Both remain best-effort community endpoints: fine for a demo, but a
+// dedicated RPC is worth setting for anything sustained, mainly because public
+// endpoints prune transaction history and `getFillDetails` reads fills back by
+// signature. PUBLIC_ prefix = shipped in the client bundle, fine for an RPC URL.
 const mainnetRpcUrl =
-  import.meta.env?.PUBLIC_SOLANA_MAINNET_RPC_URL?.trim() || "https://api.mainnet-beta.solana.com";
+  import.meta.env?.PUBLIC_SOLANA_MAINNET_RPC_URL?.trim() || "https://solana-rpc.publicnode.com";
 const devnetRpcUrl =
   import.meta.env?.PUBLIC_SOLANA_DEVNET_RPC_URL?.trim() || "https://api.devnet.solana.com";
 

--- a/src/lib/solana/client.ts
+++ b/src/lib/solana/client.ts
@@ -26,8 +26,8 @@ export function solanaRpcUrl(chainId: number | bigint): string {
  * cluster it actually serves. Same reasoning as
  * TRON_MAINNET_GENESIS_BLOCK_ID in the Tron facade.
  *
- * UNVERIFIED against a live RPC — see tests/fixtures/solana/PREFLIGHT.md.
- * These are the widely published values; confirm before enabling mainnet.
+ * Both values read from live RPC on 2026-08-13 and recorded in
+ * tests/fixtures/solana/PREFLIGHT.md.
  */
 export const SOLANA_GENESIS_HASHES: Record<string, string> = {
   [SOLANA_MAINNET_CHAIN_ID.toString()]: "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",

--- a/src/lib/solana/client.ts
+++ b/src/lib/solana/client.ts
@@ -104,14 +104,14 @@ export function getSolanaReads(chainId: number | bigint): Promise<SolanaConnecti
       },
       getBalance: async (address) => BigInt(await connection.getBalance(new PublicKey(address))),
       getTokenAccountBalance: async (address) => {
-        try {
-          const balance = await connection.getTokenAccountBalance(new PublicKey(address));
-          return BigInt(balance.value.amount);
-        } catch {
-          // An ATA that has never been funded simply does not exist. That is a
-          // zero balance, not an error — the UI must not show it as a failure.
-          return 0n;
-        }
+        // An ATA that has never been funded does not exist, and that is a zero
+        // balance rather than an error. Everything else — rate limits, network
+        // failures — must propagate: reporting those as 0n tells the user they
+        // hold nothing, which is worse than showing an error.
+        const info = await connection.getAccountInfo(new PublicKey(address));
+        if (!info) return 0n;
+        const balance = await connection.getTokenAccountBalance(new PublicKey(address));
+        return BigInt(balance.value.amount);
       },
       getLatestBlockhash: () => connection.getLatestBlockhash()
     };

--- a/src/lib/solana/client.ts
+++ b/src/lib/solana/client.ts
@@ -1,0 +1,158 @@
+import { browser } from "$app/environment";
+import { SOLANA_DEVNET_CHAIN_ID, SOLANA_MAINNET_CHAIN_ID } from "@lifi/intent";
+import { isSolanaChain, isSolanaMainnet } from "$lib/utils/chainType";
+import type { SolanaConnectionLike } from "./types";
+
+// Public endpoints rate-limit aggressively against the app's balance polling,
+// so a dedicated RPC is strongly recommended. PUBLIC_ prefix = shipped in the
+// client bundle, which is fine for an RPC URL.
+const mainnetRpcUrl =
+  import.meta.env?.PUBLIC_SOLANA_MAINNET_RPC_URL?.trim() || "https://api.mainnet-beta.solana.com";
+const devnetRpcUrl =
+  import.meta.env?.PUBLIC_SOLANA_DEVNET_RPC_URL?.trim() || "https://api.devnet.solana.com";
+
+export function solanaRpcUrl(chainId: number | bigint): string {
+  return isSolanaMainnet(chainId) ? mainnetRpcUrl : devnetRpcUrl;
+}
+
+/**
+ * Genesis hashes, used as the network guard.
+ *
+ * Checking the genesis hash rather than the RPC URL is deliberate: a wallet
+ * can be pointed at any endpoint, and only the genesis block identifies the
+ * cluster it actually serves. Same reasoning as
+ * TRON_MAINNET_GENESIS_BLOCK_ID in the Tron facade.
+ *
+ * UNVERIFIED against a live RPC — see tests/fixtures/solana/PREFLIGHT.md.
+ * These are the widely published values; confirm before enabling mainnet.
+ */
+export const SOLANA_GENESIS_HASHES: Record<string, string> = {
+  [SOLANA_MAINNET_CHAIN_ID.toString()]: "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+  [SOLANA_DEVNET_CHAIN_ID.toString()]: "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"
+};
+
+const connections = new Map<string, Promise<SolanaConnectionLike>>();
+
+/**
+ * Memoized read connection for a chain id.
+ *
+ * Keyed by chain id rather than a single global, because a Solana order's
+ * cluster comes from the order itself: an app that keeps one connection and
+ * flips it with a UI toggle will happily send a devnet order to mainnet.
+ *
+ * `@solana/web3.js` is imported lazily to keep it out of SSR and the main
+ * chunk, mirroring `getTronReads`.
+ */
+export function getSolanaReads(chainId: number | bigint): Promise<SolanaConnectionLike> {
+  if (!browser) {
+    return Promise.reject(new Error("Solana reads are only available in the browser"));
+  }
+  if (!isSolanaChain(chainId)) {
+    return Promise.reject(new Error(`Chain ${chainId} is not a Solana chain`));
+  }
+
+  const key = chainId.toString();
+  const existing = connections.get(key);
+  if (existing) return existing;
+
+  const created = import("@solana/web3.js").then(({ Connection, PublicKey }) => {
+    const connection = new Connection(solanaRpcUrl(chainId), "confirmed");
+
+    // Adapt the SDK to SolanaConnectionLike so nothing downstream sees a
+    // PublicKey. Address strings in, plain values out.
+    const adapter: SolanaConnectionLike = {
+      rpcEndpoint: connection.rpcEndpoint,
+      getGenesisHash: () => connection.getGenesisHash(),
+      getAccountInfo: async (address, commitment) => {
+        const info = await connection.getAccountInfo(new PublicKey(address), commitment);
+        if (!info) return null;
+        return {
+          owner: info.owner.toBase58(),
+          lamports: info.lamports,
+          data: new Uint8Array(info.data)
+        };
+      },
+      getMultipleAccountsInfo: async (addresses) => {
+        const infos = await connection.getMultipleAccountsInfo(
+          addresses.map((address) => new PublicKey(address))
+        );
+        return infos.map((info) =>
+          info
+            ? {
+                owner: info.owner.toBase58(),
+                lamports: info.lamports,
+                data: new Uint8Array(info.data)
+              }
+            : null
+        );
+      },
+      getTransaction: async (signature, opts) => {
+        const tx = await connection.getTransaction(signature, {
+          commitment:
+            opts?.commitment === "processed" ? "confirmed" : (opts?.commitment ?? "confirmed"),
+          maxSupportedTransactionVersion: 0
+        });
+        if (!tx) return null;
+        return {
+          slot: tx.slot,
+          blockTime: tx.blockTime,
+          meta: tx.meta ? { err: tx.meta.err, logMessages: tx.meta.logMessages ?? null } : null
+        };
+      },
+      getBalance: async (address) => BigInt(await connection.getBalance(new PublicKey(address))),
+      getTokenAccountBalance: async (address) => {
+        try {
+          const balance = await connection.getTokenAccountBalance(new PublicKey(address));
+          return BigInt(balance.value.amount);
+        } catch {
+          // An ATA that has never been funded simply does not exist. That is a
+          // zero balance, not an error — the UI must not show it as a failure.
+          return 0n;
+        }
+      },
+      getLatestBlockhash: () => connection.getLatestBlockhash()
+    };
+    return adapter;
+  });
+
+  // Do not cache a rejected connection: a transient import or network failure
+  // would otherwise poison every later call.
+  created.catch(() => connections.delete(key));
+  connections.set(key, created);
+  return created;
+}
+
+const guardedEndpoints = new Set<string>();
+
+/** Clears the memoized cluster guard. Test-only seam. */
+export function invalidateSolanaClusterGuard(): void {
+  guardedEndpoints.clear();
+}
+
+/**
+ * Asserts the connection really serves the cluster `chainId` names.
+ *
+ * Called before every write. Cached per endpoint+chain because the genesis
+ * hash cannot change for a live endpoint, and an extra round trip before each
+ * signature is a poor trade.
+ */
+export async function assertSolanaCluster(
+  chainId: number | bigint,
+  reads: SolanaConnectionLike
+): Promise<void> {
+  const expected = SOLANA_GENESIS_HASHES[chainId.toString()];
+  if (!expected) {
+    throw new Error(`No genesis hash configured for Solana chain ${chainId}`);
+  }
+
+  const cacheKey = `${reads.rpcEndpoint ?? "unknown"}:${chainId}`;
+  if (guardedEndpoints.has(cacheKey)) return;
+
+  const actual = await reads.getGenesisHash();
+  if (actual !== expected) {
+    throw new Error(
+      `Solana RPC ${reads.rpcEndpoint ?? ""} serves genesis ${actual}, expected ${expected} for chain ${chainId}. Refusing to sign against the wrong cluster.`
+    );
+  }
+  guardedEndpoints.add(cacheKey);
+}

--- a/src/lib/solana/client.ts
+++ b/src/lib/solana/client.ts
@@ -1,7 +1,10 @@
-import { browser } from "$app/environment";
 import { SOLANA_DEVNET_CHAIN_ID, SOLANA_MAINNET_CHAIN_ID } from "@lifi/intent";
 import { isSolanaChain, isSolanaMainnet } from "$lib/utils/chainType";
 import type { SolanaConnectionLike } from "./types";
+
+// Plain runtime check instead of $app/environment so bun tests can import this
+// module — same reason as src/lib/tron/signer.ts.
+const browser = typeof window !== "undefined";
 
 // Public endpoints rate-limit aggressively against the app's balance polling,
 // so a dedicated RPC is strongly recommended. PUBLIC_ prefix = shipped in the

--- a/src/lib/solana/encode.ts
+++ b/src/lib/solana/encode.ts
@@ -1,0 +1,130 @@
+// Solana payload encoding.
+//
+// Everything here is pure: viem plus @lifi/intent, no SDK imports. Anchor
+// argument shaping (PublicKey/BN) lives in the writes layer, so these helpers
+// stay testable without loading @solana/web3.js.
+//
+// Where @lifi/intent already encodes a payload byte-for-byte the same way the
+// on-chain programs do, this module re-exports it rather than reimplementing:
+// two encoders that must agree forever are one encoder too many.
+
+import { BYTES32_ZERO, FILL_MAGIC, encodeFillDescription, getOutputHash } from "@lifi/intent";
+import type { MandateOutput } from "@lifi/intent";
+import { encodePacked, hexToBytes, keccak256 } from "viem";
+
+/** Largest amount the Solana output settler can resolve; it works in u64. */
+export const U64_MAX = (1n << 64n) - 1n;
+
+function byteLength(value: `0x${string}`): number {
+  return (value.length - 2) / 2;
+}
+
+/**
+ * The shared tail of every OIF output payload:
+ * `token(32)‖amount(32)‖recipient(32)‖uint16(cbLen)‖cb‖uint16(ctxLen)‖ctx`.
+ *
+ * Mirrors `encode_common_payload` in
+ * catalyst-intent-svm/common/src/encoding/mandate_output_encoding_lib.rs.
+ */
+export function commonPayload(output: MandateOutput): `0x${string}` {
+  return encodePacked(
+    ["bytes32", "uint256", "bytes32", "uint16", "bytes", "uint16", "bytes"],
+    [
+      output.token,
+      output.amount,
+      output.recipient,
+      byteLength(output.callbackData),
+      output.callbackData,
+      byteLength(output.context),
+      output.context
+    ]
+  );
+}
+
+/**
+ * A FillDescription with the timestamp field omitted:
+ * `FILL_MAGIC(4)‖solver(32)‖orderId(32)‖commonPayload`.
+ *
+ * This is NOT the payload Polymer proves — that one carries the timestamp and
+ * comes from `encodeFillDescription`. This variant exists because its hash is
+ * used as a PDA seed, and a seed cannot depend on the fill timestamp (the
+ * account has to be derivable before the fill lands). The on-chain program
+ * verifies the timestamp separately, out of the LocalAttestation account.
+ *
+ * Mirrors `encode_fill_description_without_timestamp` in the Rust encoding lib.
+ * Conflating the two variants derives an attestation account that never
+ * exists, so they are deliberately named apart.
+ */
+export function fillDescriptionWithoutTimestamp(args: {
+  solver: `0x${string}`;
+  orderId: `0x${string}`;
+  output: MandateOutput;
+}): `0x${string}` {
+  return encodePacked(
+    ["bytes4", "bytes32", "bytes32", "bytes"],
+    [FILL_MAGIC, args.solver, args.orderId, commonPayload(args.output)]
+  );
+}
+
+/** `data_hash` of the LocalAttestation a Solana fill creates. */
+export function localAttestationDataHash(args: {
+  solver: `0x${string}`;
+  orderId: `0x${string}`;
+  output: MandateOutput;
+}): `0x${string}` {
+  return keccak256(fillDescriptionWithoutTimestamp(args));
+}
+
+/**
+ * `payload_hash` of the remote Attestation created when a fill is proven
+ * across chains. Unlike {@link localAttestationDataHash} this one includes the
+ * timestamp.
+ */
+export function fillPayloadHash(args: {
+  solver: `0x${string}`;
+  orderId: `0x${string}`;
+  timestamp: number;
+  output: MandateOutput;
+}): `0x${string}` {
+  return keccak256(encodeFillDescription(args));
+}
+
+/**
+ * `filler_data` for `output_settler_simple::fill`.
+ *
+ * `resolve_output` requires exactly 32 bytes and rejects the zero pubkey, so
+ * both are checked here — a wrong length or a zero solver otherwise surfaces
+ * as an opaque program error after the transaction has been signed.
+ */
+export function solverToFillerData(solverBytes32: `0x${string}`): Uint8Array {
+  const bytes = hexToBytes(solverBytes32);
+  if (bytes.length !== 32) {
+    throw new Error(`filler_data must be a 32-byte solver identity, got ${bytes.length} bytes`);
+  }
+  if (BigInt(solverBytes32) === 0n) {
+    throw new Error("filler_data must not be the zero pubkey");
+  }
+  return bytes;
+}
+
+/** Whether an output is native SOL, which fills through `native_fill`. */
+export function isNativeSolanaOutput(output: MandateOutput): boolean {
+  return output.token === BYTES32_ZERO;
+}
+
+/**
+ * MandateOutput.amount is bytes32 on the wire but u64 on Solana. Fail before
+ * signing rather than letting the program revert mid-fill.
+ */
+export function assertSolanaAmountFitsU64(output: MandateOutput): void {
+  if (output.amount > U64_MAX) {
+    throw new Error(
+      `Solana output amount ${output.amount} exceeds u64; the output settler cannot fill it`
+    );
+  }
+}
+
+// The Solana `mandate_output_hash` (the FillId seed) is byte-identical to the
+// library's getOutputHash — verified in tests/unit/solanaEncode.test.ts against
+// the Rust layout. Re-exported so callers never hand-roll a second one.
+export { getOutputHash };

--- a/src/lib/solana/events.ts
+++ b/src/lib/solana/events.ts
@@ -1,0 +1,251 @@
+// Solana event decoding.
+//
+// The programs emit with Anchor's `emit!`, which compiles to `sol_log_data`:
+// one `Program data: <base64>` line carrying `discriminator(8) || borsh(event)`.
+// There is no self-CPI and no event-authority PDA, so the ONLY thing tying a
+// log line to a program is the invoke frame it appears in — any program can
+// print a `Program data:` line, including one crafted to look like a fill.
+// Frame attribution is therefore the anti-spoof, not a nicety.
+//
+// None of the events below appear in the generated IDLs: they are defined in
+// the helper crates (output_settler_base, input_settler_base, oracle_base)
+// rather than inside a `#[program]` module, so `anchor build` omits them and
+// `output_settler_simple.json` ships `"events": []`. The layouts here are
+// hand-rolled against the Rust structs and pinned by tests.
+
+import { getOutputHash } from "@lifi/intent";
+import type { MandateOutput } from "@lifi/intent";
+import { bytesToHex } from "viem";
+
+/** `sha256("event:<Name>")[..8]`, pinned so a rename cannot silently pass. */
+export const OUTPUT_FILLED_DISCRIMINATOR = new Uint8Array([43, 25, 133, 52, 107, 176, 40, 213]);
+export const OUTPUT_NOT_FILLED_DISCRIMINATOR = new Uint8Array([
+  162, 22, 108, 52, 116, 186, 115, 37
+]);
+export const OPEN_DISCRIMINATOR = new Uint8Array([13, 191, 79, 145, 65, 183, 42, 90]);
+export const FINALISED_DISCRIMINATOR = new Uint8Array([226, 131, 196, 252, 105, 222, 23, 210]);
+export const OUTPUT_PROVEN_DISCRIMINATOR = new Uint8Array([85, 190, 185, 8, 90, 48, 3, 214]);
+
+const PROGRAM_DATA_PREFIX = "Program data: ";
+const PROGRAM_LOG_PREFIX = "Program log: ";
+
+export type DecodedSolanaFill = {
+  settler: `0x${string}`;
+  orderId: `0x${string}`;
+  solver: `0x${string}`;
+  timestamp: number;
+  output: MandateOutput;
+  finalAmount: bigint;
+};
+
+/** Minimal sequential borsh reader; throws rather than reading past the end. */
+class BorshReader {
+  private offset = 0;
+
+  constructor(private readonly data: Uint8Array) {}
+
+  private take(length: number): Uint8Array {
+    if (this.offset + length > this.data.length) {
+      throw new Error(
+        `Truncated event payload: wanted ${length} bytes at offset ${this.offset}, have ${this.data.length}`
+      );
+    }
+    const slice = this.data.subarray(this.offset, this.offset + length);
+    this.offset += length;
+    return slice;
+  }
+
+  bytes32(): `0x${string}` {
+    return bytesToHex(this.take(32));
+  }
+
+  u32(): number {
+    const b = this.take(4);
+    return b[0]! | (b[1]! << 8) | (b[2]! << 16) | ((b[3]! << 24) >>> 0);
+  }
+
+  u64(): bigint {
+    const b = this.take(8);
+    let value = 0n;
+    for (let i = 7; i >= 0; i--) value = (value << 8n) | BigInt(b[i]!);
+    return value;
+  }
+
+  /** A borsh `Vec<u8>`: u32 little-endian length, then that many bytes. */
+  vecU8(): `0x${string}` {
+    return bytesToHex(this.take(this.u32()));
+  }
+
+  get consumed(): number {
+    return this.offset;
+  }
+
+  get length(): number {
+    return this.data.length;
+  }
+}
+
+function startsWithDiscriminator(data: Uint8Array, discriminator: Uint8Array): boolean {
+  if (data.length < discriminator.length) return false;
+  return discriminator.every((byte, i) => data[i] === byte);
+}
+
+/**
+ * Decodes an `OutputFilledEvent` payload (discriminator already matched).
+ *
+ * Rust layout (output_settler_base/src/events.rs):
+ *   settler: Pubkey(32), order_id: [u8;32], solver: [u8;32], timestamp: u32 LE,
+ *   output: MandateOutput, final_amount: u64 LE
+ * where MandateOutput is six [u8;32] fields followed by two borsh `Vec<u8>`.
+ *
+ * `chainId` and `amount` are [u8;32] big-endian on the wire but bigint in the
+ * MandateOutput type, so they are widened here.
+ */
+export function decodeOutputFilledEvent(payload: Uint8Array): DecodedSolanaFill {
+  const reader = new BorshReader(payload.subarray(OUTPUT_FILLED_DISCRIMINATOR.length));
+
+  const settler = reader.bytes32();
+  const orderId = reader.bytes32();
+  const solver = reader.bytes32();
+  const timestamp = reader.u32();
+
+  const output: MandateOutput = {
+    oracle: reader.bytes32(),
+    settler: reader.bytes32(),
+    chainId: BigInt(reader.bytes32()),
+    token: reader.bytes32(),
+    amount: BigInt(reader.bytes32()),
+    recipient: reader.bytes32(),
+    callbackData: reader.vecU8(),
+    context: reader.vecU8()
+  } as MandateOutput;
+
+  const finalAmount = reader.u64();
+
+  // A payload that decodes but leaves bytes over is not the event we think it
+  // is — treat it as a mismatch rather than trusting a prefix parse.
+  if (reader.consumed !== reader.length) {
+    throw new Error(
+      `OutputFilledEvent has ${reader.length - reader.consumed} trailing bytes; layout mismatch`
+    );
+  }
+
+  return { settler, orderId, solver, timestamp, output, finalAmount };
+}
+
+function decodeBase64(value: string): Uint8Array | undefined {
+  try {
+    const binary = atob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Every `Program data:` line emitted inside a top-level invocation of
+ * `programId`, in order.
+ *
+ * Solana logs are a flat list with `Program <id> invoke [depth]` /
+ * `Program <id> success|failed` bracketing each frame, so the depth has to be
+ * tracked to know which program actually printed a line. Lines emitted by a
+ * CPI *into* another program belong to that program's frame, not ours.
+ */
+export function programDataLogs(logs: readonly string[], programId: string): Uint8Array[] {
+  const payloads: Uint8Array[] = [];
+  const stack: string[] = [];
+
+  for (const line of logs) {
+    const invoke = /^Program (\S+) invoke \[\d+\]$/.exec(line);
+    if (invoke) {
+      stack.push(invoke[1]!);
+      continue;
+    }
+    if (/^Program \S+ (success|failed)/.test(line)) {
+      stack.pop();
+      continue;
+    }
+    if (stack[stack.length - 1] !== programId) continue;
+
+    const raw = line.startsWith(PROGRAM_DATA_PREFIX)
+      ? line.slice(PROGRAM_DATA_PREFIX.length)
+      : undefined;
+    if (raw === undefined) continue;
+
+    const decoded = decodeBase64(raw.trim());
+    if (decoded) payloads.push(decoded);
+  }
+
+  return payloads;
+}
+
+/** The `Prove:` lines `oracle_polymer::submit` writes with `msg!`. */
+export function findProveLogs(logs: readonly string[], polymerProgramId: string): string[] {
+  const marker = `Prove: program: ${polymerProgramId},`;
+  return logs
+    .map((line) =>
+      line.startsWith(PROGRAM_LOG_PREFIX) ? line.slice(PROGRAM_LOG_PREFIX.length) : line
+    )
+    .filter((line) => line.startsWith(marker));
+}
+
+/**
+ * Finds and decodes THE OutputFilled event matching the expected order and
+ * output. Strict by design, mirroring `decodeOutputFilledFromTronLogs`:
+ * - only `Program data:` lines emitted inside the output settler's own invoke
+ *   frame are considered (any program can print one),
+ * - the 8-byte discriminator must match,
+ * - the event's orderId and the output's struct hash must both match,
+ * - zero matches is an error, and so is more than one — never silently pick
+ *   the first, because two fills of the same output cannot both be the one
+ *   being settled,
+ * - a zero solver or an out-of-range timestamp is an error.
+ */
+export function findOutputFilledLog(
+  logs: readonly string[],
+  expected: {
+    programId: string;
+    orderId: `0x${string}`;
+    output: MandateOutput;
+  }
+): DecodedSolanaFill {
+  const expectedOrderId = expected.orderId.toLowerCase();
+  const expectedHash = getOutputHash(expected.output).toLowerCase();
+
+  const matches: DecodedSolanaFill[] = [];
+  for (const payload of programDataLogs(logs, expected.programId)) {
+    if (!startsWithDiscriminator(payload, OUTPUT_FILLED_DISCRIMINATOR)) continue;
+
+    let decoded: DecodedSolanaFill;
+    try {
+      decoded = decodeOutputFilledEvent(payload);
+    } catch {
+      // A truncated or mislaid payload is not a match. It must not abort the
+      // scan: a later line in the same transaction may be the real event.
+      continue;
+    }
+
+    if (decoded.orderId.toLowerCase() !== expectedOrderId) continue;
+    if (getOutputHash(decoded.output).toLowerCase() !== expectedHash) continue;
+
+    if (BigInt(decoded.solver) === 0n) {
+      throw new Error("OutputFilledEvent has a zero solver");
+    }
+    if (!Number.isInteger(decoded.timestamp) || decoded.timestamp < 0) {
+      throw new Error(`OutputFilledEvent timestamp out of range: ${decoded.timestamp}`);
+    }
+    matches.push(decoded);
+  }
+
+  if (matches.length === 0) {
+    throw new Error("No matching OutputFilled event found in Solana transaction");
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Ambiguous fill: ${matches.length} OutputFilled events match the same order and output`
+    );
+  }
+  return matches[0]!;
+}

--- a/src/lib/solana/events.ts
+++ b/src/lib/solana/events.ts
@@ -45,6 +45,12 @@ class BorshReader {
   constructor(private readonly data: Uint8Array) {}
 
   private take(length: number): Uint8Array {
+    // A negative length would pass the upper-bound check below, return an
+    // empty slice, and move the offset BACKWARDS — re-reading earlier bytes
+    // instead of failing. Only a malformed payload can produce one.
+    if (!Number.isInteger(length) || length < 0) {
+      throw new Error(`Invalid read length ${length} at offset ${this.offset}`);
+    }
     if (this.offset + length > this.data.length) {
       throw new Error(
         `Truncated event payload: wanted ${length} bytes at offset ${this.offset}, have ${this.data.length}`
@@ -61,7 +67,10 @@ class BorshReader {
 
   u32(): number {
     const b = this.take(4);
-    return b[0]! | (b[1]! << 8) | (b[2]! << 16) | ((b[3]! << 24) >>> 0);
+    // The unsigned coercion must wrap the WHOLE expression: `|` re-coerces its
+    // operands to signed int32, so an inner `>>> 0` on the high byte alone is
+    // defeated and bit 31 would come back as a negative number.
+    return (b[0]! | (b[1]! << 8) | (b[2]! << 16) | (b[3]! << 24)) >>> 0;
   }
 
   u64(): bigint {

--- a/src/lib/solana/pda.ts
+++ b/src/lib/solana/pda.ts
@@ -49,11 +49,17 @@ function bytes32Seed(value: `0x${string}`, label: string): Uint8Array {
  * isolated here rather than inlined at each call site.
  */
 export function u128ToLeBytes(value: bigint): Uint8Array {
-  if (value < 0n || value >= 1n << 128n) {
-    throw new Error(`chain id ${value} does not fit in u128`);
+  // `BigInt(value)` despite the `bigint` type: an order container that has been
+  // through the local DB carries decimal STRINGS in its bigint fields (see
+  // toBytes32 in ./writes.ts), and `"…" & 0xffn` throws "Cannot mix BigInt and
+  // other types" — which killed every attestationPda/chainMappingPda derivation
+  // for a rehydrated order.
+  const asBigInt = BigInt(value);
+  if (asBigInt < 0n || asBigInt >= 1n << 128n) {
+    throw new Error(`chain id ${asBigInt} does not fit in u128`);
   }
   const bytes = new Uint8Array(16);
-  let rest = value;
+  let rest = asBigInt;
   for (let i = 0; i < 16; i++) {
     bytes[i] = Number(rest & 0xffn);
     rest >>= 8n;

--- a/src/lib/solana/pda.ts
+++ b/src/lib/solana/pda.ts
@@ -214,3 +214,36 @@ export function chainMappingPda(
     programId
   );
 }
+
+/** SPL Token program. Mints created before Token-2022 are owned by this one. */
+export const TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+/** Token-2022. The settlers accept either via Anchor's `TokenInterface`. */
+export const TOKEN_2022_PROGRAM_ID = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
+export const ASSOCIATED_TOKEN_PROGRAM_ID = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
+export const SYSTEM_PROGRAM_ID = "11111111111111111111111111111111";
+
+/**
+ * The associated token account for (mint, owner).
+ *
+ * Every token account in the escrow and settler instructions is constrained
+ * `associated_token::…`, so this derivation — not an arbitrary token account —
+ * is the only address the programs accept.
+ *
+ * `tokenProgramId` is a parameter because the mint's owning program is part of
+ * the seed: the same mint address under Token-2022 yields a different ATA, and
+ * passing the wrong one derives an account the program will reject.
+ */
+export function associatedTokenAddress(
+  mint: string,
+  owner: string,
+  tokenProgramId: string = TOKEN_PROGRAM_ID
+): PublicKey {
+  return derive(
+    [
+      new PublicKey(owner).toBytes(),
+      new PublicKey(tokenProgramId).toBytes(),
+      new PublicKey(mint).toBytes()
+    ],
+    ASSOCIATED_TOKEN_PROGRAM_ID
+  );
+}

--- a/src/lib/solana/pda.ts
+++ b/src/lib/solana/pda.ts
@@ -247,3 +247,34 @@ export function associatedTokenAddress(
     ASSOCIATED_TOKEN_PROGRAM_ID
   );
 }
+
+/**
+ * Polymer's prover program.
+ *
+ * An external program, not one of ours. The authoritative value lives on chain
+ * in `OraclePolymer.polymer_prover_id`; this constant is the value read from
+ * BOTH mainnet and devnet (they match), pinned so the receive path does not
+ * need an extra round trip before every proof. `assertPolymerProverId` below
+ * checks the pin against the account when it matters.
+ */
+export const POLYMER_PROVER_PROGRAM_ID = "CdvSq48QUukYuMczgZAVNZrwcHNshBdtqrjW26sQiGPs";
+
+/**
+ * The prover's scratch accounts: a proof is loaded into `cache`, validated
+ * into `result`, and `internal` holds program-wide state.
+ *
+ * `cache` and `result` are per-authority, so two solvers proving concurrently
+ * do not collide. `internal` is a singleton — its existence on both clusters,
+ * owned by the prover program, is what confirms this seed scheme.
+ */
+export function polymerScratchPdas(
+  authority: string,
+  proverProgramId: string = POLYMER_PROVER_PROGRAM_ID
+): { cache: string; result: string; internal: string } {
+  const authorityBytes = new PublicKey(authority).toBytes();
+  return {
+    cache: derive([utf8.encode("cache"), authorityBytes], proverProgramId).toBase58(),
+    result: derive([utf8.encode("result"), authorityBytes], proverProgramId).toBase58(),
+    internal: derive([utf8.encode("internal")], proverProgramId).toBase58()
+  };
+}

--- a/src/lib/solana/pda.ts
+++ b/src/lib/solana/pda.ts
@@ -1,0 +1,216 @@
+import { PublicKey } from "@solana/web3.js";
+import { bytesToHex, hexToBytes } from "viem";
+import {
+  INPUT_SETTLER_ESCROW_PROGRAM_ID,
+  INTENTS_PROTOCOL_PROGRAM_ID,
+  OUTPUT_SETTLER_SIMPLE_PROGRAM_ID,
+  POLYMER_PROGRAM_ID
+} from "$lib/idl";
+
+// PDA seeds, transcribed from the Rust `constants.rs` of each program. Kept as
+// literals rather than re-derived from the IDL because Anchor only emits seeds
+// for `seeds::program`-style constant seeds — the `order_id`/hash seeds below
+// are instruction-argument derived and never appear in the IDL at all.
+//   programs/protocol/src/constants.rs
+//   programs/inputs/input_settler_escrow/src/constants.rs
+//   programs/outputs/output_settler_simple/src/constants.rs
+//   programs/oracles/oracle_polymer/src/constants.rs
+export const SOLANA_PDA_SEEDS = {
+  chainId: "chain_id",
+  chainMapping: "chain_mapping",
+  localAttestation: "local_attestation",
+  attestation: "attestation",
+  inputSettlerEscrow: "input_settler_escrow",
+  orderContext: "order_context",
+  consumedOrder: "consumed_order",
+  outputSettlerSimple: "output_settler_simple",
+  // NOTE: the polymer oracle's singleton seed is "polymer", not the IDL name
+  // "oracle_polymer" — see POLYMER_ORACLE_SEED.
+  polymerOracle: "polymer"
+} as const;
+
+const utf8 = new TextEncoder();
+
+/** 32-byte hex (the form every `MandateOutput` field uses) → raw seed bytes. */
+function bytes32Seed(value: `0x${string}`, label: string): Uint8Array {
+  const bytes = hexToBytes(value);
+  if (bytes.length !== 32) {
+    throw new Error(`${label} must be 32 bytes, got ${bytes.length}`);
+  }
+  return bytes;
+}
+
+/**
+ * `u128` → 16 little-endian bytes.
+ *
+ * Solana's `to_le_bytes()` is the ONLY endianness used in seeds, and it is the
+ * opposite of the big-endian `chain_id` carried inside a `MandateOutput`. A
+ * big-endian seed derives a valid-looking but wrong PDA, so the conversion is
+ * isolated here rather than inlined at each call site.
+ */
+export function u128ToLeBytes(value: bigint): Uint8Array {
+  if (value < 0n || value >= 1n << 128n) {
+    throw new Error(`chain id ${value} does not fit in u128`);
+  }
+  const bytes = new Uint8Array(16);
+  let rest = value;
+  for (let i = 0; i < 16; i++) {
+    bytes[i] = Number(rest & 0xffn);
+    rest >>= 8n;
+  }
+  return bytes;
+}
+
+/** A PDA's raw key as bytes32 hex — the form `MandateOutput`/`StandardOrder` fields take. */
+export function pubkeyToBytes32(key: PublicKey): `0x${string}` {
+  return bytesToHex(key.toBytes());
+}
+
+/** bytes32 hex → `PublicKey`, for feeding an on-chain-encoded key back into a derivation. */
+export function bytes32ToPubkey(value: `0x${string}`): PublicKey {
+  return new PublicKey(bytes32Seed(value, "pubkey"));
+}
+
+// `findProgramAddressSync` is canonical-bump-by-construction: it walks bumps
+// 255→0 and returns the first off-curve hit, which is exactly what Anchor's
+// `bump` (no explicit value) constraint enforces on-chain. Never accept a
+// caller-supplied bump here.
+function derive(seeds: (Uint8Array | string)[], programId: string): PublicKey {
+  const raw = seeds.map((seed) => (typeof seed === "string" ? utf8.encode(seed) : seed));
+  return PublicKey.findProgramAddressSync(raw, new PublicKey(programId))[0];
+}
+
+/** The protocol's singleton `ChainId` account, holding this cluster's protocol chain id. */
+export function chainIdPda(programId: string = INTENTS_PROTOCOL_PROGRAM_ID): PublicKey {
+  return derive([SOLANA_PDA_SEEDS.chainId], programId);
+}
+
+/**
+ * The input settler escrow's singleton state PDA — the value a `StandardOrder`'s
+ * input settler field must hold. NOT the program id: the program id signs
+ * nothing, the PDA does.
+ */
+export function inputSettlerEscrowPda(
+  programId: string = INPUT_SETTLER_ESCROW_PROGRAM_ID
+): PublicKey {
+  return derive([SOLANA_PDA_SEEDS.inputSettlerEscrow], programId);
+}
+
+/**
+ * The output settler's singleton state PDA — the value `MandateOutput.settler`
+ * must hold (`validate_settler_is_output_settler` compares against this key).
+ */
+export function outputSettlerSimplePda(
+  programId: string = OUTPUT_SETTLER_SIMPLE_PROGRAM_ID
+): PublicKey {
+  return derive([SOLANA_PDA_SEEDS.outputSettlerSimple], programId);
+}
+
+/**
+ * The Polymer oracle's singleton state PDA — the value `StandardOrder.inputOracle`
+ * must hold when Solana is the INPUT chain.
+ *
+ * Do NOT use this for `MandateOutput.oracle`: `oracle_polymer::submit` compares
+ * the fill's `LocalAttestation.consumer` against its own PROGRAM ID, so a fill
+ * whose output oracle is this PDA can never be proven.
+ */
+export function polymerOraclePda(programId: string = POLYMER_PROGRAM_ID): PublicKey {
+  return derive([SOLANA_PDA_SEEDS.polymerOracle], programId);
+}
+
+/** Per-order escrow bookkeeping, and the authority owning the escrowed ATAs. */
+export function orderContextPda(
+  orderId: `0x${string}`,
+  programId: string = INPUT_SETTLER_ESCROW_PROGRAM_ID
+): PublicKey {
+  return derive([SOLANA_PDA_SEEDS.orderContext, bytes32Seed(orderId, "orderId")], programId);
+}
+
+/** Replay marker: `open` creates it, so a second open of the same order id fails. */
+export function consumedOrderPda(
+  orderId: `0x${string}`,
+  programId: string = INPUT_SETTLER_ESCROW_PROGRAM_ID
+): PublicKey {
+  return derive([SOLANA_PDA_SEEDS.consumedOrder, bytes32Seed(orderId, "orderId")], programId);
+}
+
+/**
+ * The fill record. Seeds are `[order_id, mandateOutputHash]` with NO string
+ * prefix — unlike every other PDA here. `attest_not_filled` proves a non-fill by
+ * checking this account is still system-owned and empty, so getting the seeds
+ * wrong turns "already filled" into "provably not filled".
+ */
+export function fillIdPda(
+  orderId: `0x${string}`,
+  mandateOutputHash: `0x${string}`,
+  programId: string = OUTPUT_SETTLER_SIMPLE_PROGRAM_ID
+): PublicKey {
+  return derive(
+    [bytes32Seed(orderId, "orderId"), bytes32Seed(mandateOutputHash, "mandateOutputHash")],
+    programId
+  );
+}
+
+/**
+ * A same-chain attestation written by `intents_protocol::create_local_attestation`.
+ *
+ * `attestator` is the settler PDA that signed the CPI (not the filler),
+ * `consumer` is `MandateOutput.oracle`, and `dataHash` is the fill description
+ * hash WITHOUT the timestamp (see `fillLocalAttestationDataHash` in ./encode).
+ */
+export function localAttestationPda(
+  attestator: PublicKey,
+  consumer: `0x${string}`,
+  dataHash: `0x${string}`,
+  programId: string = INTENTS_PROTOCOL_PROGRAM_ID
+): PublicKey {
+  return derive(
+    [
+      SOLANA_PDA_SEEDS.localAttestation,
+      attestator.toBytes(),
+      bytes32Seed(consumer, "consumer"),
+      bytes32Seed(dataHash, "dataHash")
+    ],
+    programId
+  );
+}
+
+/**
+ * A remote attestation written by `intents_protocol::create_attestation` once an
+ * oracle has verified a proof from `chainId`.
+ *
+ * `attestator` is the oracle PDA that signed the CPI, and `payloadHash` is the
+ * FULL fill description hash — the one that DOES include the timestamp.
+ */
+export function attestationPda(
+  attestator: PublicKey,
+  chainId: bigint,
+  source: `0x${string}`,
+  application: `0x${string}`,
+  payloadHash: `0x${string}`,
+  programId: string = INTENTS_PROTOCOL_PROGRAM_ID
+): PublicKey {
+  return derive(
+    [
+      SOLANA_PDA_SEEDS.attestation,
+      attestator.toBytes(),
+      u128ToLeBytes(chainId),
+      bytes32Seed(source, "source"),
+      bytes32Seed(application, "application"),
+      bytes32Seed(payloadHash, "payloadHash")
+    ],
+    programId
+  );
+}
+
+/** Maps a protocol chain id to a Polymer/Wormhole-native chain id for `oracle`. */
+export function chainMappingPda(
+  oracle: PublicKey,
+  protocolChainId: bigint,
+  programId: string = INTENTS_PROTOCOL_PROGRAM_ID
+): PublicKey {
+  return derive(
+    [SOLANA_PDA_SEEDS.chainMapping, oracle.toBytes(), u128ToLeBytes(protocolChainId)],
+    programId
+  );
+}

--- a/src/lib/solana/program.ts
+++ b/src/lib/solana/program.ts
@@ -1,0 +1,164 @@
+// The single place Anchor is imported.
+//
+// Reviewer feedback on the previous Solana attempt was that the provider and
+// wallet boilerplate got copy-pasted into every library that needed a program.
+// It lives here once, behind `SolanaProgramsLike`, so the writes layer never
+// sees an `AnchorProvider`, a `PublicKey` or a `BN`.
+
+import {
+  INPUT_SETTLER_ESCROW_IDL,
+  INTENTS_PROTOCOL_IDL,
+  OUTPUT_SETTLER_SIMPLE_IDL,
+  POLYMER_IDL
+} from "$lib/idl";
+import { getSolanaReads, solanaRpcUrl } from "./client";
+import type {
+  SolanaAccountMeta,
+  SolanaInstructionBuilder,
+  SolanaInstructionLike,
+  SolanaProgramLike,
+  SolanaProgramsLike
+} from "./types";
+
+/** Anchor's builder, narrowed to the parts the adapter touches. */
+type AnchorBuilder = {
+  accounts(accounts: Record<string, unknown>): AnchorBuilder;
+  remainingAccounts(accounts: unknown[]): AnchorBuilder;
+  instruction(): Promise<{
+    programId: { toBase58(): string };
+    keys: { pubkey: { toBase58(): string }; isSigner: boolean; isWritable: boolean }[];
+    data: Uint8Array;
+  }>;
+};
+
+type AnchorProgram = {
+  programId: { toBase58(): string };
+  methods: Record<string, (...args: unknown[]) => AnchorBuilder>;
+};
+
+function adaptBuilder(
+  builder: AnchorBuilder,
+  toPublicKey: (address: string) => unknown
+): SolanaInstructionBuilder {
+  return {
+    accounts(accounts) {
+      const mapped = Object.fromEntries(
+        Object.entries(accounts).map(([name, address]) => [name, toPublicKey(address)])
+      );
+      return adaptBuilder(builder.accounts(mapped), toPublicKey);
+    },
+    remainingAccounts(accounts) {
+      const mapped = accounts.map((account) => ({
+        pubkey: toPublicKey(account.pubkey),
+        isSigner: account.isSigner,
+        isWritable: account.isWritable
+      }));
+      return adaptBuilder(builder.remainingAccounts(mapped), toPublicKey);
+    },
+    async instruction(): Promise<SolanaInstructionLike> {
+      const ix = await builder.instruction();
+      return {
+        programId: ix.programId.toBase58(),
+        keys: ix.keys.map(
+          (key): SolanaAccountMeta => ({
+            pubkey: key.pubkey.toBase58(),
+            isSigner: key.isSigner,
+            isWritable: key.isWritable
+          })
+        ),
+        data: new Uint8Array(ix.data)
+      };
+    }
+  };
+}
+
+function adaptProgram(
+  program: AnchorProgram,
+  toPublicKey: (address: string) => unknown
+): SolanaProgramLike {
+  return {
+    programId: program.programId.toBase58(),
+    // A Proxy rather than an enumerated map: Anchor derives method names from
+    // the IDL, so listing them here would be a second copy of the interface
+    // that silently rots when the programs change.
+    methods: new Proxy({} as Record<string, (...args: unknown[]) => SolanaInstructionBuilder>, {
+      get(_target, name) {
+        if (typeof name !== "string") return undefined;
+        const method = program.methods[name];
+        if (!method) {
+          throw new Error(`Program ${program.programId.toBase58()} has no instruction "${name}"`);
+        }
+        return (...args: unknown[]) => adaptBuilder(method(...args), toPublicKey);
+      }
+    })
+  };
+}
+
+const programCache = new Map<string, Promise<SolanaProgramsLike>>();
+
+/**
+ * The four programs, bound to `chainId`'s connection.
+ *
+ * The provider is deliberately read-only: it carries a public key so Anchor
+ * can populate `signer`-flagged accounts, but its signing methods reject.
+ * Signing goes through `SolanaSignerLike` instead, which keeps one path to the
+ * wallet and stops a stray `.rpc()` call from bypassing the cluster guard.
+ *
+ * `publicKey` is optional because instruction *building* needs it only when an
+ * account is derived from the signer; reads never do.
+ */
+export function createSolanaPrograms(args: {
+  chainId: number | bigint;
+  publicKey?: string;
+}): Promise<SolanaProgramsLike> {
+  const key = `${args.chainId}:${args.publicKey ?? "none"}`;
+  const existing = programCache.get(key);
+  if (existing) return existing;
+
+  const created = (async () => {
+    const [anchor, web3, reads] = await Promise.all([
+      import("@coral-xyz/anchor"),
+      import("@solana/web3.js"),
+      getSolanaReads(args.chainId)
+    ]);
+    void reads;
+
+    const { AnchorProvider, Program } = anchor;
+    const { Connection, PublicKey } = web3;
+
+    // Anchor wants a real web3.js Connection, so build one here rather than
+    // trying to force the SolanaConnectionLike adapter through its API. Same
+    // endpoint, so it shares the RPC configuration.
+    const connection = new Connection(solanaRpcUrl(args.chainId), "confirmed");
+
+    const rejectSigning = () => {
+      throw new Error(
+        "The Anchor provider does not sign. Route the instruction through SolanaSignerLike so the cluster guard runs."
+      );
+    };
+    const wallet = {
+      publicKey: args.publicKey ? new PublicKey(args.publicKey) : PublicKey.default,
+      signTransaction: rejectSigning,
+      signAllTransactions: rejectSigning
+    };
+
+    const provider = new AnchorProvider(connection, wallet as never, {
+      commitment: "confirmed"
+    });
+
+    const toPublicKey = (address: string) => new PublicKey(address);
+    const build = (idl: unknown) =>
+      adaptProgram(new Program(idl as never, provider) as unknown as AnchorProgram, toPublicKey);
+
+    return {
+      inputSettlerEscrow: build(INPUT_SETTLER_ESCROW_IDL),
+      outputSettlerSimple: build(OUTPUT_SETTLER_SIMPLE_IDL),
+      polymer: build(POLYMER_IDL),
+      intentsProtocol: build(INTENTS_PROTOCOL_IDL)
+    } satisfies SolanaProgramsLike;
+  })();
+
+  created.catch(() => programCache.delete(key));
+  programCache.set(key, created);
+  return created;
+}

--- a/src/lib/solana/reads.ts
+++ b/src/lib/solana/reads.ts
@@ -157,10 +157,13 @@ export async function readSplBalance(
   reads: SolanaConnectionLike,
   args: { mintBytes32: `0x${string}`; ownerBase58: string; tokenProgramId?: string }
 ): Promise<bigint> {
-  const ata = associatedTokenAddress(
-    bytes32ToPubkey(args.mintBytes32).toBase58(),
-    args.ownerBase58,
-    args.tokenProgramId
-  );
+  const mint = bytes32ToPubkey(args.mintBytes32).toBase58();
+  // The mint's owning program is part of the ATA seed, so SPL and Token-2022
+  // give different addresses for the same mint. Defaulting to SPL would read a
+  // Token-2022 balance as zero, which looks like "you hold none" rather than
+  // "we looked in the wrong place" — so resolve it unless the caller knows.
+  const tokenProgramId = args.tokenProgramId ?? (await reads.getAccountInfo(mint))?.owner;
+  if (!tokenProgramId) return 0n;
+  const ata = associatedTokenAddress(mint, args.ownerBase58, tokenProgramId);
   return reads.getTokenAccountBalance(ata.toBase58());
 }

--- a/src/lib/solana/reads.ts
+++ b/src/lib/solana/reads.ts
@@ -15,6 +15,7 @@ import {
 } from "$lib/idl";
 import { localAttestationDataHash } from "./encode";
 import {
+  POLYMER_PROVER_PROGRAM_ID,
   associatedTokenAddress,
   attestationPda,
   bytes32ToPubkey,
@@ -22,7 +23,8 @@ import {
   fillIdPda,
   localAttestationPda,
   orderContextPda,
-  outputSettlerSimplePda
+  outputSettlerSimplePda,
+  polymerOraclePda
 } from "./pda";
 import type { SolanaConnectionLike } from "./types";
 
@@ -166,4 +168,36 @@ export async function readSplBalance(
   if (!tokenProgramId) return 0n;
   const ata = associatedTokenAddress(mint, args.ownerBase58, tokenProgramId);
   return reads.getTokenAccountBalance(ata.toBase58());
+}
+
+/**
+ * The Polymer prover program id, read from the on-chain `OraclePolymer`
+ * account.
+ *
+ * `OraclePolymer` layout (oracle_polymer/src/state):
+ *   discriminator[8] | polymer_prover_id: Pubkey | owner: Pubkey | chain_id u128 | bump
+ *
+ * The prover belongs to Polymer, not to this protocol, so its id is read
+ * rather than assumed — a rotation on their side would otherwise surface as an
+ * opaque CPI failure mid-proof. The result is checked against the pinned
+ * constant so a change is loud rather than silent.
+ */
+export async function readPolymerProverId(reads: SolanaConnectionLike): Promise<string> {
+  const oracle = polymerOraclePda().toBase58();
+  const info = await reads.getAccountInfo(oracle);
+  if (!info) {
+    throw new Error(`Polymer oracle account ${oracle} does not exist on this cluster`);
+  }
+  if (info.data.length < 8 + 32) {
+    throw new Error(`Polymer oracle account ${oracle} is too short to hold a prover id`);
+  }
+  let hex = "0x";
+  for (const byte of info.data.subarray(8, 40)) hex += byte.toString(16).padStart(2, "0");
+  const onChain = bytes32ToPubkey(hex as `0x${string}`).toBase58();
+  if (onChain !== POLYMER_PROVER_PROGRAM_ID) {
+    throw new Error(
+      `Polymer rotated its prover program: the oracle names ${onChain}, but this build pins ${POLYMER_PROVER_PROGRAM_ID}. Update POLYMER_PROVER_PROGRAM_ID and re-verify the scratch-PDA seeds.`
+    );
+  }
+  return onChain;
 }

--- a/src/lib/solana/reads.ts
+++ b/src/lib/solana/reads.ts
@@ -155,16 +155,41 @@ export async function readSolBalance(
  * funded is a zero balance, not an error, and surfacing it as one would put a
  * spurious failure in front of every user holding none of a listed token.
  */
+// A mint's owning program is fixed for the life of the mint, so this is
+// cached: without it every balance refresh would spend an extra RPC call
+// re-reading a value that cannot change.
+const mintProgramCache = new Map<string, string>();
+
+/** Clears the mint→token-program memo. Test-only seam. */
+export function invalidateMintProgramCache(): void {
+  mintProgramCache.clear();
+}
+
+/**
+ * The program that owns `mint`, memoised.
+ *
+ * Needed because the owning program is part of the associated-token-account
+ * seed: SPL and Token-2022 give different ATAs for the same mint, so assuming
+ * SPL would read a Token-2022 balance as zero — indistinguishable from
+ * "you hold none of this".
+ */
+async function tokenProgramForMint(
+  reads: SolanaConnectionLike,
+  mint: string
+): Promise<string | undefined> {
+  const cached = mintProgramCache.get(mint);
+  if (cached) return cached;
+  const owner = (await reads.getAccountInfo(mint))?.owner;
+  if (owner) mintProgramCache.set(mint, owner);
+  return owner;
+}
+
 export async function readSplBalance(
   reads: SolanaConnectionLike,
   args: { mintBytes32: `0x${string}`; ownerBase58: string; tokenProgramId?: string }
 ): Promise<bigint> {
   const mint = bytes32ToPubkey(args.mintBytes32).toBase58();
-  // The mint's owning program is part of the ATA seed, so SPL and Token-2022
-  // give different addresses for the same mint. Defaulting to SPL would read a
-  // Token-2022 balance as zero, which looks like "you hold none" rather than
-  // "we looked in the wrong place" — so resolve it unless the caller knows.
-  const tokenProgramId = args.tokenProgramId ?? (await reads.getAccountInfo(mint))?.owner;
+  const tokenProgramId = args.tokenProgramId ?? (await tokenProgramForMint(reads, mint));
   if (!tokenProgramId) return 0n;
   const ata = associatedTokenAddress(mint, args.ownerBase58, tokenProgramId);
   return reads.getTokenAccountBalance(ata.toBase58());

--- a/src/lib/solana/reads.ts
+++ b/src/lib/solana/reads.ts
@@ -1,0 +1,166 @@
+// Read-side Solana state.
+//
+// Almost every question the flow asks — was this filled, was it proven, is it
+// finished — is answered on Solana by whether a PDA exists. The programs
+// create marker accounts rather than writing status enums, so "account
+// present" is the fact, and the account's owner is what makes it trustworthy:
+// anyone can fund an address, only the program can own it.
+
+import { getOutputHash } from "@lifi/intent";
+import type { MandateOutput } from "@lifi/intent";
+import {
+  INPUT_SETTLER_ESCROW_PROGRAM_ID,
+  INTENTS_PROTOCOL_PROGRAM_ID,
+  OUTPUT_SETTLER_SIMPLE_PROGRAM_ID
+} from "$lib/idl";
+import { localAttestationDataHash } from "./encode";
+import {
+  associatedTokenAddress,
+  attestationPda,
+  bytes32ToPubkey,
+  consumedOrderPda,
+  fillIdPda,
+  localAttestationPda,
+  orderContextPda,
+  outputSettlerSimplePda
+} from "./pda";
+import type { SolanaConnectionLike } from "./types";
+
+/**
+ * Whether `address` holds a live account owned by `expectedOwner`.
+ *
+ * The owner check is the point. A PDA address is public and anyone can send
+ * lamports to it, which creates a system-owned account there — so "an account
+ * exists" alone would let a stranger fake a fill or an attestation for the
+ * price of rent.
+ */
+async function accountExistsOwnedBy(
+  reads: SolanaConnectionLike,
+  address: string,
+  expectedOwner: string
+): Promise<boolean> {
+  const info = await reads.getAccountInfo(address);
+  return info?.owner === expectedOwner;
+}
+
+/** Whether the output settler has recorded a fill for this order and output. */
+export async function readIsOutputFilled(
+  reads: SolanaConnectionLike,
+  args: { orderId: `0x${string}`; output: MandateOutput }
+): Promise<boolean> {
+  const fillId = fillIdPda(args.orderId, getOutputHash(args.output));
+  return accountExistsOwnedBy(reads, fillId.toBase58(), OUTPUT_SETTLER_SIMPLE_PROGRAM_ID);
+}
+
+/**
+ * Whether a same-chain fill has been locally attested.
+ *
+ * The attestator is the output settler PDA (it signs the CPI that creates the
+ * attestation, so the filler's own key never appears), the consumer is
+ * whatever the output named as its oracle, and the data hash is the
+ * timestamp-free fill description — which is precisely why that variant
+ * exists, since the account must be derivable without knowing when the fill
+ * landed.
+ */
+export async function readIsLocallyAttested(
+  reads: SolanaConnectionLike,
+  args: { orderId: `0x${string}`; output: MandateOutput; solver: `0x${string}` }
+): Promise<boolean> {
+  const dataHash = localAttestationDataHash({
+    solver: args.solver,
+    orderId: args.orderId,
+    output: args.output
+  });
+  const pda = localAttestationPda(outputSettlerSimplePda(), args.output.oracle, dataHash);
+  return accountExistsOwnedBy(reads, pda.toBase58(), INTENTS_PROTOCOL_PROGRAM_ID);
+}
+
+/**
+ * Whether a remote fill has been proven to this Solana input chain, i.e. the
+ * oracle has created the Attestation account `finalise` will look for.
+ *
+ * `payloadHash` is the FULL fill description hash, including the timestamp —
+ * not the one used for local attestations.
+ */
+export async function readIsProvenOnSolana(
+  reads: SolanaConnectionLike,
+  args: {
+    inputOracle: `0x${string}`;
+    output: MandateOutput;
+    payloadHash: `0x${string}`;
+  }
+): Promise<boolean> {
+  const pda = attestationPda(
+    bytes32ToPubkey(args.inputOracle),
+    args.output.chainId,
+    args.output.oracle,
+    args.output.settler,
+    args.payloadHash
+  );
+  return accountExistsOwnedBy(reads, pda.toBase58(), INTENTS_PROTOCOL_PROGRAM_ID);
+}
+
+/** Whether the escrow still holds this order (i.e. it is open, not settled). */
+export async function readIsOrderOpen(
+  reads: SolanaConnectionLike,
+  orderId: `0x${string}`
+): Promise<boolean> {
+  return accountExistsOwnedBy(
+    reads,
+    orderContextPda(orderId).toBase58(),
+    INPUT_SETTLER_ESCROW_PROGRAM_ID
+  );
+}
+
+/**
+ * Whether the order has reached a terminal state on the input chain.
+ *
+ * There is no OrderStatus enum on Solana. `finalise` and `refund` BOTH close
+ * `order_context` (returning its rent), while `consumed_order` is created at
+ * open and never closed — so "context gone, consumed_order still there" is the
+ * only available signal, and it means *terminal*, not specifically *claimed*.
+ *
+ * That matches how the app already treats EVM and Tron, where Claimed and
+ * Refunded are folded into one state (flowProgress.ts, Finalise.svelte).
+ * Telling them apart would mean scanning FinalisedEvent vs RefundedEvent, and
+ * would need doing on all three chain types to be worth anything.
+ */
+export async function readIsOrderFinalised(
+  reads: SolanaConnectionLike,
+  orderId: `0x${string}`
+): Promise<boolean> {
+  const [context, consumed] = await reads.getMultipleAccountsInfo([
+    orderContextPda(orderId).toBase58(),
+    consumedOrderPda(orderId).toBase58()
+  ]);
+  const wasOpened = consumed?.owner === INPUT_SETTLER_ESCROW_PROGRAM_ID;
+  const stillOpen = context?.owner === INPUT_SETTLER_ESCROW_PROGRAM_ID;
+  return wasOpened && !stillOpen;
+}
+
+/** Native SOL balance, in lamports. */
+export async function readSolBalance(
+  reads: SolanaConnectionLike,
+  ownerBase58: string
+): Promise<bigint> {
+  return reads.getBalance(ownerBase58);
+}
+
+/**
+ * SPL balance for an owner and mint, via the associated token account.
+ *
+ * Resolves to 0n when the ATA does not exist: an account that has never been
+ * funded is a zero balance, not an error, and surfacing it as one would put a
+ * spurious failure in front of every user holding none of a listed token.
+ */
+export async function readSplBalance(
+  reads: SolanaConnectionLike,
+  args: { mintBytes32: `0x${string}`; ownerBase58: string; tokenProgramId?: string }
+): Promise<bigint> {
+  const ata = associatedTokenAddress(
+    bytes32ToPubkey(args.mintBytes32).toBase58(),
+    args.ownerBase58,
+    args.tokenProgramId
+  );
+  return reads.getTokenAccountBalance(ata.toBase58());
+}

--- a/src/lib/solana/types.ts
+++ b/src/lib/solana/types.ts
@@ -1,0 +1,119 @@
+// Structural types for the Solana facade.
+//
+// Everything below is expressed against these shapes rather than the real
+// @solana/web3.js and @coral-xyz/anchor types, so `writes.ts` can be unit
+// tested against a hand-built mock with no SDK in the test process. Unlike
+// Tron — where bun genuinely cannot load `tronweb` — the Solana SDKs do import
+// under bun; the seam is kept anyway because the value is isolating the
+// signer, not working around a loader.
+//
+// Addresses cross this boundary as base58 strings and payloads as hex or raw
+// bytes. `PublicKey` and `BN` stay inside the Anchor adapter.
+
+export type SolanaCommitment = "processed" | "confirmed" | "finalized";
+
+export type SolanaAccountInfoLike = {
+  owner: string;
+  lamports: number;
+  data: Uint8Array;
+} | null;
+
+export type SolanaTransactionLike = {
+  slot: number;
+  blockTime?: number | null;
+  meta: {
+    err: unknown;
+    logMessages: string[] | null;
+  } | null;
+} | null;
+
+export type SolanaBlockhash = {
+  blockhash: string;
+  lastValidBlockHeight: number;
+};
+
+/** The read surface: everything the app needs from an RPC connection. */
+export type SolanaConnectionLike = {
+  rpcEndpoint?: string;
+  getGenesisHash(): Promise<string>;
+  getAccountInfo(address: string, commitment?: SolanaCommitment): Promise<SolanaAccountInfoLike>;
+  getMultipleAccountsInfo(addresses: string[]): Promise<SolanaAccountInfoLike[]>;
+  getTransaction(
+    signature: string,
+    opts?: { commitment?: SolanaCommitment }
+  ): Promise<SolanaTransactionLike>;
+  getBalance(address: string): Promise<bigint>;
+  /** Resolves to 0n when the associated token account does not exist yet. */
+  getTokenAccountBalance(address: string): Promise<bigint>;
+  getLatestBlockhash(): Promise<SolanaBlockhash>;
+};
+
+export type SolanaAccountMeta = {
+  pubkey: string;
+  isSigner: boolean;
+  isWritable: boolean;
+};
+
+export type SolanaInstructionLike = {
+  programId: string;
+  keys: SolanaAccountMeta[];
+  data: Uint8Array;
+};
+
+/**
+ * Anchor's fluent instruction builder, narrowed to what the writes layer uses.
+ *
+ * `accounts` takes base58 strings so callers never construct a `PublicKey`,
+ * and `remainingAccounts` is explicit because `finalise` passes one attestation
+ * per output and their order is load-bearing.
+ */
+export type SolanaInstructionBuilder = {
+  accounts(accounts: Record<string, string>): SolanaInstructionBuilder;
+  remainingAccounts(accounts: SolanaAccountMeta[]): SolanaInstructionBuilder;
+  instruction(): Promise<SolanaInstructionLike>;
+};
+
+export type SolanaProgramLike = {
+  programId: string;
+  methods: Record<string, (...args: unknown[]) => SolanaInstructionBuilder>;
+};
+
+export type SolanaProgramsLike = {
+  inputSettlerEscrow: SolanaProgramLike;
+  outputSettlerSimple: SolanaProgramLike;
+  polymer: SolanaProgramLike;
+  intentsProtocol: SolanaProgramLike;
+};
+
+/**
+ * The signing surface. Kept deliberately narrow: the wallet adapter signs, the
+ * connection sends, and the writes layer only ever asks for "run these
+ * instructions and tell me it landed".
+ */
+export type SolanaSignerLike = {
+  /** Connected wallet address, base58. */
+  publicKey: string;
+  /**
+   * Signs, sends and waits for the transaction. Must reject when the
+   * transaction landed with an error — never resolve on absent metadata,
+   * which reads as success but is only "not indexed yet".
+   */
+  signAndSend(
+    instructions: SolanaInstructionLike[],
+    opts?: { computeUnitLimit?: number }
+  ): Promise<string>;
+};
+
+/**
+ * Dependency bundle threaded through every write. `chainId` travels with the
+ * connection deliberately: the cluster must come from the ORDER, never from a
+ * UI network toggle, or a devnet order signed while the UI says mainnet goes
+ * to the wrong cluster while its attestation derivation still targets the
+ * right one.
+ */
+export type SolanaDeps = {
+  chainId: bigint;
+  reads: SolanaConnectionLike;
+  signer: SolanaSignerLike;
+  programs: SolanaProgramsLike;
+};

--- a/src/lib/solana/wallet.ts
+++ b/src/lib/solana/wallet.ts
@@ -6,7 +6,7 @@
 // cost is a Buffer polyfill, installed in src/hooks.client.ts.
 
 import { solanaBase58ToBytes32 } from "@lifi/intent";
-import { assertSolanaCluster, getSolanaReads } from "./client";
+import { assertSolanaCluster, getSolanaReads, solanaRpcUrl } from "./client";
 import type { SolanaInstructionLike, SolanaSignerLike } from "./types";
 
 // Plain runtime check instead of $app/environment so bun tests can import this
@@ -230,6 +230,31 @@ export function watchSolanaConnection(
 }
 
 /**
+ * Program logs from a failed `sendRawTransaction`.
+ *
+ * `SendTransactionError` exposes them two ways and neither is guaranteed: the
+ * RPC sometimes returns them inline (`logs`), and otherwise they have to be
+ * fetched with `getLogs(connection)`. Both are tried, and a failure to read
+ * them is swallowed — this runs on an error path and must not replace the
+ * original error with one about log fetching.
+ */
+async function simulationLogs(error: unknown, connection: unknown): Promise<string[]> {
+  if (!error || typeof error !== "object") return [];
+  const candidate = error as {
+    logs?: unknown;
+    getLogs?: (connection: unknown) => Promise<unknown>;
+  };
+  if (Array.isArray(candidate.logs) && candidate.logs.length) return candidate.logs.map(String);
+  if (typeof candidate.getLogs !== "function") return [];
+  try {
+    const logs = await candidate.getLogs(connection);
+    return Array.isArray(logs) ? logs.map(String) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
  * A signer bound to `chainId`.
  *
  * The chain id is required, not inferred from any UI state: the cluster
@@ -274,16 +299,28 @@ export async function getSolanaSigner(chainId: number | bigint): Promise<SolanaS
         );
       }
 
-      const connection = new Connection(
-        reads.rpcEndpoint ?? "https://api.mainnet-beta.solana.com",
-        "confirmed"
-      );
+      // solanaRpcUrl, not a literal: api.mainnet-beta.solana.com 403s
+      // application traffic, so hardcoding it as a fallback would send writes
+      // to an endpoint that cannot answer them.
+      const connection = new Connection(reads.rpcEndpoint ?? solanaRpcUrl(chainId), "confirmed");
       const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash();
       transaction.recentBlockhash = blockhash;
       transaction.feePayer = new PublicKey(address);
 
       const signed = await adapter.signTransaction(transaction);
-      const signature = await connection.sendRawTransaction(signed.serialize());
+      // A preflight failure carries the program logs, but only on the error
+      // object — the message alone reduces an Anchor failure to a bare
+      // `custom program error: 0x…`, which names neither the account nor the
+      // constraint that rejected it. Surface the logs or the send is
+      // undiagnosable from the browser console.
+      const signature = await connection
+        .sendRawTransaction(signed.serialize())
+        .catch(async (error: unknown) => {
+          const logs = await simulationLogs(error, connection);
+          if (!logs.length) throw error;
+          const message = error instanceof Error ? error.message : String(error);
+          throw new Error(`${message}\n\nProgram logs:\n${logs.join("\n")}`, { cause: error });
+        });
 
       const confirmation = await connection.confirmTransaction(
         { signature, blockhash, lastValidBlockHeight },

--- a/src/lib/solana/wallet.ts
+++ b/src/lib/solana/wallet.ts
@@ -7,7 +7,7 @@
 
 import { solanaBase58ToBytes32 } from "@lifi/intent";
 import { assertSolanaCluster, getSolanaReads, solanaRpcUrl } from "./client";
-import type { SolanaInstructionLike, SolanaSignerLike } from "./types";
+import type { SolanaConnectionLike, SolanaInstructionLike, SolanaSignerLike } from "./types";
 
 // Plain runtime check instead of $app/environment so bun tests can import this
 // module — same reason as src/lib/tron/signer.ts.
@@ -255,6 +255,49 @@ async function simulationLogs(error: unknown, connection: unknown): Promise<stri
 }
 
 /**
+ * Whether `error` is web3.js signalling that the blockhash expired before a
+ * confirmation arrived.
+ *
+ * Matched by name rather than `instanceof`: the class is only reachable
+ * through the lazily-imported module, and an `instanceof` against a second
+ * copy of it would silently never match.
+ */
+function isBlockheightExceeded(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const named = error as { name?: unknown; message?: unknown };
+  return (
+    named.name === "TransactionExpiredBlockheightExceededError" ||
+    (typeof named.message === "string" && named.message.includes("block height exceeded"))
+  );
+}
+
+/**
+ * Reads a transaction back, tolerating indexing lag.
+ *
+ * A transaction is queryable only once the RPC has indexed it, which trails
+ * confirmation by a second or two — and by longer on a public endpoint under
+ * load. A single immediate read therefore reports a perfectly good
+ * transaction as unreadable, so this polls before giving up.
+ */
+async function readBackTransaction(reads: SolanaConnectionLike, signature: string) {
+  let lastError: unknown;
+  for (const waitMs of [0, 1000, 2000, 3000, 5000]) {
+    if (waitMs) await new Promise((resolve) => setTimeout(resolve, waitMs));
+    try {
+      const tx = await reads.getTransaction(signature, { commitment: "confirmed" });
+      if (tx?.meta) return tx;
+    } catch (error) {
+      // A read failure here is transport noise, not a verdict on the
+      // transaction — keep polling and let the caller decide after the budget
+      // is spent.
+      lastError = error;
+    }
+  }
+  if (lastError) console.warn(`Could not read back Solana transaction ${signature}`, lastError);
+  return null;
+}
+
+/**
  * A signer bound to `chainId`.
  *
  * The chain id is required, not inferred from any UI state: the cluster
@@ -322,20 +365,32 @@ export async function getSolanaSigner(chainId: number | bigint): Promise<SolanaS
           throw new Error(`${message}\n\nProgram logs:\n${logs.join("\n")}`, { cause: error });
         });
 
-      const confirmation = await connection.confirmTransaction(
-        { signature, blockhash, lastValidBlockHeight },
-        "confirmed"
-      );
-      if (confirmation.value.err) {
-        throw new Error(
-          `Solana transaction ${signature} failed: ${JSON.stringify(confirmation.value.err)}`
+      try {
+        const confirmation = await connection.confirmTransaction(
+          { signature, blockhash, lastValidBlockHeight },
+          "confirmed"
         );
+        if (confirmation.value.err) {
+          throw new Error(
+            `Solana transaction ${signature} failed: ${JSON.stringify(confirmation.value.err)}`
+          );
+        }
+      } catch (error) {
+        // `TransactionExpiredBlockheightExceededError` means the blockhash
+        // stopped being valid before this client saw a confirmation — NOT that
+        // the transaction failed. It routinely fires on a transaction that
+        // landed, when the signature subscription drops or the fill lands near
+        // the boundary. The read-back below is the authoritative answer, so
+        // expiry falls through to it instead of surfacing as a failure on a
+        // transaction the user can see succeeded.
+        if (!isBlockheightExceeded(error)) throw error;
       }
 
       // Confirmation alone is not proof the instructions succeeded — read the
       // transaction back and check `meta.err`. Absent metadata means "not
-      // indexed yet", which must never be reported as success.
-      const tx = await reads.getTransaction(signature, { commitment: "confirmed" });
+      // indexed yet", which must never be reported as success; it is also the
+      // normal state for a few seconds after landing, hence the retries.
+      const tx = await readBackTransaction(reads, signature);
       if (!tx?.meta) {
         throw new Error(
           `Solana transaction ${signature} landed but its result could not be read back; treat it as unconfirmed`

--- a/src/lib/solana/wallet.ts
+++ b/src/lib/solana/wallet.ts
@@ -19,6 +19,8 @@ export type SolanaWalletConnection = {
   address?: string;
   /** The same key as 32-byte hex — the app's canonical internal identity. */
   addressBytes32?: `0x${string}`;
+  /** Which adapter is connected, so the UI can label the right wallet. */
+  walletName?: string;
 };
 
 export type SolanaWalletOption = {
@@ -41,40 +43,103 @@ type Adapter = {
   off(event: string, handler: () => void): void;
 };
 
-let adapters: Adapter[] | undefined;
+let adapters: Promise<Adapter[]> | undefined;
 let active: Adapter | undefined;
 
-async function loadAdapters(): Promise<Adapter[]> {
+/**
+ * The adapter singletons.
+ *
+ * The *promise* is memoised, not the resolved array: several callers subscribe
+ * during startup (the store's connection watcher plus every component showing
+ * a connect affordance), and caching only the settled value lets concurrent
+ * callers each construct their own adapter set. The last one would win,
+ * stranding earlier subscribers on orphaned adapters that never fire again.
+ */
+function loadAdapters(): Promise<Adapter[]> {
   if (adapters) return adapters;
-  const [{ PhantomWalletAdapter }, { SolflareWalletAdapter }] = await Promise.all([
+  const created = Promise.all([
     import("@solana/wallet-adapter-phantom"),
     import("@solana/wallet-adapter-solflare")
-  ]);
-  adapters = [
+  ]).then(([{ PhantomWalletAdapter }, { SolflareWalletAdapter }]) => [
     new PhantomWalletAdapter() as unknown as Adapter,
     new SolflareWalletAdapter() as unknown as Adapter
-  ];
-  return adapters;
+  ]);
+  // A failed dynamic import must not be cached forever, or one flaky network
+  // moment disables Solana for the whole session.
+  created.catch(() => {
+    if (adapters === created) adapters = undefined;
+  });
+  adapters = created;
+  return created;
+}
+
+function describeWallet(adapter: Adapter): SolanaWalletOption {
+  return {
+    name: adapter.name,
+    readyState: String(adapter.readyState),
+    icon: adapter.icon
+  };
 }
 
 /** The wallets we offer, with whatever the adapter knows about availability. */
 export async function listSolanaWallets(): Promise<SolanaWalletOption[]> {
   if (!browser) return [];
   const all = await loadAdapters();
-  return all.map((adapter) => ({
-    name: adapter.name,
-    readyState: String(adapter.readyState),
-    icon: adapter.icon
-  }));
+  return all.map(describeWallet);
+}
+
+/**
+ * Whether a wallet can actually be connected right now.
+ *
+ * Solflare reports "Loadable" rather than "Installed" because it has a web
+ * fallback that works without the extension, so only NotDetected/Unsupported
+ * are genuinely unusable.
+ */
+export function isSolanaWalletDetected(wallet: SolanaWalletOption): boolean {
+  return wallet.readyState !== "NotDetected" && wallet.readyState !== "Unsupported";
+}
+
+/**
+ * Subscribes to wallet *availability* (as opposed to connection state).
+ *
+ * `readyState` is not static: an adapter reports NotDetected until its
+ * extension injects, which routinely lands after first paint. A list captured
+ * once at mount therefore leaves an installed wallet permanently greyed out,
+ * so anything rendering a connect affordance must subscribe rather than read
+ * `listSolanaWallets()` a single time.
+ */
+export function watchSolanaWallets(onChange: (wallets: SolanaWalletOption[]) => void): () => void {
+  if (!browser) return () => undefined;
+
+  let disposed = false;
+  const detachers: (() => void)[] = [];
+
+  void loadAdapters()
+    .then((all) => {
+      if (disposed) return;
+      const emit = () => onChange(all.map(describeWallet));
+      for (const adapter of all) {
+        adapter.on("readyStateChange", emit);
+        detachers.push(() => adapter.off("readyStateChange", emit));
+      }
+      emit();
+    })
+    .catch((error) => console.warn("Could not load Solana wallet adapters", error));
+
+  return () => {
+    disposed = true;
+    for (const detach of detachers) detach();
+  };
 }
 
 function toConnection(adapter: Adapter | undefined): SolanaWalletConnection {
   const address = adapter?.connected ? adapter.publicKey?.toBase58() : undefined;
-  if (!address) return { status: "disconnected" };
+  if (!address || !adapter) return { status: "disconnected" };
   return {
     status: "connected",
     address,
-    addressBytes32: solanaBase58ToBytes32(address)
+    addressBytes32: solanaBase58ToBytes32(address),
+    walletName: adapter.name
   };
 }
 
@@ -82,7 +147,7 @@ export function getSolanaConnectionState(): SolanaWalletConnection {
   return toConnection(active);
 }
 
-export async function connectSolanaWallet(name: string): Promise<SolanaWalletConnection> {
+async function doConnect(name: string): Promise<SolanaWalletConnection> {
   const all = await loadAdapters();
   const adapter = all.find((candidate) => candidate.name === name);
   if (!adapter) throw new Error(`Unknown Solana wallet: ${name}`);
@@ -96,6 +161,28 @@ export async function connectSolanaWallet(name: string): Promise<SolanaWalletCon
   await adapter.connect();
   active = adapter;
   return toConnection(adapter);
+}
+
+let connectQueue: Promise<unknown> = Promise.resolve();
+
+/**
+ * Connects `name`, serialised against any other in-flight connect.
+ *
+ * The queue is module-level because more than one component renders a connect
+ * affordance (the status bar and the full-screen picker are mounted together),
+ * and each tracks its own "connecting" flag. Without this, two overlapping
+ * attempts can both pass the `active` check above, connect different adapters,
+ * and leave `active` and the store disagreeing about which wallet is live.
+ */
+export function connectSolanaWallet(name: string): Promise<SolanaWalletConnection> {
+  // Settle either way before starting the next: a rejected attempt must not
+  // block the queue.
+  const next = connectQueue.then(
+    () => doConnect(name),
+    () => doConnect(name)
+  );
+  connectQueue = next.catch(() => undefined);
+  return next;
 }
 
 export async function disconnectSolanaWallet(): Promise<SolanaWalletConnection> {
@@ -119,20 +206,22 @@ export function watchSolanaConnection(
   let disposed = false;
   const detachers: (() => void)[] = [];
 
-  void loadAdapters().then((all) => {
-    if (disposed) return;
-    for (const adapter of all) {
-      const handler = () => {
-        if (adapter.connected) active = adapter;
-        else if (active === adapter) active = undefined;
-        onChange(toConnection(active));
-      };
-      for (const event of ["connect", "disconnect", "error"]) {
-        adapter.on(event, handler);
-        detachers.push(() => adapter.off(event, handler));
+  void loadAdapters()
+    .then((all) => {
+      if (disposed) return;
+      for (const adapter of all) {
+        const handler = () => {
+          if (adapter.connected) active = adapter;
+          else if (active === adapter) active = undefined;
+          onChange(toConnection(active));
+        };
+        for (const event of ["connect", "disconnect", "error"]) {
+          adapter.on(event, handler);
+          detachers.push(() => adapter.off(event, handler));
+        }
       }
-    }
-  });
+    })
+    .catch((error) => console.warn("Could not load Solana wallet adapters", error));
 
   return () => {
     disposed = true;

--- a/src/lib/solana/wallet.ts
+++ b/src/lib/solana/wallet.ts
@@ -229,29 +229,78 @@ export function watchSolanaConnection(
   };
 }
 
+/** Where a set of recovered program logs came from, for labelling the error. */
+type LogSource = "inline" | "transaction" | "re-simulation";
+
+/** The parts of a web3.js `Connection` the log recovery below needs. */
+type LogRecoveryConnection = {
+  simulateTransaction(transaction: unknown): Promise<{
+    value: { logs?: string[] | null };
+  }>;
+};
+
 /**
- * Program logs from a failed `sendRawTransaction`.
+ * Program logs for a failed `sendRawTransaction`, from whichever of three
+ * sources can actually answer.
  *
- * `SendTransactionError` exposes them two ways and neither is guaranteed: the
- * RPC sometimes returns them inline (`logs`), and otherwise they have to be
- * fetched with `getLogs(connection)`. Both are tried, and a failure to read
- * them is swallowed — this runs on an error path and must not replace the
- * original error with one about log fetching.
+ * The message alone reduces an Anchor failure to a bare `custom program error:
+ * 0x…`, which names neither the account nor the constraint that rejected it, so
+ * recovering the logs is the difference between a diagnosable failure and an
+ * undiagnosable one. Sources, in order of authority:
+ *
+ *  1. `error.logs` — what the RPC returned inline with the preflight rejection.
+ *     Exactly what happened, but many providers omit it.
+ *  2. `error.getLogs(connection)` — authoritative when the transaction LANDED
+ *     and then failed, because it reads the recorded logs back. Useless for a
+ *     preflight rejection: it is `getTransaction(signature)` underneath
+ *     (@solana/web3.js `SendTransactionError.getLogs`), and a transaction
+ *     rejected at preflight never landed, so it rejects with "Log messages not
+ *     found".
+ *  3. Re-simulating the signed transaction. This is the only source that works
+ *     for a preflight rejection — the case that used to surface as no logs at
+ *     all. It is a fresh execution against current state rather than a record
+ *     of the original attempt, hence the distinct `source` so the caller can
+ *     say so. Safe to replay an already-signed transaction: for a legacy
+ *     `Transaction`, `simulateTransaction` installs a fresh blockhash and does
+ *     not set `sigVerify`, so the stale signatures are not checked.
+ *
+ * Every failure here is swallowed: this runs on an error path and must never
+ * replace the original error with one about log fetching.
  */
-async function simulationLogs(error: unknown, connection: unknown): Promise<string[]> {
-  if (!error || typeof error !== "object") return [];
-  const candidate = error as {
-    logs?: unknown;
-    getLogs?: (connection: unknown) => Promise<unknown>;
-  };
-  if (Array.isArray(candidate.logs) && candidate.logs.length) return candidate.logs.map(String);
-  if (typeof candidate.getLogs !== "function") return [];
-  try {
-    const logs = await candidate.getLogs(connection);
-    return Array.isArray(logs) ? logs.map(String) : [];
-  } catch {
-    return [];
+async function failureLogs(
+  error: unknown,
+  connection: LogRecoveryConnection,
+  signed: unknown
+): Promise<{ logs: string[]; source: LogSource } | undefined> {
+  if (error && typeof error === "object") {
+    const candidate = error as {
+      logs?: unknown;
+      getLogs?: (connection: unknown) => Promise<unknown>;
+    };
+    if (Array.isArray(candidate.logs) && candidate.logs.length) {
+      return { logs: candidate.logs.map(String), source: "inline" };
+    }
+    if (typeof candidate.getLogs === "function") {
+      try {
+        const logs = await candidate.getLogs(connection);
+        if (Array.isArray(logs) && logs.length) {
+          return { logs: logs.map(String), source: "transaction" };
+        }
+      } catch {
+        // Expected for a preflight rejection — fall through to re-simulation.
+      }
+    }
   }
+  try {
+    const simulated = await connection.simulateTransaction(signed);
+    const logs = simulated.value.logs;
+    if (Array.isArray(logs) && logs.length) {
+      return { logs: logs.map(String), source: "re-simulation" };
+    }
+  } catch (resimulationError) {
+    console.warn("Could not re-simulate a failed Solana transaction", resimulationError);
+  }
+  return undefined;
 }
 
 /**
@@ -351,18 +400,24 @@ export async function getSolanaSigner(chainId: number | bigint): Promise<SolanaS
       transaction.feePayer = new PublicKey(address);
 
       const signed = await adapter.signTransaction(transaction);
-      // A preflight failure carries the program logs, but only on the error
-      // object — the message alone reduces an Anchor failure to a bare
-      // `custom program error: 0x…`, which names neither the account nor the
-      // constraint that rejected it. Surface the logs or the send is
-      // undiagnosable from the browser console.
+      // Attach the program logs to the thrown error — see `failureLogs` for why
+      // three sources are needed and which one answers for a preflight
+      // rejection. Without this an Anchor failure reaches the console as a bare
+      // `custom program error: 0x…` and has to be reproduced offline before it
+      // can be read.
       const signature = await connection
         .sendRawTransaction(signed.serialize())
         .catch(async (error: unknown) => {
-          const logs = await simulationLogs(error, connection);
-          if (!logs.length) throw error;
+          const found = await failureLogs(error, connection, signed);
+          if (!found) throw error;
           const message = error instanceof Error ? error.message : String(error);
-          throw new Error(`${message}\n\nProgram logs:\n${logs.join("\n")}`, { cause: error });
+          // A re-simulation is labelled as such: it ran against current state,
+          // so it is evidence about the failure rather than a record of it.
+          const heading =
+            found.source === "re-simulation"
+              ? "Program logs (re-simulated after the failure; chain state may have moved since)"
+              : "Program logs";
+          throw new Error(`${message}\n\n${heading}:\n${found.logs.join("\n")}`, { cause: error });
         });
 
       try {

--- a/src/lib/solana/wallet.ts
+++ b/src/lib/solana/wallet.ts
@@ -1,0 +1,228 @@
+// Solana wallet connection, via @solana/wallet-adapter.
+//
+// Adapters are used rather than a hand-rolled `window.solana` binding (the
+// Tron facade's approach) because Solana has several wallets with meaningfully
+// different injection behaviour, and the adapters already encode that. The
+// cost is a Buffer polyfill, installed in src/hooks.client.ts.
+
+import { solanaBase58ToBytes32 } from "@lifi/intent";
+import { assertSolanaCluster, getSolanaReads } from "./client";
+import type { SolanaInstructionLike, SolanaSignerLike } from "./types";
+
+// Plain runtime check instead of $app/environment so bun tests can import this
+// module — same reason as src/lib/tron/signer.ts.
+const browser = typeof window !== "undefined";
+
+export type SolanaWalletConnection = {
+  status: "connected" | "disconnected";
+  /** Base58, for display and for building instructions. */
+  address?: string;
+  /** The same key as 32-byte hex — the app's canonical internal identity. */
+  addressBytes32?: `0x${string}`;
+};
+
+export type SolanaWalletOption = {
+  name: string;
+  /** "Installed" | "Loadable" | "NotDetected" | "Unsupported" */
+  readyState: string;
+  icon?: string;
+};
+
+type Adapter = {
+  name: string;
+  icon?: string;
+  readyState: string;
+  publicKey: { toBase58(): string } | null;
+  connected: boolean;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  signTransaction<T>(tx: T): Promise<T>;
+  on(event: string, handler: () => void): void;
+  off(event: string, handler: () => void): void;
+};
+
+let adapters: Adapter[] | undefined;
+let active: Adapter | undefined;
+
+async function loadAdapters(): Promise<Adapter[]> {
+  if (adapters) return adapters;
+  const [{ PhantomWalletAdapter }, { SolflareWalletAdapter }] = await Promise.all([
+    import("@solana/wallet-adapter-phantom"),
+    import("@solana/wallet-adapter-solflare")
+  ]);
+  adapters = [
+    new PhantomWalletAdapter() as unknown as Adapter,
+    new SolflareWalletAdapter() as unknown as Adapter
+  ];
+  return adapters;
+}
+
+/** The wallets we offer, with whatever the adapter knows about availability. */
+export async function listSolanaWallets(): Promise<SolanaWalletOption[]> {
+  if (!browser) return [];
+  const all = await loadAdapters();
+  return all.map((adapter) => ({
+    name: adapter.name,
+    readyState: String(adapter.readyState),
+    icon: adapter.icon
+  }));
+}
+
+function toConnection(adapter: Adapter | undefined): SolanaWalletConnection {
+  const address = adapter?.connected ? adapter.publicKey?.toBase58() : undefined;
+  if (!address) return { status: "disconnected" };
+  return {
+    status: "connected",
+    address,
+    addressBytes32: solanaBase58ToBytes32(address)
+  };
+}
+
+export function getSolanaConnectionState(): SolanaWalletConnection {
+  return toConnection(active);
+}
+
+export async function connectSolanaWallet(name: string): Promise<SolanaWalletConnection> {
+  const all = await loadAdapters();
+  const adapter = all.find((candidate) => candidate.name === name);
+  if (!adapter) throw new Error(`Unknown Solana wallet: ${name}`);
+
+  // Disconnect the previous wallet first, otherwise two adapters both believe
+  // they are connected and `getSolanaConnectionState` depends on call order.
+  if (active && active !== adapter && active.connected) {
+    await active.disconnect().catch(() => undefined);
+  }
+
+  await adapter.connect();
+  active = adapter;
+  return toConnection(adapter);
+}
+
+export async function disconnectSolanaWallet(): Promise<SolanaWalletConnection> {
+  if (active?.connected) await active.disconnect().catch(() => undefined);
+  active = undefined;
+  return { status: "disconnected" };
+}
+
+/**
+ * Subscribes to wallet connect/disconnect/account changes.
+ *
+ * The adapters emit real events, so unlike the Tron watcher this needs no
+ * polling fallback. Handlers are attached to every adapter, not just the
+ * active one, so connecting a second wallet still reports through.
+ */
+export function watchSolanaConnection(
+  onChange: (connection: SolanaWalletConnection) => void
+): () => void {
+  if (!browser) return () => undefined;
+
+  let disposed = false;
+  const detachers: (() => void)[] = [];
+
+  void loadAdapters().then((all) => {
+    if (disposed) return;
+    for (const adapter of all) {
+      const handler = () => {
+        if (adapter.connected) active = adapter;
+        else if (active === adapter) active = undefined;
+        onChange(toConnection(active));
+      };
+      for (const event of ["connect", "disconnect", "error"]) {
+        adapter.on(event, handler);
+        detachers.push(() => adapter.off(event, handler));
+      }
+    }
+  });
+
+  return () => {
+    disposed = true;
+    for (const detach of detachers) detach();
+  };
+}
+
+/**
+ * A signer bound to `chainId`.
+ *
+ * The chain id is required, not inferred from any UI state: the cluster
+ * belongs to the order being signed, and `assertSolanaCluster` runs before
+ * every send so a wallet pointed at the wrong network fails loudly instead of
+ * broadcasting somewhere unintended.
+ */
+export async function getSolanaSigner(chainId: number | bigint): Promise<SolanaSignerLike> {
+  const adapter = active;
+  const address = adapter?.connected ? adapter.publicKey?.toBase58() : undefined;
+  if (!adapter || !address) {
+    throw new Error("No Solana wallet is connected");
+  }
+
+  const reads = await getSolanaReads(chainId);
+
+  return {
+    publicKey: address,
+    async signAndSend(instructions: SolanaInstructionLike[], opts) {
+      await assertSolanaCluster(chainId, reads);
+
+      const { ComputeBudgetProgram, Connection, PublicKey, Transaction, TransactionInstruction } =
+        await import("@solana/web3.js");
+
+      const transaction = new Transaction();
+      if (opts?.computeUnitLimit) {
+        // The default 200k CU is not enough for the proof-verification path;
+        // without this the transaction fails late, after the signature.
+        transaction.add(ComputeBudgetProgram.setComputeUnitLimit({ units: opts.computeUnitLimit }));
+      }
+      for (const ix of instructions) {
+        transaction.add(
+          new TransactionInstruction({
+            programId: new PublicKey(ix.programId),
+            keys: ix.keys.map((key) => ({
+              pubkey: new PublicKey(key.pubkey),
+              isSigner: key.isSigner,
+              isWritable: key.isWritable
+            })),
+            data: Buffer.from(ix.data)
+          })
+        );
+      }
+
+      const connection = new Connection(
+        reads.rpcEndpoint ?? "https://api.mainnet-beta.solana.com",
+        "confirmed"
+      );
+      const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash();
+      transaction.recentBlockhash = blockhash;
+      transaction.feePayer = new PublicKey(address);
+
+      const signed = await adapter.signTransaction(transaction);
+      const signature = await connection.sendRawTransaction(signed.serialize());
+
+      const confirmation = await connection.confirmTransaction(
+        { signature, blockhash, lastValidBlockHeight },
+        "confirmed"
+      );
+      if (confirmation.value.err) {
+        throw new Error(
+          `Solana transaction ${signature} failed: ${JSON.stringify(confirmation.value.err)}`
+        );
+      }
+
+      // Confirmation alone is not proof the instructions succeeded — read the
+      // transaction back and check `meta.err`. Absent metadata means "not
+      // indexed yet", which must never be reported as success.
+      const tx = await reads.getTransaction(signature, { commitment: "confirmed" });
+      if (!tx?.meta) {
+        throw new Error(
+          `Solana transaction ${signature} landed but its result could not be read back; treat it as unconfirmed`
+        );
+      }
+      if (tx.meta.err) {
+        const logs = (tx.meta.logMessages ?? []).slice(-5).join("\n");
+        throw new Error(
+          `Solana transaction ${signature} reverted: ${JSON.stringify(tx.meta.err)}\n${logs}`
+        );
+      }
+
+      return signature;
+    }
+  };
+}

--- a/src/lib/solana/writes.ts
+++ b/src/lib/solana/writes.ts
@@ -8,12 +8,7 @@
 
 import { getOutputHash } from "@lifi/intent";
 import type { MandateOutput, StandardSolana } from "@lifi/intent";
-import {
-  INPUT_SETTLER_ESCROW_PROGRAM_ID,
-  INTENTS_PROTOCOL_PROGRAM_ID,
-  OUTPUT_SETTLER_SIMPLE_PROGRAM_ID,
-  POLYMER_PROGRAM_ID
-} from "$lib/idl";
+import { INTENTS_PROTOCOL_PROGRAM_ID, POLYMER_PROGRAM_ID } from "$lib/idl";
 import { assertSolanaCluster } from "./client";
 import {
   assertSolanaAmountFitsU64,

--- a/src/lib/solana/writes.ts
+++ b/src/lib/solana/writes.ts
@@ -55,9 +55,21 @@ async function codecs() {
 
 type Codecs = Awaited<ReturnType<typeof codecs>>;
 
-/** bytes32 hex → the `[u8; 32]` Anchor expects. */
+/**
+ * bytes32 hex → the `[u8; 32]` Anchor expects.
+ *
+ * Validated rather than trusted: the loop below reads exactly 32 bytes, so a
+ * short, odd-length or non-hex value (a base58 Solana address, say) would fill
+ * the tail with `NaN` — borsh-encoded as zeroes — and produce an instruction
+ * argument that disagrees with the PDAs the client derived from the same field.
+ * That surfaces on chain as an opaque `ConstraintSeeds`, so it is rejected
+ * here instead.
+ */
 function bytes32Array(value: `0x${string}`): number[] {
   const hex = value.replace(/^0x/, "");
+  if (!/^[0-9a-fA-F]{64}$/.test(hex)) {
+    throw new Error(`Expected 32-byte hex for a Solana instruction argument, got ${value}`);
+  }
   const out: number[] = [];
   for (let i = 0; i < 64; i += 2) out.push(parseInt(hex.slice(i, i + 2), 16));
   return out;
@@ -76,8 +88,32 @@ function toAnchorOutput(output: MandateOutput) {
   };
 }
 
+/**
+ * A numeric order field → 32-byte big-endian hex.
+ *
+ * `BigInt(value)` is not redundant despite the `bigint` type: orders are
+ * persisted with `JSON.stringify` under the `BigInt.prototype.toJSON` polyfill
+ * and read back with a plain `JSON.parse`, so every amount and chain id in a
+ * container that has been through the local DB is a decimal STRING at runtime.
+ * `String.prototype.toString` ignores its radix argument, so the unguarded
+ * version re-read those decimal digits as hex — amount `1496250` became
+ * `0x…01496250` (21,455,440) and chain id `1151111081099710` became
+ * `0x…1151111081099710`.
+ *
+ * Only the instruction arguments went through here; the fill's PDAs are seeded
+ * off `getOutputHash`, which coerces through viem and stayed correct. So the
+ * client asked the program to derive `fill_id` from a different mandate-output
+ * hash than the one it had derived itself, and the fill died in `try_accounts`
+ * with `ConstraintSeeds` (2006 / 0x7d6) — before `validate_chain_id_is_output_chain_id`
+ * could name the real problem. Had the seeds happened to line up, the SPL
+ * transfer would have moved 21.455440 USDC instead of 1.496250.
+ */
 function toBytes32(value: bigint): `0x${string}` {
-  return `0x${value.toString(16).padStart(64, "0")}`;
+  const asBigInt = BigInt(value);
+  if (asBigInt < 0n || asBigInt >= 1n << 256n) {
+    throw new Error(`Value ${asBigInt} does not fit in bytes32`);
+  }
+  return `0x${asBigInt.toString(16).padStart(64, "0")}`;
 }
 
 function toAnchorOrder(order: StandardSolana, c: Codecs) {
@@ -499,7 +535,11 @@ export async function finalise(
 
   const remaining = order.outputs.map((output, index) => {
     const params = solveParams[index] ?? first;
-    const sameChain = output.chainId === order.originChainId;
+    // Compared as bigints, not with `===`: a container reloaded from the local
+    // DB carries these as decimal strings (see `toBytes32`), and a string/bigint
+    // pair is never `===`. That silently classified a same-chain output as
+    // remote and put the wrong attestation account in `remainingAccounts`.
+    const sameChain = BigInt(output.chainId) === BigInt(order.originChainId);
     const pubkey = sameChain
       ? localAttestationPda(
           outputSettlerSimplePda(),

--- a/src/lib/solana/writes.ts
+++ b/src/lib/solana/writes.ts
@@ -203,7 +203,51 @@ export async function fillOutput(
     solverBytes32: `0x${string}`;
   }
 ): Promise<string> {
+  return fillOutputs(deps, { ...args, outputs: [args.output] });
+}
+
+/**
+ * Fills several outputs in ONE transaction.
+ *
+ * The settler takes a single `MandateOutput` per instruction — there is no
+ * batch equivalent of the EVM `fillOrderOutputs` — but the instructions can
+ * share a transaction, and they must: the caller stores one transaction
+ * reference per output, and solver/timestamp are later recovered by searching
+ * that transaction's logs for each output's `OutputFilledEvent`. Filling
+ * across separate transactions would leave outputs 2..N pointing at a
+ * transaction that does not contain their event — they would be filled and
+ * then unprovable.
+ *
+ * Transactions are capped at 1232 bytes, so a large group will not fit; that
+ * surfaces as a send failure from the RPC rather than being silently split.
+ */
+export async function fillOutputs(
+  deps: SolanaDeps,
+  args: {
+    orderId: `0x${string}`;
+    outputs: MandateOutput[];
+    fillDeadline: number;
+    solverBytes32: `0x${string}`;
+  }
+): Promise<string> {
   await assertSolanaCluster(deps.chainId, deps.reads);
+  if (args.outputs.length === 0) throw new Error("fillOutputs requires at least one output");
+  const instructions: SolanaInstructionLike[] = [];
+  for (const output of args.outputs) {
+    instructions.push(await buildFillInstruction(deps, { ...args, output }));
+  }
+  return deps.signer.signAndSend(instructions);
+}
+
+async function buildFillInstruction(
+  deps: SolanaDeps,
+  args: {
+    orderId: `0x${string}`;
+    output: MandateOutput;
+    fillDeadline: number;
+    solverBytes32: `0x${string}`;
+  }
+): Promise<SolanaInstructionLike> {
   const c = await codecs();
   const { orderId, output, fillDeadline, solverBytes32 } = args;
 
@@ -266,7 +310,7 @@ export async function fillOutput(
           .instruction();
       })();
 
-  return deps.signer.signAndSend([instruction]);
+  return instruction;
 }
 
 /**
@@ -522,15 +566,22 @@ export async function finalise(
 /**
  * Reads `sponsor` out of a raw OrderContext account.
  *
- * Layout: 8-byte Anchor discriminator, then `sponsor: Pubkey`. Decoded by hand
- * rather than through the Anchor account coder so this stays on the DI seam
- * and unit tests can supply plain bytes. Falls back to `user` when the data is
- * too short to contain it, which is what the account looks like on a cluster
- * running a different build.
+ * Layout (input_settler_escrow/src/state/input_settler_escrow.rs):
+ *   discriminator[8] | input_token: Pubkey | user: Pubkey | sponsor: Pubkey | bump
+ * so `sponsor` starts at byte 72, NOT immediately after the discriminator.
+ *
+ * The sponsor is whoever paid the rent at open — often but not always the
+ * user — and `finalise` refunds the closed account to it under a
+ * `has_one = sponsor` constraint, so reading the wrong offset makes every
+ * claim fail. Decoded by hand rather than through the Anchor account coder so
+ * this stays on the DI seam and tests can supply plain bytes.
  */
+const ORDER_CONTEXT_SPONSOR_OFFSET = 8 + 32 + 32;
+
 function readSponsor(data: Uint8Array, fallback: string): string {
-  if (data.length < 8 + 32) return fallback;
-  const bytes = data.subarray(8, 40);
+  const end = ORDER_CONTEXT_SPONSOR_OFFSET + 32;
+  if (data.length < end) return fallback;
+  const bytes = data.subarray(ORDER_CONTEXT_SPONSOR_OFFSET, end);
   let hex = "0x";
   for (const byte of bytes) hex += byte.toString(16).padStart(2, "0");
   return bytes32ToPubkey(hex as `0x${string}`).toBase58();

--- a/src/lib/solana/writes.ts
+++ b/src/lib/solana/writes.ts
@@ -1,0 +1,537 @@
+// Solana write paths: open, fill, submit, receive, finalise.
+//
+// Every function takes `SolanaDeps` first and touches the chain only through
+// it, so the whole layer is testable against a hand-built mock. Each one
+// asserts the cluster before signing — the guard belongs here rather than in
+// the UI, because the cluster comes from the order and the UI is exactly what
+// gets it wrong.
+
+import { getOutputHash } from "@lifi/intent";
+import type { MandateOutput, StandardSolana } from "@lifi/intent";
+import {
+  INPUT_SETTLER_ESCROW_PROGRAM_ID,
+  INTENTS_PROTOCOL_PROGRAM_ID,
+  OUTPUT_SETTLER_SIMPLE_PROGRAM_ID,
+  POLYMER_PROGRAM_ID
+} from "$lib/idl";
+import { assertSolanaCluster } from "./client";
+import {
+  assertSolanaAmountFitsU64,
+  fillPayloadHash,
+  isNativeSolanaOutput,
+  localAttestationDataHash,
+  solverToFillerData
+} from "./encode";
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  SYSTEM_PROGRAM_ID,
+  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+  associatedTokenAddress,
+  attestationPda,
+  bytes32ToPubkey,
+  chainMappingPda,
+  consumedOrderPda,
+  fillIdPda,
+  inputSettlerEscrowPda,
+  localAttestationPda,
+  orderContextPda,
+  outputSettlerSimplePda,
+  polymerOraclePda
+} from "./pda";
+import type { SolanaConnectionLike, SolanaDeps, SolanaInstructionLike } from "./types";
+
+/** `receive_attest` verifies a proof by CPI and needs well above the 200k default. */
+const RECEIVE_ATTEST_COMPUTE_UNITS = 1_000_000;
+
+/**
+ * Lazily-loaded Anchor argument codecs.
+ *
+ * Loaded on demand so `@solana/web3.js` and Anchor stay out of the main chunk;
+ * this module is imported eagerly by the solver, the SDKs are not.
+ */
+async function codecs() {
+  const [web3, anchor] = await Promise.all([
+    import("@solana/web3.js"),
+    import("@coral-xyz/anchor")
+  ]);
+  return { PublicKey: web3.PublicKey, BN: anchor.BN };
+}
+
+type Codecs = Awaited<ReturnType<typeof codecs>>;
+
+/** bytes32 hex → the `[u8; 32]` Anchor expects. */
+function bytes32Array(value: `0x${string}`): number[] {
+  const hex = value.replace(/^0x/, "");
+  const out: number[] = [];
+  for (let i = 0; i < 64; i += 2) out.push(parseInt(hex.slice(i, i + 2), 16));
+  return out;
+}
+
+function toAnchorOutput(output: MandateOutput) {
+  return {
+    oracle: bytes32Array(output.oracle),
+    settler: bytes32Array(output.settler),
+    chainId: bytes32Array(toBytes32(output.chainId)),
+    token: bytes32Array(output.token),
+    amount: bytes32Array(toBytes32(output.amount)),
+    recipient: bytes32Array(output.recipient),
+    callbackData: Buffer.from(output.callbackData.replace(/^0x/, ""), "hex"),
+    context: Buffer.from(output.context.replace(/^0x/, ""), "hex")
+  };
+}
+
+function toBytes32(value: bigint): `0x${string}` {
+  return `0x${value.toString(16).padStart(64, "0")}`;
+}
+
+function toAnchorOrder(order: StandardSolana, c: Codecs) {
+  const { PublicKey, BN } = c;
+  const [input] = order.inputs;
+  if (!input) throw new Error("A Solana order must have exactly one input");
+  const [token, amount] = input;
+  return {
+    user: new PublicKey(bytes32ToPubkey(order.user as `0x${string}`).toBytes()),
+    nonce: new BN(order.nonce.toString()),
+    originChainId: new BN(order.originChainId.toString()),
+    expires: order.expires,
+    fillDeadline: order.fillDeadline,
+    inputOracle: new PublicKey(bytes32ToPubkey(order.inputOracle).toBytes()),
+    input: {
+      token: new PublicKey(bytes32ToPubkey(toBytes32(token)).toBytes()),
+      amount: new BN(amount.toString())
+    },
+    outputs: order.outputs.map(toAnchorOutput)
+  };
+}
+
+/**
+ * The program that owns `mint`.
+ *
+ * The settlers accept SPL and Token-2022 through Anchor's `TokenInterface`,
+ * but the owning program is part of the associated-token-account seed, so
+ * guessing it derives an ATA the program will reject. Read it.
+ */
+async function tokenProgramForMint(
+  reads: SolanaConnectionLike,
+  mintBase58: string
+): Promise<string> {
+  const info = await reads.getAccountInfo(mintBase58);
+  if (!info) throw new Error(`Mint ${mintBase58} does not exist on this cluster`);
+  if (info.owner !== TOKEN_PROGRAM_ID && info.owner !== TOKEN_2022_PROGRAM_ID) {
+    throw new Error(`Mint ${mintBase58} is owned by ${info.owner}, which is not a token program`);
+  }
+  return info.owner;
+}
+
+/**
+ * Opens the escrow for a Solana-input order.
+ *
+ * There is no approval step: `open` debits the user's ATA under the user's own
+ * signature, so nothing corresponding to an ERC-20 allowance exists — which is
+ * why `escrowApprove` no-ops for Solana rather than doing something clever.
+ */
+export async function openEscrow(
+  deps: SolanaDeps,
+  args: { order: StandardSolana; orderId: `0x${string}` }
+): Promise<string> {
+  await assertSolanaCluster(deps.chainId, deps.reads);
+  const c = await codecs();
+  const { order, orderId } = args;
+
+  const [input] = order.inputs;
+  if (!input) throw new Error("A Solana order must have exactly one input");
+  const [tokenId] = input;
+  const mint = bytes32ToPubkey(toBytes32(tokenId));
+  if (tokenId === 0n) {
+    throw new Error(
+      "Solana escrow has no native-SOL input path; `open` requires an SPL mint. Use a wrapped-SOL mint instead."
+    );
+  }
+
+  // The escrow pulls from the user's ATA under the user's signature, so the
+  // connected wallet must BE the order's user — signing for someone else
+  // silently produces a transaction that cannot succeed.
+  const user = bytes32ToPubkey(order.user as `0x${string}`).toBase58();
+  if (deps.signer.publicKey !== user) {
+    throw new Error(
+      `Connected wallet ${deps.signer.publicKey} is not the order's user ${user}; it cannot open this escrow`
+    );
+  }
+
+  const tokenProgram = await tokenProgramForMint(deps.reads, mint.toBase58());
+  const orderContext = orderContextPda(orderId);
+
+  const instruction = await deps.programs.inputSettlerEscrow.methods
+    .open(toAnchorOrder(order, c))
+    .accounts({
+      sponsor: deps.signer.publicKey,
+      user,
+      inputSettlerEscrow: inputSettlerEscrowPda().toBase58(),
+      userTokenAccount: associatedTokenAddress(mint.toBase58(), user, tokenProgram).toBase58(),
+      orderContext: orderContext.toBase58(),
+      consumedOrder: consumedOrderPda(orderId).toBase58(),
+      // The escrow vault: the order context PDA's own ATA for the input mint.
+      orderPdaTokenAccount: associatedTokenAddress(
+        mint.toBase58(),
+        orderContext.toBase58(),
+        tokenProgram
+      ).toBase58(),
+      mint: mint.toBase58(),
+      tokenProgram,
+      associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+      systemProgram: SYSTEM_PROGRAM_ID
+    })
+    .instruction();
+
+  return deps.signer.signAndSend([instruction]);
+}
+
+/**
+ * Fills one output.
+ *
+ * The settler takes a single `MandateOutput` per instruction — there is no
+ * batch equivalent of the EVM `fillOrderOutputs` — so a multi-output fill is
+ * several instructions, and the caller decides how to group them.
+ */
+export async function fillOutput(
+  deps: SolanaDeps,
+  args: {
+    orderId: `0x${string}`;
+    output: MandateOutput;
+    fillDeadline: number;
+    solverBytes32: `0x${string}`;
+  }
+): Promise<string> {
+  await assertSolanaCluster(deps.chainId, deps.reads);
+  const c = await codecs();
+  const { orderId, output, fillDeadline, solverBytes32 } = args;
+
+  assertSolanaAmountFitsU64(output);
+  if (output.callbackData !== "0x") {
+    throw new Error("The Solana output settler does not support callbackData");
+  }
+  const fillerData = solverToFillerData(solverBytes32);
+
+  const recipient = bytes32ToPubkey(output.recipient).toBase58();
+  const fillId = fillIdPda(orderId, getOutputHash(output));
+  // Created by CPI into the protocol; the client must derive and pass it,
+  // because the IDL cannot express a seed that is a hash of an argument.
+  const localAttestation = localAttestationPda(
+    outputSettlerSimplePda(),
+    output.oracle,
+    localAttestationDataHash({ solver: solverBytes32, orderId, output })
+  );
+
+  const settlerPda = outputSettlerSimplePda().toBase58();
+  const common = {
+    filler: deps.signer.publicKey,
+    recipient,
+    outputSettlerSimple: settlerPda,
+    fillId: fillId.toBase58(),
+    localAttestation: localAttestation.toBase58(),
+    intentsProtocolProgram: INTENTS_PROTOCOL_PROGRAM_ID,
+    systemProgram: SYSTEM_PROGRAM_ID
+  };
+
+  const anchorOutput = toAnchorOutput(output);
+  const deadline = new c.BN(fillDeadline);
+
+  const instruction = isNativeSolanaOutput(output)
+    ? await deps.programs.outputSettlerSimple.methods
+        .nativeFill(bytes32Array(orderId), anchorOutput, deadline, Buffer.from(fillerData))
+        .accounts(common)
+        .instruction()
+    : await (async () => {
+        const mint = bytes32ToPubkey(output.token);
+        const tokenProgram = await tokenProgramForMint(deps.reads, mint.toBase58());
+        return deps.programs.outputSettlerSimple.methods
+          .fill(bytes32Array(orderId), anchorOutput, deadline, Buffer.from(fillerData))
+          .accounts({
+            ...common,
+            fillerTokenAccount: associatedTokenAddress(
+              mint.toBase58(),
+              deps.signer.publicKey,
+              tokenProgram
+            ).toBase58(),
+            recipientTokenAccount: associatedTokenAddress(
+              mint.toBase58(),
+              recipient,
+              tokenProgram
+            ).toBase58(),
+            mint: mint.toBase58(),
+            tokenProgram,
+            associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID
+          })
+          .instruction();
+      })();
+
+  return deps.signer.signAndSend([instruction]);
+}
+
+/**
+ * Submits a filled output to Polymer, producing the `Prove:` log its indexer
+ * reads.
+ *
+ * `source` is the output settler PDA, and it becomes `application` on the EVM
+ * side. The output's own oracle must be the Polymer PROGRAM ID: `submit`
+ * compares it against `ctx.program_id`, so an order naming the oracle PDA
+ * instead fills fine and then cannot be proven. Checked up front so that shows
+ * up as a legible error rather than a revert.
+ */
+export async function submitFillProof(
+  deps: SolanaDeps,
+  args: {
+    orderId: `0x${string}`;
+    output: MandateOutput;
+    solverBytes32: `0x${string}`;
+    timestamp: number;
+  }
+): Promise<string> {
+  await assertSolanaCluster(deps.chainId, deps.reads);
+  const c = await codecs();
+  const { orderId, output, solverBytes32, timestamp } = args;
+
+  const expectedOracle = bytes32ToPubkey(output.oracle).toBase58();
+  if (expectedOracle !== POLYMER_PROGRAM_ID) {
+    throw new Error(
+      `This output names oracle ${expectedOracle}; Polymer can only prove outputs whose oracle is the Polymer program ${POLYMER_PROGRAM_ID}`
+    );
+  }
+
+  const { encodeFillDescription } = await import("@lifi/intent");
+  const payload = encodeFillDescription({ solver: solverBytes32, orderId, timestamp, output });
+
+  const localAttestation = localAttestationPda(
+    outputSettlerSimplePda(),
+    output.oracle,
+    localAttestationDataHash({ solver: solverBytes32, orderId, output })
+  );
+
+  const instruction = await deps.programs.polymer.methods
+    .submit(new c.PublicKey(outputSettlerSimplePda().toBytes()), [
+      Buffer.from(payload.replace(/^0x/, ""), "hex")
+    ])
+    .accounts({
+      submitter: deps.signer.publicKey,
+      oraclePolymer: polymerOraclePda().toBase58(),
+      intentsProtocolProgram: INTENTS_PROTOCOL_PROGRAM_ID
+    })
+    .remainingAccounts([
+      { pubkey: localAttestation.toBase58(), isSigner: false, isWritable: false }
+    ])
+    .instruction();
+
+  return deps.signer.signAndSend([instruction]);
+}
+
+/**
+ * Verifies a Polymer proof on Solana and writes the attestation `finalise`
+ * will read.
+ *
+ * Two transactions, because that is why the program splits the steps: the
+ * prover CPI plus the attestation exceed one transaction's compute and size
+ * budget. Idempotent — if the attestation already exists there is nothing to
+ * do, and re-running would only waste a signature.
+ */
+export async function receiveProof(
+  deps: SolanaDeps,
+  args: {
+    proof: Uint8Array;
+    orderId: `0x${string}`;
+    output: MandateOutput;
+    solverBytes32: `0x${string}`;
+    timestamp: number;
+    proverProgramId: string;
+    proverAccounts: { cache: string; result: string; internal: string };
+  }
+): Promise<{ loadSignature?: string; attestSignature?: string; attestation: string }> {
+  await assertSolanaCluster(deps.chainId, deps.reads);
+
+  const payloadHash = fillPayloadHash({
+    solver: args.solverBytes32,
+    orderId: args.orderId,
+    timestamp: args.timestamp,
+    output: args.output
+  });
+  const attestation = attestationPda(
+    polymerOraclePda(),
+    args.output.chainId,
+    args.output.oracle,
+    args.output.settler,
+    payloadHash
+  );
+
+  const existing = await deps.reads.getAccountInfo(attestation.toBase58());
+  if (existing?.owner === INTENTS_PROTOCOL_PROGRAM_ID) {
+    return { attestation: attestation.toBase58() };
+  }
+
+  const oracle = polymerOraclePda().toBase58();
+  const proverCommon = {
+    signer: deps.signer.publicKey,
+    oraclePolymer: oracle,
+    polymerProverProgram: args.proverProgramId,
+    cacheAccount: args.proverAccounts.cache,
+    internal: args.proverAccounts.internal,
+    resultAccount: args.proverAccounts.result,
+    systemProgram: SYSTEM_PROGRAM_ID
+  };
+
+  const loadIx = await deps.programs.polymer.methods
+    .receiveLoadProof(Buffer.from(args.proof))
+    .accounts(proverCommon)
+    .instruction();
+  const loadSignature = await deps.signer.signAndSend([loadIx], {
+    computeUnitLimit: RECEIVE_ATTEST_COMPUTE_UNITS
+  });
+
+  const chainMapping = chainMappingPda(polymerOraclePda(), args.output.chainId);
+  const attestIx = await deps.programs.polymer.methods
+    .receiveAttest()
+    .accounts({
+      signer: deps.signer.publicKey,
+      oraclePolymer: oracle,
+      polymerProverProgram: args.proverProgramId,
+      chainMapping: chainMapping.toBase58(),
+      cacheAccount: args.proverAccounts.cache,
+      internal: args.proverAccounts.internal,
+      resultAccount: args.proverAccounts.result,
+      attestation: attestation.toBase58(),
+      intentsProtocolProgram: INTENTS_PROTOCOL_PROGRAM_ID,
+      systemProgram: SYSTEM_PROGRAM_ID
+    })
+    .instruction();
+  const attestSignature = await deps.signer.signAndSend([attestIx], {
+    computeUnitLimit: RECEIVE_ATTEST_COMPUTE_UNITS
+  });
+
+  return { loadSignature, attestSignature, attestation: attestation.toBase58() };
+}
+
+/**
+ * Finalises a Solana-input order, releasing the escrow to the solver.
+ *
+ * `remainingAccounts` carries one attestation per output IN `order.outputs`
+ * ORDER — the program indexes them positionally, so a reordering settles the
+ * wrong output. Same-chain outputs use a LocalAttestation, remote ones the
+ * oracle-written Attestation.
+ */
+export async function finalise(
+  deps: SolanaDeps,
+  args: {
+    order: StandardSolana;
+    orderId: `0x${string}`;
+    solveParams: { timestamp: number; solver: `0x${string}` }[];
+    destinationBytes32: `0x${string}`;
+  }
+): Promise<string> {
+  await assertSolanaCluster(deps.chainId, deps.reads);
+  const c = await codecs();
+  const { order, orderId, solveParams, destinationBytes32 } = args;
+
+  const first = solveParams[0];
+  if (!first) throw new Error("finalise requires at least one solve param");
+
+  // The program requires solve_params[0].solver to sign. Check before building
+  // the transaction so the wrong wallet gets a sentence, not a program error.
+  const requiredSigner = bytes32ToPubkey(first.solver).toBase58();
+  if (deps.signer.publicKey !== requiredSigner) {
+    throw new Error(
+      `finalise must be signed by the first solver ${requiredSigner}, but the connected wallet is ${deps.signer.publicKey}`
+    );
+  }
+
+  const orderContext = orderContextPda(orderId);
+  // `sponsor` is whoever paid the rent at open, which need not be the user.
+  // It is stored on the order context and reclaimed there, so read it back
+  // rather than assuming.
+  const contextInfo = await deps.reads.getAccountInfo(orderContext.toBase58());
+  if (!contextInfo) {
+    throw new Error(`Order ${orderId} has no open escrow on Solana; it may already be settled`);
+  }
+
+  const [input] = order.inputs;
+  if (!input) throw new Error("A Solana order must have exactly one input");
+  const mint = bytes32ToPubkey(toBytes32(input[0]));
+  const tokenProgram = await tokenProgramForMint(deps.reads, mint.toBase58());
+  const destination = bytes32ToPubkey(destinationBytes32).toBase58();
+  const user = bytes32ToPubkey(order.user as `0x${string}`).toBase58();
+
+  const remaining = order.outputs.map((output, index) => {
+    const params = solveParams[index] ?? first;
+    const sameChain = output.chainId === order.originChainId;
+    const pubkey = sameChain
+      ? localAttestationPda(
+          outputSettlerSimplePda(),
+          output.oracle,
+          localAttestationDataHash({ solver: params.solver, orderId, output })
+        )
+      : attestationPda(
+          bytes32ToPubkey(order.inputOracle),
+          output.chainId,
+          output.oracle,
+          output.settler,
+          fillPayloadHash({
+            solver: params.solver,
+            orderId,
+            timestamp: params.timestamp,
+            output
+          })
+        );
+    return { pubkey: pubkey.toBase58(), isSigner: false, isWritable: false };
+  });
+
+  const instruction = await deps.programs.inputSettlerEscrow.methods
+    .finalise(
+      toAnchorOrder(order, c),
+      solveParams.map((param) => ({
+        solver: bytes32Array(param.solver),
+        timestamp: param.timestamp
+      }))
+    )
+    .accounts({
+      solver: deps.signer.publicKey,
+      inputSettlerEscrow: inputSettlerEscrowPda().toBase58(),
+      user,
+      sponsor: readSponsor(contextInfo.data, user),
+      destination,
+      destinationTokenAccount: associatedTokenAddress(
+        mint.toBase58(),
+        destination,
+        tokenProgram
+      ).toBase58(),
+      orderContext: orderContext.toBase58(),
+      orderPdaTokenAccount: associatedTokenAddress(
+        mint.toBase58(),
+        orderContext.toBase58(),
+        tokenProgram
+      ).toBase58(),
+      mint: mint.toBase58(),
+      intentsProtocolProgram: INTENTS_PROTOCOL_PROGRAM_ID,
+      tokenProgram,
+      associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+      systemProgram: SYSTEM_PROGRAM_ID
+    })
+    .remainingAccounts(remaining)
+    .instruction();
+
+  return deps.signer.signAndSend([instruction]);
+}
+
+/**
+ * Reads `sponsor` out of a raw OrderContext account.
+ *
+ * Layout: 8-byte Anchor discriminator, then `sponsor: Pubkey`. Decoded by hand
+ * rather than through the Anchor account coder so this stays on the DI seam
+ * and unit tests can supply plain bytes. Falls back to `user` when the data is
+ * too short to contain it, which is what the account looks like on a cluster
+ * running a different build.
+ */
+function readSponsor(data: Uint8Array, fallback: string): string {
+  if (data.length < 8 + 32) return fallback;
+  const bytes = data.subarray(8, 40);
+  let hex = "0x";
+  for (const byte of bytes) hex += byte.toString(16).padStart(2, "0");
+  return bytes32ToPubkey(hex as `0x${string}`).toBase58();
+}

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -44,9 +44,13 @@ import {
   watchTronConnection
 } from "$lib/tron/signer";
 import { getTronReads } from "$lib/tron/client";
+import type { SolanaWalletConnection } from "$lib/solana/wallet";
+import { getSolanaConnectionState, watchSolanaConnection } from "$lib/solana/wallet";
 import { getTrc20Allowance, getTrc20Balance, getTrxBalance } from "$lib/tron/reads";
+import { getSolanaReads } from "$lib/solana/client";
+import { readSolBalance, readSplBalance } from "$lib/solana/reads";
 import { maxUint256 } from "viem";
-import { isTronChain } from "./utils/chainType";
+import { isSolanaChain, isTronChain } from "./utils/chainType";
 import type { TxRef } from "./utils/txRef";
 
 function generateUUID(): string {
@@ -256,12 +260,40 @@ class Store {
   );
   _unwatchTronConnection?: () => void;
 
+  solanaWalletConnection = $state<SolanaWalletConnection>({ status: "disconnected" });
+  solanaConnectedAccount = $derived(
+    this.solanaWalletConnection.status === "connected" && this.solanaWalletConnection.addressBytes32
+      ? {
+          address: this.solanaWalletConnection.addressBytes32,
+          base58Address: this.solanaWalletConnection.address!
+        }
+      : undefined
+  );
+  _unwatchSolanaConnection?: () => void;
+
   anyWalletConnected = $derived(
-    (!!this.connectedAccount && !!this.walletClient) || !!this.tronConnectedAccount
+    (!!this.connectedAccount && !!this.walletClient) ||
+      !!this.tronConnectedAccount ||
+      !!this.solanaConnectedAccount
   );
 
+  /**
+   * The acting account for a chain, as bytes32-compatible hex.
+   *
+   * Solana returns the 32-byte form of the pubkey rather than base58, because
+   * bytes32 is the app's canonical internal identity everywhere else
+   * (order.user, solveParams.solver). Use `accountDisplayForChain` for UI.
+   */
   accountForChain(chainId: number | bigint): `0x${string}` | undefined {
     if (isTronChain(chainId)) return this.tronConnectedAccount?.address;
+    if (isSolanaChain(chainId)) return this.solanaConnectedAccount?.address;
+    return this.connectedAccount?.address;
+  }
+
+  /** The same account in the form that chain's explorers and wallets show. */
+  accountDisplayForChain(chainId: number | bigint): string | undefined {
+    if (isTronChain(chainId)) return this.tronConnectedAccount?.base58Address;
+    if (isSolanaChain(chainId)) return this.solanaConnectedAccount?.base58Address;
     return this.connectedAccount?.address;
   }
 
@@ -282,13 +314,23 @@ class Store {
     this.refreshEpoch;
     const evmAccount = this.connectedAccount?.address;
     const tronAccount = this.tronConnectedAccount?.address;
+    const solanaAccount = this.solanaConnectedAccount?.base58Address;
     return this.mapOverCoinsCached({
       bucket: "balance",
       ttlMs: 30_000,
       tronTtlMs: 120_000,
       isMainnet: this.mainnet,
-      scopeKey: `${evmAccount ?? "none"}:${tronAccount ?? "none"}`,
+      // Every connected account is in the scope key: without the Solana one,
+      // cached balances would leak across a Solana wallet switch.
+      scopeKey: `${evmAccount ?? "none"}:${tronAccount ?? "none"}:${solanaAccount ?? "none"}`,
       fetcher: async (asset, client, chainId) => {
+        if (isSolanaChain(chainId)) {
+          if (!solanaAccount) return 0n;
+          const reads = await getSolanaReads(chainId);
+          return asset.toLowerCase() === ADDRESS_ZERO
+            ? readSolBalance(reads, solanaAccount)
+            : readSplBalance(reads, { mintBytes32: asset, ownerBase58: solanaAccount });
+        }
         const account = isTronChain(chainId) ? tronAccount : evmAccount;
         if (!account) return 0n;
         if (isTronChain(chainId)) {
@@ -307,6 +349,7 @@ class Store {
     this.refreshEpoch;
     const evmAccount = this.connectedAccount?.address;
     const tronAccount = this.tronConnectedAccount?.address;
+    const solanaAccount = this.solanaConnectedAccount?.base58Address;
     const spender =
       this.inputSettler === INPUT_SETTLER_COMPACT_LIFI ||
       this.inputSettler === MULTICHAIN_INPUT_SETTLER_COMPACT
@@ -317,8 +360,11 @@ class Store {
       ttlMs: 60_000,
       tronTtlMs: 180_000,
       isMainnet: this.mainnet,
-      scopeKey: `${evmAccount ?? "none"}:${tronAccount ?? "none"}:${spender}`,
+      scopeKey: `${evmAccount ?? "none"}:${tronAccount ?? "none"}:${solanaAccount ?? "none"}:${spender}`,
       fetcher: async (asset, client, chainId) => {
+        // Solana has no allowance concept: `open` debits the user's ATA under
+        // the user's own signature, so nothing is ever "not approved".
+        if (isSolanaChain(chainId)) return maxUint256;
         const account = isTronChain(chainId) ? tronAccount : evmAccount;
         if (!account) return 0n;
         if (isTronChain(chainId)) {
@@ -342,7 +388,8 @@ class Store {
       isMainnet: this.mainnet,
       scopeKey: `${account ?? "none"}:${allocatorId}`,
       fetcher: (asset, client, chainId) => {
-        if (isTronChain(chainId)) return Promise.resolve(0n);
+        // Neither Tron nor Solana has a Compact deployment.
+        if (isTronChain(chainId) || isSolanaChain(chainId)) return Promise.resolve(0n);
         return getCompactBalance(account, asset, client, allocatorId);
       }
     });
@@ -585,7 +632,10 @@ class Store {
   }
 
   async setWalletToCorrectChain(chainId: number | bigint) {
-    if (isTronChain(chainId)) return;
+    // Only EVM wallets have a chain to switch. Tron and Solana wallets are
+    // bound to their own network, and the cluster/network guard in each facade
+    // is what catches a mismatch.
+    if (isTronChain(chainId) || isSolanaChain(chainId)) return;
     try {
       return await switchWalletChain(this.walletClient, Number(chainId));
     } catch (error) {
@@ -647,6 +697,11 @@ class Store {
       this.tronWalletConnection = getTronConnection();
       this._unwatchTronConnection = watchTronConnection((connection) => {
         this.tronWalletConnection = connection;
+      });
+
+      this.solanaWalletConnection = getSolanaConnectionState();
+      this._unwatchSolanaConnection = watchSolanaConnection((connection) => {
+        this.solanaWalletConnection = connection;
       });
     }
 

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -28,7 +28,7 @@ import {
   tokens as tokensTable
 } from "./schema";
 import { and, eq, ne, notInArray } from "drizzle-orm";
-import { containerToIntent } from "./utils/intent";
+import { containerToIntent, reviveOrderBigInts } from "./utils/intent";
 import { getOrFetchRpc, invalidateRpcPrefix } from "./libraries/rpcCache";
 import {
   getCurrentConnection,
@@ -73,6 +73,9 @@ class Store {
     const rows = await db!.select().from(intents);
     this.orders = rows.map((r) => {
       const order = JSON.parse(r.data) as OrderContainerWithMeta;
+      // The blob was stringified under the BigInt.prototype.toJSON polyfill,
+      // so every bigint field is a decimal string here until revived.
+      order.order = reviveOrderBigInts(order.order);
       // Re-attach the authoritative column values dropped by JSON.parse. The
       // dedicated `created_at` column always wins over anything stale in the
       // blob; `submitTime` (order-server time) round-trips inside the blob.

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -47,6 +47,7 @@ import { getTronReads } from "$lib/tron/client";
 import { getTrc20Allowance, getTrc20Balance, getTrxBalance } from "$lib/tron/reads";
 import { maxUint256 } from "viem";
 import { isTronChain } from "./utils/chainType";
+import type { TxRef } from "./utils/txRef";
 
 function generateUUID(): string {
   return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
@@ -142,12 +143,12 @@ class Store {
     if (!db) await initDb();
     if (!db) return;
     const rows = await db!.select().from(fillTransactionsTable);
-    const loaded: { [outputId: string]: `0x${string}` } = {};
-    for (const row of rows) loaded[row.outputHash] = row.txHash as `0x${string}`;
+    const loaded: { [outputId: string]: TxRef } = {};
+    for (const row of rows) loaded[row.outputHash] = row.txHash;
     this.fillTransactions = loaded;
   }
 
-  async saveFillTransaction(outputHash: string, txHash: `0x${string}`) {
+  async saveFillTransaction(outputHash: string, txHash: TxRef) {
     if (!browser) return;
     if (!db) await initDb();
     if (!db) return;
@@ -268,7 +269,9 @@ class Store {
   manualTokenKeys = $state<Set<string>>(new Set());
   inputTokens = $state<AppTokenContext[]>([]);
   outputTokens = $state<AppTokenContext[]>([]);
-  fillTransactions = $state<{ [outputId: string]: `0x${string}` }>({});
+  // TxRef, not `0x${string}`: a Solana fill signature is base58. The schema
+  // column is already `text`, so this needs no migration.
+  fillTransactions = $state<{ [outputId: string]: TxRef }>({});
   transactionReceipts = $state<Record<string, string>>({});
 
   refreshEpoch = $state(0);

--- a/src/lib/tron/writes.ts
+++ b/src/lib/tron/writes.ts
@@ -200,7 +200,7 @@ export async function fillOutputs(
   return txId;
 }
 
-// Use only the single-bytes overload so TronLink's ethers does not pick bytes[].
+// Use only the single-bytes overloads so TronLink's ethers does not pick bytes[].
 const RECEIVE_MESSAGE_SINGLE_ABI = [
   {
     type: "function",
@@ -208,18 +208,33 @@ const RECEIVE_MESSAGE_SINGLE_ABI = [
     inputs: [{ name: "proof", type: "bytes", internalType: "bytes" }],
     outputs: [],
     stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "receiveSolanaMessage",
+    inputs: [{ name: "proof", type: "bytes", internalType: "bytes" }],
+    outputs: [],
+    stateMutability: "nonpayable"
   }
 ] as const;
 
+/**
+ * `entryPoint` is chosen by the chain the proof came FROM (the output chain),
+ * exactly like the EVM path's `polymerReceiveFunction`: the oracle decodes a
+ * Solana proof only in `receiveSolanaMessage`, and handing it to
+ * `receiveMessage` reverts with no reason string. See
+ * src/lib/libraries/polymerReceive.ts for the full rationale.
+ */
 export async function submitReceiveMessage(
   deps: TronDeps,
   oracleHex: `0x${string}`,
-  proof: string
+  proof: string,
+  entryPoint: "receiveMessage" | "receiveSolanaMessage" = "receiveMessage"
 ): Promise<string> {
   await assertTronMainnet(deps.signer, deps.reads);
   const contract = await signerContract(deps, RECEIVE_MESSAGE_SINGLE_ABI, oracleHex);
   const proofBytes = `0x${proof.replace(/^0x/, "")}`;
-  const txId = await contract.receiveMessage!(proofBytes).send({ feeLimit: ORACLE_FEE_LIMIT });
+  const txId = await contract[entryPoint]!(proofBytes).send({ feeLimit: ORACLE_FEE_LIMIT });
   await waitForTronTransaction(deps.reads, txId, { mode: "confirmed" });
   return txId;
 }

--- a/src/lib/utils/address.ts
+++ b/src/lib/utils/address.ts
@@ -5,6 +5,7 @@ import {
   solanaBase58ToBytes32,
   tronBase58ToHex
 } from "@lifi/intent";
+import type { ChainType } from "$lib/utils/chainType";
 
 /**
  * Resolves a user-entered address to the app's internal hex form: 20 bytes for
@@ -26,4 +27,38 @@ export function resolveAddress(value: string): `0x${string}` | undefined {
   if (isTronBase58Address(trimmed)) return tronBase58ToHex(trimmed);
   if (isSolanaBase58Address(trimmed)) return solanaBase58ToBytes32(trimmed);
   return undefined;
+}
+
+/**
+ * Resolves a user-entered address, accepting only the format the given chain
+ * type can pay out to.
+ *
+ * `resolveAddress` above answers "is this any address"; this answers "is this
+ * an address ON THAT CHAIN". The distinction is asset loss, not pedantry:
+ * `@lifi/intent` runs every recipient through `addressToBytes32`, which
+ * zero-pads a 20-byte EVM address into a 32-byte value — as a Solana pubkey
+ * that is a key nobody controls — and the EVM output settler truncates a
+ * 32-byte Solana key to its low 20 bytes on transfer (LibAddress.sol). Both
+ * directions move funds to an address the user never meant, silently.
+ *
+ * EVM and Tron accept each other's text forms: both name the same 20-byte
+ * secp256k1 identity, the app's internal form is the hex either way, and a
+ * recipient must satisfy EVERY output chain type at once — rejecting `T...`
+ * for a mixed Tron+EVM order would force the user to hand-convert an address
+ * that is already exact. Solana accepts only base58: a 0x value is
+ * indistinguishable from the padding mistake this function exists to catch.
+ */
+export function resolveAddressForChainType(
+  value: string,
+  chainType: ChainType
+): `0x${string}` | undefined {
+  const trimmed = value.trim();
+  switch (chainType) {
+    case "solana":
+      return isSolanaBase58Address(trimmed) ? solanaBase58ToBytes32(trimmed) : undefined;
+    case "tron":
+    case "evm":
+      if (isTronBase58Address(trimmed)) return tronBase58ToHex(trimmed);
+      return isAddress(trimmed, { strict: false }) ? trimmed : undefined;
+  }
 }

--- a/src/lib/utils/address.ts
+++ b/src/lib/utils/address.ts
@@ -1,14 +1,29 @@
 import { isAddress } from "viem";
-import { isTronBase58Address, tronBase58ToHex } from "@lifi/intent";
+import {
+  isSolanaBase58Address,
+  isTronBase58Address,
+  solanaBase58ToBytes32,
+  tronBase58ToHex
+} from "@lifi/intent";
 
 /**
- * Resolves a user-entered address to its 20-byte hex form. Accepts EVM hex
- * addresses and Tron Base58Check addresses — the latter are checksum-verified
- * by the library, so a typo'd Tron address resolves to `undefined` instead of
- * silently becoming a different recipient.
+ * Resolves a user-entered address to the app's internal hex form: 20 bytes for
+ * EVM and Tron, 32 for Solana.
+ *
+ * Order matters. Tron is checked before Solana because a Tron address is
+ * Base58Check — 34 characters decoding to a 21-byte payload — so it can never
+ * satisfy the Solana 32-byte check, but testing Solana first would make the
+ * intent of the ordering unclear. A typo'd Tron address resolves to
+ * `undefined` because the library verifies its checksum.
+ *
+ * Solana base58 carries NO checksum, so a typo that still decodes to 32 bytes
+ * resolves to a different, valid key. Callers must render the resolved address
+ * back to the user before it is used as a recipient.
  */
 export function resolveAddress(value: string): `0x${string}` | undefined {
-  if (isAddress(value, { strict: false })) return value;
-  if (isTronBase58Address(value)) return tronBase58ToHex(value);
+  const trimmed = value.trim();
+  if (isAddress(trimmed, { strict: false })) return trimmed;
+  if (isTronBase58Address(trimmed)) return tronBase58ToHex(trimmed);
+  if (isSolanaBase58Address(trimmed)) return solanaBase58ToBytes32(trimmed);
   return undefined;
 }

--- a/src/lib/utils/chainType.ts
+++ b/src/lib/utils/chainType.ts
@@ -3,7 +3,9 @@ import {
   SOLANA_MAINNET_CHAIN_ID,
   SOLANA_TESTNET_CHAIN_ID,
   TRON_MAINNET_CHAIN_ID,
+  bytes32ToSolanaBase58,
   hexToTronBase58,
+  isSolanaBase58Address,
   isTronBase58Address
 } from "@lifi/intent";
 
@@ -52,14 +54,13 @@ export function isEvmChain(chainId: number | bigint): boolean {
   return getChainType(chainId) === "evm";
 }
 
-// Address validation and conversion live in @lifi/intent (Base58Check with
-// checksum verification) — re-exported here for existing import sites.
-export { isTronBase58Address };
+// Address validation and conversion live in @lifi/intent — Base58Check with
+// checksum verification for Tron, raw base58 for Solana. Re-exported here for
+// existing import sites.
+export { isSolanaBase58Address, isTronBase58Address };
 
 export function formatAddressForChain(address: `0x${string}`, chainId: number | bigint): string {
   if (isTronChain(chainId)) return hexToTronBase58(address);
-  // TODO(solana): render Solana values as base58 via bytes32ToSolanaBase58
-  // once @lifi/intent 0.4.0 is published. Until then a Solana address renders
-  // as its 32-byte hex, which is correct but unfriendly.
+  if (isSolanaChain(chainId)) return bytes32ToSolanaBase58(address);
   return address;
 }

--- a/src/lib/utils/chainType.ts
+++ b/src/lib/utils/chainType.ts
@@ -1,3 +1,4 @@
+import type { Namespace } from "@lifi/intent";
 import {
   SOLANA_DEVNET_CHAIN_ID,
   SOLANA_MAINNET_CHAIN_ID,
@@ -58,6 +59,27 @@ export function isEvmChain(chainId: number | bigint): boolean {
 // checksum verification for Tron, raw base58 for Solana. Re-exported here for
 // existing import sites.
 export { isSolanaBase58Address, isTronBase58Address };
+
+/**
+ * The CAIP-2 namespace a chain id belongs to.
+ *
+ * This is the app's chain *type* under the name the wire uses. It travels with
+ * a chain id into `@lifi/intent` — into `token.chainNamespace` when building an
+ * intent, and into the quote request, where it selects both the `namespace:id`
+ * chain prefix and the encoding of every address and asset alongside it. The
+ * two must agree: a Solana mint declared under `eip155` is rejected by the
+ * order service as `bytes32 value has non-zero upper bytes`, because a 32-byte
+ * key cannot be read as a left-padded 20-byte EVM address.
+ */
+const NAMESPACE_BY_CHAIN_TYPE = {
+  evm: "eip155",
+  tron: "tron",
+  solana: "solana"
+} as const satisfies Record<ChainType, Namespace>;
+
+export function namespaceForChain(chainId: number | bigint): Namespace {
+  return NAMESPACE_BY_CHAIN_TYPE[getChainType(chainId)];
+}
 
 export function formatAddressForChain(address: `0x${string}`, chainId: number | bigint): string {
   if (isTronChain(chainId)) return hexToTronBase58(address);

--- a/src/lib/utils/chainType.ts
+++ b/src/lib/utils/chainType.ts
@@ -1,11 +1,35 @@
-import { TRON_MAINNET_CHAIN_ID, hexToTronBase58, isTronBase58Address } from "@lifi/intent";
+import {
+  SOLANA_DEVNET_CHAIN_ID,
+  SOLANA_MAINNET_CHAIN_ID,
+  SOLANA_TESTNET_CHAIN_ID,
+  TRON_MAINNET_CHAIN_ID,
+  hexToTronBase58,
+  isTronBase58Address
+} from "@lifi/intent";
 
-export type ChainType = "evm" | "tron";
+export type ChainType = "evm" | "tron" | "solana";
 
 const TRON_CHAIN_IDS = new Set([Number(TRON_MAINNET_CHAIN_ID)]);
 
+// Solana's OIF chain ids (1151111081099710/11/12) are ~1.15e15, comfortably
+// inside Number.MAX_SAFE_INTEGER (~9.0e15), so a Set<number> keyed on
+// Number(chainId) is exact. Asserted in tests/unit/solanaSupport.test.ts.
+const SOLANA_CHAIN_ID_SET = new Set([
+  Number(SOLANA_MAINNET_CHAIN_ID),
+  Number(SOLANA_TESTNET_CHAIN_ID),
+  Number(SOLANA_DEVNET_CHAIN_ID)
+]);
+
+/** The Solana chain ids this app knows about, as bigints. Single source of truth. */
+export const SOLANA_CHAIN_IDS: ReadonlySet<bigint> = new Set([
+  SOLANA_MAINNET_CHAIN_ID,
+  SOLANA_TESTNET_CHAIN_ID,
+  SOLANA_DEVNET_CHAIN_ID
+]);
+
 export function getChainType(chainId: number | bigint): ChainType {
   if (TRON_CHAIN_IDS.has(Number(chainId))) return "tron";
+  if (SOLANA_CHAIN_ID_SET.has(Number(chainId))) return "solana";
   return "evm";
 }
 
@@ -13,8 +37,19 @@ export function isTronChain(chainId: number | bigint): boolean {
   return TRON_CHAIN_IDS.has(Number(chainId));
 }
 
+export function isSolanaChain(chainId: number | bigint): boolean {
+  return SOLANA_CHAIN_ID_SET.has(Number(chainId));
+}
+
+export function isSolanaMainnet(chainId: number | bigint): boolean {
+  return Number(chainId) === Number(SOLANA_MAINNET_CHAIN_ID);
+}
+
+// Deliberately positive rather than `!isTronChain`: with a third chain type,
+// "not Tron" no longer implies EVM, and every caller that assumed it did was
+// a latent Solana bug.
 export function isEvmChain(chainId: number | bigint): boolean {
-  return !isTronChain(chainId);
+  return getChainType(chainId) === "evm";
 }
 
 // Address validation and conversion live in @lifi/intent (Base58Check with
@@ -23,5 +58,8 @@ export { isTronBase58Address };
 
 export function formatAddressForChain(address: `0x${string}`, chainId: number | bigint): string {
   if (isTronChain(chainId)) return hexToTronBase58(address);
+  // TODO(solana): render Solana values as base58 via bytes32ToSolanaBase58
+  // once @lifi/intent 0.4.0 is published. Until then a Solana address renders
+  // as its 32-byte hex, which is correct but unfriendly.
   return address;
 }

--- a/src/lib/utils/intent.ts
+++ b/src/lib/utils/intent.ts
@@ -1,20 +1,11 @@
 import {
   orderToIntent,
-  SOLANA_MAINNET_CHAIN_ID,
-  SOLANA_TESTNET_CHAIN_ID,
-  SOLANA_DEVNET_CHAIN_ID,
   StandardEVMIntent,
   StandardSolanaIntent,
   MultichainOrderIntent
 } from "@lifi/intent";
 import type { OrderContainer } from "@lifi/intent";
-import { isTronChain } from "./chainType";
-
-const SOLANA_CHAIN_IDS = new Set([
-  SOLANA_MAINNET_CHAIN_ID,
-  SOLANA_TESTNET_CHAIN_ID,
-  SOLANA_DEVNET_CHAIN_ID
-]);
+import { isSolanaChain, isTronChain } from "./chainType";
 
 export function containerToIntent(
   container: OrderContainer
@@ -23,7 +14,7 @@ export function containerToIntent(
   if (!("originChainId" in order)) {
     return orderToIntent({ namespace: "eip155", inputSettler, order });
   }
-  if (SOLANA_CHAIN_IDS.has(order.originChainId)) {
+  if (isSolanaChain(order.originChainId)) {
     return orderToIntent({ namespace: "solana", inputSettler, order });
   }
   if (isTronChain(order.originChainId)) {

--- a/src/lib/utils/intent.ts
+++ b/src/lib/utils/intent.ts
@@ -4,8 +4,54 @@ import {
   StandardSolanaIntent,
   MultichainOrderIntent
 } from "@lifi/intent";
-import type { OrderContainer } from "@lifi/intent";
+import type { MandateOutput, OrderContainer } from "@lifi/intent";
 import { isSolanaChain, isTronChain } from "./chainType";
+
+/**
+ * Re-establish the `bigint` fields of an order that has been through JSON.
+ *
+ * Two ingestion paths deliver orders as parsed JSON with decimal strings in
+ * every `bigint`-typed field: the local DB (persisted under the
+ * `BigInt.prototype.toJSON` polyfill, read back with a plain `JSON.parse`) and
+ * the order-server websocket (`user:vm-order-submit` hands over `message.data`
+ * raw — unlike `getAndParseOrders`, which converts). Downstream code trusts
+ * the types: `"…" & 0xffn` in a Solana PDA derivation throws "Cannot mix
+ * BigInt and other types", and a string/bigint pair is never `===`, so a
+ * same-chain output was silently classified as remote.
+ */
+export function reviveOrderBigInts(order: OrderContainer["order"]): OrderContainer["order"] {
+  const outputs = order.outputs.map(
+    (output): MandateOutput => ({
+      ...output,
+      chainId: BigInt(output.chainId),
+      amount: BigInt(output.amount)
+    })
+  );
+  if ("originChainId" in order) {
+    return {
+      ...order,
+      nonce: BigInt(order.nonce),
+      originChainId: BigInt(order.originChainId),
+      inputs: order.inputs.map(([token, amount]): [bigint, bigint] => [
+        BigInt(token),
+        BigInt(amount)
+      ]),
+      outputs
+    };
+  }
+  return {
+    ...order,
+    nonce: BigInt(order.nonce),
+    inputs: order.inputs.map((input) => ({
+      chainId: BigInt(input.chainId),
+      inputs: input.inputs.map(([token, amount]): [bigint, bigint] => [
+        BigInt(token),
+        BigInt(amount)
+      ])
+    })),
+    outputs
+  };
+}
 
 export function containerToIntent(
   container: OrderContainer

--- a/src/lib/utils/txRef.ts
+++ b/src/lib/utils/txRef.ts
@@ -1,0 +1,75 @@
+// Chain-agnostic transaction references.
+//
+// EVM and Tron identify a transaction by a 32-byte hash; Solana uses a 64-byte
+// signature rendered in base58. They have no common syntax, so the app cannot
+// keep typing these as `0x${string}` — and the checks scattered across the
+// screens all assumed 0x-prefixed 66-char strings.
+//
+// The subtlety worth stating once: a FILL transaction belongs to the OUTPUT
+// chain, not the source chain. A Solana fill of an EVM-input order is base58
+// even though the order's source chain is EVM, so validation must be handed
+// `output.chainId`, never `sourceChainId`.
+
+import { base58 } from "@scure/base";
+import { getChainType } from "./chainType";
+
+/** A 0x-prefixed 32-byte hash (EVM, Tron) or a base58 signature (Solana). */
+export type TxRef = string;
+
+const EVM_TX_HASH = /^0x[0-9a-fA-F]{64}$/;
+const BARE_TX_HASH = /^[0-9a-fA-F]{64}$/;
+
+/** Solana signatures are 64 bytes; a 32-byte value is a pubkey, not a signature. */
+function isSolanaSignature(value: string): boolean {
+  try {
+    return base58.decode(value).length === 64;
+  } catch {
+    return false;
+  }
+}
+
+export function isValidTxRef(
+  value: string | undefined | null,
+  chainId: number | bigint | undefined
+): value is TxRef {
+  if (!value) return false;
+  if (chainId !== undefined && getChainType(chainId) === "solana") {
+    return isSolanaSignature(value);
+  }
+  // Tron reports transaction ids without the 0x prefix.
+  if (chainId !== undefined && getChainType(chainId) === "tron") {
+    return EVM_TX_HASH.test(value) || BARE_TX_HASH.test(value);
+  }
+  return EVM_TX_HASH.test(value);
+}
+
+/**
+ * Canonical storage form. Tron ids gain the 0x prefix they are usually shown
+ * without; Solana signatures are returned untouched, because base58 has no
+ * prefix to add and lower-casing one would corrupt it.
+ */
+export function normalizeTxRef(value: string, chainId: number | bigint | undefined): TxRef {
+  const trimmed = value.trim();
+  if (chainId !== undefined && getChainType(chainId) === "solana") return trimmed;
+  if (BARE_TX_HASH.test(trimmed)) return `0x${trimmed}`;
+  return trimmed;
+}
+
+export function txRefPlaceholder(chainId: number | bigint | undefined): string {
+  if (chainId === undefined) return "0x...";
+  switch (getChainType(chainId)) {
+    case "solana":
+      return "base58 signature";
+    case "tron":
+      return "0x... or bare hex";
+    default:
+      return "0x...";
+  }
+}
+
+export function txRefError(chainId: number | bigint | undefined): string {
+  if (chainId !== undefined && getChainType(chainId) === "solana") {
+    return "Enter a Solana transaction signature (base58, 64 bytes)";
+  }
+  return "Enter a 32-byte transaction hash";
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,7 +14,7 @@
   import FlowStepTracker from "$lib/components/ui/FlowStepTracker.svelte";
   import store from "$lib/state.svelte";
   import { containerToIntent } from "$lib/utils/intent";
-  import { isTronChain } from "$lib/utils/chainType";
+  import { getChainType } from "$lib/utils/chainType";
 
   BigInt.prototype.toJSON = function () {
     return this.toString();
@@ -100,13 +100,22 @@
   // Wallet identity is bound to the chain of the OPERATION, not to the draft
   // issuance form: filling uses the selected order's output chain, proving and
   // finalising use its input chain. The draft form only drives issuance.
-  // An EVM address is never a valid identity on Tron (and vice versa), so a
-  // missing Tron wallet blocks instead of silently falling back.
+  // An address from one namespace is never a valid identity in another, so a
+  // missing wallet blocks instead of silently falling back to the EVM account.
   const accountFor = (chainId: number | bigint | undefined) => {
-    if (chainId !== undefined && isTronChain(chainId)) {
-      const tronAccount = store.accountForChain(chainId);
-      if (!tronAccount) throw new Error("Connect TronLink to act on Tron");
-      return tronAccount;
+    if (chainId !== undefined) {
+      const chainType = getChainType(chainId);
+      if (chainType !== "evm") {
+        const resolved = store.accountForChain(chainId);
+        if (!resolved) {
+          throw new Error(
+            chainType === "tron"
+              ? "Connect TronLink to act on Tron"
+              : "Connect a Solana wallet to act on Solana"
+          );
+        }
+        return resolved;
+      }
     }
     const resolved = chainId !== undefined ? store.accountForChain(chainId) : undefined;
     return resolved ?? store.connectedAccount?.address!;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,7 +13,7 @@
   import WalletStatus from "$lib/components/WalletStatus.svelte";
   import FlowStepTracker from "$lib/components/ui/FlowStepTracker.svelte";
   import store from "$lib/state.svelte";
-  import { containerToIntent } from "$lib/utils/intent";
+  import { containerToIntent, reviveOrderBigInts } from "$lib/utils/intent";
   import { getChainType } from "$lib/utils/chainType";
 
   BigInt.prototype.toJSON = function () {
@@ -68,7 +68,15 @@
               type: "None",
               payload: "0x"
             } as NoSignature);
-        const orderContainer = { ...order, allocatorSignature, sponsorSignature };
+        // The socket hands over raw parsed JSON (`user:vm-order-submit` skips
+        // the BigInt conversion getAndParseOrders does), so every bigint field
+        // arrives as a decimal string — which broke Solana PDA derivations.
+        const orderContainer = {
+          ...order,
+          order: reviveOrderBigInts(order.order),
+          allocatorSignature,
+          sponsorSignature
+        };
 
         // Deduplicate: only add if not already present
         const orderId = containerToIntent(orderContainer).orderId();

--- a/src/routes/polymer/+server.ts
+++ b/src/routes/polymer/+server.ts
@@ -6,7 +6,13 @@ import {
   PRIVATE_POLYMER_TESTNET_ZONE_API_KEY
 } from "$env/static/private";
 import { toByteArray } from "base64-js";
+import { base58 } from "@scure/base";
 import { verifyProvableLog } from "$lib/libraries/provableLogVerify";
+import {
+  POLYMER_SOLANA_PROGRAM_ID,
+  verifyProvableSolanaLog
+} from "$lib/libraries/provableSolanaLogVerify";
+import { isSolanaChain } from "$lib/utils/chainType";
 
 function getPolymerUrl(mainnet: boolean) {
   return mainnet
@@ -22,6 +28,34 @@ function isPositiveInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
 }
 
+/** Decode base58 and require an exact byte length, without throwing on malformed input. */
+function isBase58OfLength(value: unknown, bytes: number): value is string {
+  if (typeof value !== "string" || value.length === 0) return false;
+  try {
+    return base58.decode(value).length === bytes;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The request body, as a discriminated union:
+ *
+ * - `polymerIndex` present  — poll an existing job, no source-log fields needed (#64).
+ * - `txSignature` present   — Solana source: a transaction signature plus the program that
+ *                             emitted the `Prove:` log.
+ * - otherwise               — EVM source: (block, globalLogIndex) coordinates.
+ */
+type PolymerRequestBody = {
+  srcChainId?: number;
+  srcBlockNumber?: number;
+  globalLogIndex?: number;
+  txSignature?: string;
+  programID?: string;
+  polymerIndex?: number;
+  mainnet?: boolean;
+};
+
 export const POST: RequestHandler = async ({ request }) => {
   let body: unknown;
   try {
@@ -34,15 +68,26 @@ export const POST: RequestHandler = async ({ request }) => {
     return json({ error: "Body must be a JSON object" }, { status: 400 });
   }
 
-  const { srcChainId, srcBlockNumber, globalLogIndex, polymerIndex, mainnet } = body as {
-    srcChainId: number;
-    srcBlockNumber: number;
-    globalLogIndex: number;
-    polymerIndex?: number;
-    mainnet?: boolean;
-  };
+  const {
+    srcChainId,
+    srcBlockNumber,
+    globalLogIndex,
+    txSignature,
+    programID,
+    polymerIndex,
+    mainnet
+  } = body as PolymerRequestBody;
 
   const isPolling = polymerIndex !== undefined && polymerIndex !== null;
+  // Discriminate on `txSignature` before the EVM validators run: a Solana request carries no
+  // block number, so running them first would reject it as "Missing or invalid 'srcBlockNumber'".
+  const isSolanaSource = !isPolling && typeof txSignature === "string";
+
+  // The EVM validators below narrow these three fields, but that narrowing does not survive into
+  // the request branch further down, which sits in a separate control-flow block. Capturing the
+  // validated values keeps the proof request honest about what it actually verified, instead of
+  // asserting non-null over an optional the type says may be missing.
+  let evmSource: { srcChainId: number; srcBlockNumber: bigint; globalLogIndex: number } | undefined;
 
   if (mainnet !== undefined && mainnet !== null && typeof mainnet !== "boolean") {
     return json({ error: "Invalid 'mainnet'" }, { status: 400 });
@@ -52,6 +97,23 @@ export const POST: RequestHandler = async ({ request }) => {
   if (isPolling) {
     if (!isPositiveInteger(polymerIndex)) {
       return json({ error: "Invalid 'polymerIndex'" }, { status: 400 });
+    }
+  } else if (isSolanaSource) {
+    if (!isPositiveInteger(srcChainId) || !isSolanaChain(srcChainId)) {
+      return json({ error: "Missing or invalid Solana 'srcChainId'" }, { status: 400 });
+    }
+    // A Solana signature is 64 bytes, not 32 — a base58 string that decodes to 32 is a pubkey,
+    // not a signature.
+    if (!isBase58OfLength(txSignature, 64)) {
+      return json({ error: "Missing or invalid 'txSignature'" }, { status: 400 });
+    }
+    if (!isBase58OfLength(programID, 32)) {
+      return json({ error: "Missing or invalid 'programID'" }, { status: 400 });
+    }
+    // Pinned: this endpoint spends the org's Polymer API key for unauthenticated callers, so it
+    // must not prove logs of an arbitrary program. Same rationale as PROVABLE_EVENTS on EVM.
+    if (programID !== POLYMER_SOLANA_PROGRAM_ID) {
+      return json({ error: "'programID' is not the Polymer oracle program" }, { status: 400 });
     }
   } else {
     if (!isPositiveInteger(srcChainId)) {
@@ -67,6 +129,11 @@ export const POST: RequestHandler = async ({ request }) => {
     ) {
       return json({ error: "Missing or invalid 'globalLogIndex'" }, { status: 400 });
     }
+    evmSource = {
+      srcChainId,
+      srcBlockNumber: BigInt(srcBlockNumber),
+      globalLogIndex
+    };
   }
 
   try {
@@ -74,13 +141,51 @@ export const POST: RequestHandler = async ({ request }) => {
     const PRIVATE_POLYMER_ZONE_API_KEY = getPolymerKey(useMainnet);
 
     let polymerRequestIndex = polymerIndex;
-    if (!isPolling) {
+    if (isSolanaSource) {
+      // Same pre-flight as the EVM path: confirm the transaction really carries the pinned
+      // program's `Prove:` log before spending a Polymer proof request on it.
+      const verification = await verifyProvableSolanaLog(
+        Number(srcChainId),
+        String(txSignature),
+        String(programID)
+      );
+      if (verification === "mismatch") {
+        console.warn("polymer proof request rejected: transaction has no Prove log", {
+          srcChainId,
+          txSignature
+        });
+        return json({ error: "transaction does not contain a Polymer Prove log" }, { status: 400 });
+      }
+      const requestProof = await axios.post(
+        POLYMER_URL,
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "polymer_requestProof",
+          params: [
+            {
+              srcChainId,
+              txSignature,
+              programID
+            }
+          ]
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${PRIVATE_POLYMER_ZONE_API_KEY}`,
+            "Content-Type": "application/json",
+            Accept: "application/json"
+          }
+        }
+      );
+      polymerRequestIndex = requestProof.data.result;
+    } else if (evmSource) {
       // V2-199 (#53) + #63: confirm the referenced log really is one of the allowlisted
       // output-settler events before spending a Polymer proof request on it.
       const verification = await verifyProvableLog(
-        Number(srcChainId),
-        BigInt(srcBlockNumber),
-        Number(globalLogIndex)
+        evmSource.srcChainId,
+        evmSource.srcBlockNumber,
+        evmSource.globalLogIndex
       );
       if (verification === "mismatch") {
         console.warn("polymer proof request rejected: log is not an allowlisted event", {
@@ -172,8 +277,10 @@ export const POST: RequestHandler = async ({ request }) => {
   } catch (error) {
     console.error("polymer proof request failed", {
       srcChainId,
-      srcBlockNumber,
-      globalLogIndex,
+      // Only the fields the caller actually sent: a Solana or polling request has no
+      // (block, logIndex) coordinates, and logging them as undefined is noise.
+      ...(isSolanaSource ? { txSignature, programID } : {}),
+      ...(!isSolanaSource && !isPolling ? { srcBlockNumber, globalLogIndex } : {}),
       polymerIndex: polymerIndex ?? null,
       polling: isPolling,
       error: error instanceof Error ? error.message : String(error)

--- a/src/routes/polymer/+server.ts
+++ b/src/routes/polymer/+server.ts
@@ -14,6 +14,48 @@ import {
 } from "$lib/libraries/provableSolanaLogVerify";
 import { isSolanaChain } from "$lib/utils/chainType";
 
+/**
+ * Solana's chain id in Polymer's own registry.
+ *
+ * Polymer does NOT use the OIF chain id (1151111081099710 and friends) for
+ * Solana; it has its own small integer namespace and rejects anything else with
+ * `srcChainId is required for Solana and must be 2`. Read off that error from
+ * the live API on 2026-08-14 — their docs do not state it.
+ *
+ * The cluster is selected by which API host we talk to (api.polymer.zone vs
+ * api.testnet.polymer.zone), so this same id is used for both. Only mainnet has
+ * been confirmed against the live API; devnet is assumed to match and is listed
+ * as unverified in tests/fixtures/solana/PREFLIGHT.md.
+ */
+const POLYMER_SOLANA_CHAIN_ID = 2;
+
+/**
+ * Reads the request index out of a `polymer_requestProof` response.
+ *
+ * JSON-RPC reports failures in `error`, not by HTTP status, so axios resolves
+ * happily and `result` is simply absent. Reading `.result` blindly yields
+ * `undefined`, which then gets passed to `polymer_queryProof` and comes back as
+ * a bare `not_found` — the caller sees "no proof yet" and polls forever for a
+ * request that was never accepted. Fail loudly with Polymer's own reason
+ * instead.
+ */
+function assertRequestAccepted(data: unknown, source: "solana" | "evm"): number {
+  const body = data as { result?: unknown; error?: { code?: number; message?: string } };
+  if (body?.error) {
+    throw new Error(
+      `Polymer rejected the ${source} proof request: ${body.error.message ?? "unknown error"}${
+        body.error.code === undefined ? "" : ` (code ${body.error.code})`
+      }`
+    );
+  }
+  if (typeof body?.result !== "number") {
+    throw new Error(
+      `Polymer returned no request index for the ${source} proof request: ${JSON.stringify(data)}`
+    );
+  }
+  return body.result;
+}
+
 function getPolymerUrl(mainnet: boolean) {
   return mainnet
     ? ("https://api.polymer.zone/v1/" as const)
@@ -164,7 +206,9 @@ export const POST: RequestHandler = async ({ request }) => {
           method: "polymer_requestProof",
           params: [
             {
-              srcChainId,
+              // Polymer's own id, not the OIF one we validate above — the two
+              // namespaces are unrelated for Solana.
+              srcChainId: POLYMER_SOLANA_CHAIN_ID,
               txSignature,
               programID
             }
@@ -178,7 +222,7 @@ export const POST: RequestHandler = async ({ request }) => {
           }
         }
       );
-      polymerRequestIndex = requestProof.data.result;
+      polymerRequestIndex = assertRequestAccepted(requestProof.data, "solana");
     } else if (evmSource) {
       // V2-199 (#53) + #63: confirm the referenced log really is one of the allowlisted
       // output-settler events before spending a Polymer proof request on it.
@@ -220,7 +264,7 @@ export const POST: RequestHandler = async ({ request }) => {
           }
         }
       );
-      polymerRequestIndex = requestProof.data.result;
+      polymerRequestIndex = assertRequestAccepted(requestProof.data, "evm");
     }
     const requestProofData = await axios.post(
       POLYMER_URL,
@@ -254,8 +298,12 @@ export const POST: RequestHandler = async ({ request }) => {
             status: "complete";
             proof: "string";
           }
+        // "initialized" and "pending" are both in-progress; "not_found" comes
+        // back when the queried index does not exist. All three observed live —
+        // only "error" and "complete" are terminal, and the caller polls on
+        // anything else.
         | {
-            status: "initialized";
+            status: "initialized" | "pending" | "not_found";
           }
       );
     } = requestProofData.data;

--- a/tests/fixtures/solana/PREFLIGHT.md
+++ b/tests/fixtures/solana/PREFLIGHT.md
@@ -180,30 +180,50 @@ from inside a dependency at signing time.
 
 ---
 
-## NOT YET VERIFIED ON CHAIN
+## Verified on chain (2026-08-13, `finalized`)
 
-Everything above is derived from source. The following must be confirmed
-against live RPCs **before mainnet is enabled**, and nothing here should be
-treated as fact until it is. All reads at `finalized` commitment.
+Read directly from mainnet-beta and devnet RPC. These were previously
+assumptions; they are now measurements.
 
-- [ ] **`ChainId` PDA contents on each cluster.** The programs enforce
-      `output.chain_id == chain_id`, so a wrong value silently invalidates
-      every fill. Expect `1151111081099710` (mainnet) / `1151111081099712`
-      (devnet). **If this is wrong, stop.**
-- [ ] **Genesis hashes**, which back the network guard in
-      `src/lib/solana/client.ts`. Currently the widely published values,
-      marked UNVERIFIED in code:
-      mainnet `5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d`,
-      devnet `EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG`.
+| Fact                              | mainnet                                        | devnet                                         |
+| --------------------------------- | ---------------------------------------------- | ---------------------------------------------- |
+| Genesis hash                      | `5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d` | `EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG` |
+| `ChainId` PDA contents            | `1151111081099710` ✅                          | `1151111081099712` ✅                          |
+| `OraclePolymer.chain_id`          | `1151111081099710`                             | `1151111081099712`                             |
+| `OraclePolymer.polymer_prover_id` | `CdvSq48QUukYuMczgZAVNZrwcHNshBdtqrjW26sQiGPs` | same                                           |
+| `OraclePolymer.owner`             | `7P94xcg7X4Xc8goZ3GW2VQDJUhiab7h7rnTfvnNShZ29` | `DED5bXSyFUL8YDFF8jZ5o7Aj7vpzhKvS8CgKw6MYHQY1` |
+| `InputSettlerEscrow` PDA          | initialised, owned by `LiFiRp8RM7…`, 25 bytes  | same                                           |
+| `OutputSettlerSimple` PDA         | initialised, owned by `LiFiEDFjz5…`, 25 bytes  | same                                           |
+| Prover program                    | deployed, executable, BPFLoaderUpgradeable     | same                                           |
+
+The mainnet oracle owner matches the ceremony key pinned in
+`scripts/initialize_programs.ts`.
+
+### Prover scratch PDAs — seed scheme confirmed
+
+The prover's accounts are `["cache", authority]`, `["result", authority]` and
+`["internal"]`, derived under the prover program id. `cache` and `result` are
+per-authority (so concurrent solvers do not collide) and exist only during a
+proof, but the `internal` singleton derives to
+`4w6Lac3Yc8ZdJ7H4Nt9FS98VMt8w6DwkGRJL1h4Ww5z1`, **which exists on both
+clusters owned by the prover program** — confirming the scheme. Pinned in
+`tests/unit/solanaPda.test.ts`.
+
+`readPolymerProverId` re-checks the pinned prover id against the on-chain
+account before every receive. The prover belongs to Polymer, not to this
+protocol, so a rotation on their side must fail loudly rather than as an
+opaque CPI error mid-proof.
+
+---
+
+## STILL NOT VERIFIED
+
+The remaining unknowns. Nothing below should be treated as fact until checked.
+
 - [ ] **Deployed binary matches the audited source** — program accounts
       executable, program-data address resolved, binary hash recorded, upgrade
       authority recorded (or immutability confirmed). Matching a PDA and a
       chain id does not prove this.
-- [ ] **Settler PDAs initialised** with the expected account owner and
-      discriminator.
-- [ ] **`OraclePolymer.polymer_prover_id` and `owner`.** The prover's
-      `cache`/`result`/`internal` PDA seeds currently come from a stale test
-      and must be confirmed against the prover's published IDL.
 - [ ] **`chain_mapping` PDAs** exist for every EVM chain offered as a
       counterpart.
 - [ ] **Polymer's proof-request API shape for a Solana source.** The

--- a/tests/fixtures/solana/PREFLIGHT.md
+++ b/tests/fixtures/solana/PREFLIGHT.md
@@ -199,6 +199,18 @@ assumptions; they are now measurements.
 The mainnet oracle owner matches the ceremony key pinned in
 `scripts/initialize_programs.ts`.
 
+### Listed mints (read from chain, same date)
+
+| Network | Token | Mint                                           | Decimals | Program   |
+| ------- | ----- | ---------------------------------------------- | -------- | --------- |
+| mainnet | USDC  | `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` | 6        | SPL Token |
+| mainnet | USDT  | `Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB` | 6        | SPL Token |
+| mainnet | wSOL  | `So11111111111111111111111111111111111111112`  | 9        | SPL Token |
+| devnet  | USDC  | `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU` | 6        | SPL Token |
+
+All legacy SPL Token, so the default ATA derivation applies; none exercise the
+Token-2022 path.
+
 ### Prover scratch PDAs — seed scheme confirmed
 
 The prover's accounts are `["cache", authority]`, `["result", authority]` and
@@ -229,7 +241,6 @@ The remaining unknowns. Nothing below should be treated as fact until checked.
 - [ ] **Polymer's proof-request API shape for a Solana source.** The
       `{srcChainId, txSignature, programID}` body is inferred from a previous
       attempt (PR #47), not from Polymer documentation.
-- [ ] **SPL mints and decimals** for the tokens listed in `config.ts`.
 - [ ] One real devnet fill, with its full log dump saved beside this file as
       `tx-fill-devnet.json` (the analogue of Tron's
       `txinfo-fill-old-settler.json`).

--- a/tests/fixtures/solana/PREFLIGHT.md
+++ b/tests/fixtures/solana/PREFLIGHT.md
@@ -265,6 +265,45 @@ leave a stale timestamp that fails every retry with
 false proof — `oracle_base::validate_payload` compares the payload against the
 on-chain `LocalAttestation` — so the failure mode is loud, not silent.
 
+## The Base input oracle (verified on chain 2026-08-14)
+
+`0x008C3800F3Ad9b3B662d002E90Cc00000000eE17` on Base is **`PolymerOracleMapped`**
+(verified source, compiler 0.8.30), constructed with
+`crossL2Prover = 0x95ccEAE71605c5d97A0AC0EA13013b058729d075`.
+
+**It has two receive entry points and they are not interchangeable:**
+
+| Entry point                   | Prover call                                    | Use for            |
+| ----------------------------- | ---------------------------------------------- | ------------------ |
+| `receiveMessage(bytes)`       | `validateEvent` — parses an EVM event log      | EVM / Tron outputs |
+| `receiveSolanaMessage(bytes)` | `validateSolLogs` — parses Solana program logs | **Solana outputs** |
+
+Sending a Solana proof to `receiveMessage` reverts with no reason string.
+Confirmed by simulating one real proof against both on Base: `receiveMessage`
+reverts, `receiveSolanaMessage` succeeds.
+
+They also key the attestation differently, which is why `output.oracle` must be
+the Polymer PROGRAM ID for a Solana output:
+
+- EVM path: `_attestations[chain][address(this).toIdentifier()][emittingContract][hash]`
+- Solana path: `_attestations[chain][returnedProgramId][application][hash]`
+
+where for Solana `application` is the first 32 bytes of the decoded log — the
+**OutputSettlerSimple PDA** — and the payload hash is `keccak256` of the rest.
+
+**Chain map is configured** (this closes the earlier `chain_mapping` unknown for
+Base <-> Solana). `PolymerOracleMapped._getChainId` reverts `ZeroValue()` on an
+unmapped id; read from chain:
+
+| Call                                  | Value              |
+| ------------------------------------- | ------------------ |
+| `chainIdMap(2)`                       | `1151111081099710` |
+| `reverseChainIdMap(1151111081099710)` | `2`                |
+| `chainIdMap(8453)`                    | `8453`             |
+
+Note `SOLANA_POLYMER_CHAIN_ID = 2` is hardcoded in `PolymerOracle`, matching what
+Polymer's API demands — the same `2` documented above.
+
 ## STILL NOT VERIFIED
 
 The remaining unknowns. Nothing below should be treated as fact until checked.
@@ -274,7 +313,8 @@ The remaining unknowns. Nothing below should be treated as fact until checked.
       authority recorded (or immutability confirmed). Matching a PDA and a
       chain id does not prove this.
 - [ ] **`chain_mapping` PDAs** exist for every EVM chain offered as a
-      counterpart.
+      counterpart. (Base <-> Solana confirmed on the EVM side; the Solana-side
+      PDAs for other EVM counterparts are still unchecked.)
 - [ ] **Polymer's Solana chain id on the TESTNET API.** Mainnet is confirmed as
       `2`; devnet is assumed to be the same because the host selects the
       cluster, but has not been exercised.

--- a/tests/fixtures/solana/PREFLIGHT.md
+++ b/tests/fixtures/solana/PREFLIGHT.md
@@ -1,0 +1,218 @@
+# Solana preflight
+
+Deployment and RPC-semantics record for the Solana integration, mirroring
+`tests/fixtures/tron/PREFLIGHT.md`. Code comments cite this file by name.
+
+Source of truth: `catalyst-intent-svm` @ `291e1da4e9a7d5f0a5ba27f07fca32e82cdae4db`
+(2026-08-13). Program ids read from the **top-level `address`** of each
+`target/idl/*.json` — Anchor ≥ 0.30 moved it out of `metadata`, which now holds
+only `name`/`version`/`spec`. Reading `metadata.address` yields `undefined` and
+derives every PDA under a garbage program id.
+
+---
+
+## ⚠️ Three different values are all called "the Solana Polymer oracle"
+
+**This is the single most likely source of a silent failure.** Getting it wrong
+produces an order that fills — moving the solver's tokens — and can then never
+be proven.
+
+| Field                                                    | Must hold              | Value                                                           | Proof                                                                                                                                                    |
+| -------------------------------------------------------- | ---------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MandateOutput.settler` (Solana output)                  | output settler **PDA** | `DHShHmVkTwCzUzAQbCu4GDqJmursuDscNR6o4hTBgeRy` / `0xb68296ce…`  | `programs/outputs/output_settler_base/src/base.rs:122`                                                                                                   |
+| `MandateOutput.oracle` (Solana output, cross-chain)      | polymer **PROGRAM ID** | `LiFiBtfyPT1DnTHTAeZ2rwr5RgMrThwA5kt7KGT5nBV` / `0x050cae5588…` | `programs/oracles/oracle_polymer/src/instructions/submit.rs:71` — compares the LocalAttestation consumer against `ctx.program_id`                        |
+| `StandardSolana.inputOracle` (Solana input, cross-chain) | polymer oracle **PDA** | `49zLKETMq34CUC2E2wL1xvv6uN2AUgyhjVX221mjE3Rw` / `0x2ee088ac…`  | `oracle_polymer/src/instructions/receive_attest.rs:142` + `programs/inputs/input_settler_base/src/base.rs:125`                                           |
+| Same-chain Solana→Solana, both oracle fields             | output settler **PDA** | `0xb68296ce…`                                                   | `input_settler_base/src/base.rs:88-111` — the LocalAttestation branch never reads `input_oracle`; this is canonical encoding, not a contract requirement |
+
+The EVM rule "`output.oracle` = the input chain's oracle" holds only because
+`PolymerOracle` is CREATE2-identical across EVM chains. It does **not** carry
+over to Solana.
+
+---
+
+## Programs (identical on devnet and mainnet)
+
+`Anchor.toml` declares the same ids under `[programs.devnet]` and
+`[programs.mainnet]`, so PDAs derived from them are cluster-independent.
+
+| Program                            | Base58                                        | bytes32                                                              |
+| ---------------------------------- | --------------------------------------------- | -------------------------------------------------------------------- |
+| `intents_protocol`                 | `LiFixdGLT5CMdLsHBvaijTXpPy4Uux9Y53SXkuR4HaK` | `0x050cae668656471e02181ee1e6c52ee00a779ca7c481a04fb0e2ab9085f5c304` |
+| `input_settler_escrow`             | `LiFiRp8RM7nJUZyUYC9FPPpDr7sAy5XPfBN6ABzBgT7` | `0x050cae5ad286a6a6227a55fd650d63a3eccc866d6c293c94b87839e5cb6dba86` |
+| `output_settler_simple`            | `LiFiEDFjz5x1jJe9gSXNDHQW4dWt4yLXdp2VN4EiQUt` | `0x050cae566a93270d66dbfe1915b80dc06e4a80178992592b3d8f51e888d0afe5` |
+| `polymer` (crate `oracle_polymer`) | `LiFiBtfyPT1DnTHTAeZ2rwr5RgMrThwA5kt7KGT5nBV` | `0x050cae5588f8d907500199177ab1239f61b8557af2ffacd5defed0070b858ad4` |
+
+### State PDAs
+
+| Account                      | Seed                    | Bump | Base58                                         | bytes32                                                              |
+| ---------------------------- | ----------------------- | ---- | ---------------------------------------------- | -------------------------------------------------------------------- |
+| `ChainId`                    | `chain_id`              | 255  | `BkEw3WHFvJR9a5deUcwPLJ79yK3r9YGdQ61TehFXzAQ`  | `0x02c0b32f8be4a5319a95cca17bd05eba48e7195ce52f1608723b51e575457df5` |
+| `InputSettlerEscrowAccount`  | `input_settler_escrow`  | 253  | `Cj3mSoPJtgi5bubC9rLz8oM1DuXoJj97RMw1uC6ev9zm` | `0xae3613f974fc9cd94682bbff7bd7f229697616c5b6fdb6e0c16d1f02607242ae` |
+| `OutputSettlerSimpleAccount` | `output_settler_simple` | 255  | `DHShHmVkTwCzUzAQbCu4GDqJmursuDscNR6o4hTBgeRy` | `0xb68296ce230150bb20190a46eb26a198b05bec8fc7f0fa893d690cf531fa9e54` |
+| `OraclePolymer`              | `polymer`               | 253  | `49zLKETMq34CUC2E2wL1xvv6uN2AUgyhjVX221mjE3Rw` | `0x2ee088ace4ac030d2266e50d829feeac73d1acb13e5825ef835d6f3318804796` |
+
+Derivation is re-verified from `(program id, seed, bump)` in `@lifi/intent`'s
+`constants.spec.ts` and again app-side in `tests/unit/solanaPda.test.ts`, so
+these are computed values rather than magic constants.
+
+**Superseded — must never reappear.** `catalyst-intent-svm` commit `21fc982`
+rotated every program id to the `LiFi…` vanity keys. The PDAs under the old
+ids are correctly shaped and correctly derived, which is why they survived two
+`@lifi/intent` releases unnoticed:
+`0x0cb3931fa2bfb2296eb48e6f431df4ab41dc084c068b39f7e1f125604252611c`
+(input settler) and
+`0x57e93c230b75ab3ad76e89157ae3ce486fbe4ae4c4ac120882ccf2fdfb88a8bf`
+(output settler).
+
+### Order-scoped PDAs
+
+- `order_context` = `["order_context", orderId]` — closed by `finalise` **and** by `refund`
+- `consumed_order` = `["consumed_order", orderId]` — created at open, never closed (replay guard)
+- `fill_id` = `[orderId, mandateOutputHash]` — **no string prefix**
+- `local_attestation` = `["local_attestation", attestator, consumer, dataHash]`
+- `attestation` = `["attestation", oraclePda, chainId u128 LE, source, application, payloadHash]`
+
+---
+
+## Hashes
+
+| Value                                   | Preimage                                                                                                                                                     |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `mandate_output_hash` (the FillId seed) | Byte-identical to `getOutputHash()` in `@lifi/intent`. **Reuse it; do not reimplement.** Verified in `tests/unit/solanaEncode.test.ts`.                      |
+| LocalAttestation `data_hash`            | Fill description **WITHOUT** the timestamp — it is a PDA seed, so it must be derivable before the fill lands. The program verifies the timestamp separately. |
+| Remote Attestation `payload_hash`       | Fill description **WITH** the timestamp.                                                                                                                     |
+
+`FILL_MAGIC = 0xd1252dff`, `NOT_FILLED_MAGIC = 0x830c1e1c`
+(`common/src/encoding/mandate_output_encoding_lib.rs`). Conflating the two fill
+descriptions derives an attestation account that never exists.
+
+---
+
+## Events
+
+Anchor `emit!` compiles to `sol_log_data`: a single `Program data: <base64>`
+line carrying `discriminator(8) || borsh(event)`, emitted inside the emitting
+program's own invoke frame. **Not** `emit_cpi!`; there is no event-authority
+PDA and no self-CPI.
+
+**Any program can print a `Program data:` line**, so frame attribution —
+tracking `Program <id> invoke [n]` / `success` nesting — is the anti-spoof, not
+a nicety. `findOutputFilledLog` in `src/lib/solana/events.ts` implements it and
+`tests/unit/solanaEvents.test.ts` includes a forged event that must be rejected.
+
+**None of these events appear in the generated IDLs.** They are defined in the
+helper crates (`output_settler_base`, `input_settler_base`, `oracle_base`)
+rather than inside a `#[program]` module, so `anchor build` omits them —
+`output_settler_simple.json` ships `"events": []`. Layouts are hand-rolled.
+
+| Event                  | Discriminator = `sha256("event:<Name>")[..8]` |
+| ---------------------- | --------------------------------------------- |
+| `OutputFilledEvent`    | `[43,25,133,52,107,176,40,213]`               |
+| `OutputNotFilledEvent` | `[162,22,108,52,116,186,115,37]`              |
+| `OpenEvent`            | `[13,191,79,145,65,183,42,90]`                |
+| `FinalisedEvent`       | `[226,131,196,252,105,222,23,210]`            |
+| `OutputProvenEvent`    | `[85,190,185,8,90,48,3,214]`                  |
+
+`OutputFilledEvent` layout: `settler Pubkey(32)`, `order_id [u8;32]`,
+`solver [u8;32]`, `timestamp u32 LE`, `output MandateOutput` (six `[u8;32]`
+then two u32-LE-length-prefixed `Vec<u8>`), `final_amount u64 LE`.
+
+`oracle_polymer::submit` does **not** emit an event — it writes a plain `msg!`:
+`Prove: program: {program_id}, {base64(source ‖ payload)}`. That log line is
+what Polymer's indexer scrapes.
+
+---
+
+## Instruction gotchas
+
+- **`fill_id` must be passed explicitly.** Not a general Anchor limitation: the
+  IDL can only express the second seed as the raw `output` argument, not as
+  `get_mandate_output_hash(output)`. `local_attestation` is likewise created by
+  CPI and must be derived client-side.
+- **`open` has no native-SOL input path.** It requires an SPL mint, so an order
+  depositing SOL must use wrapped SOL. Native outputs _are_ supported, via
+  `native_fill` (zero token address).
+- **There is no single `receive` instruction.** It is
+  `receive_load_proof` + `receive_attest`, with a chunked fallback
+  (`create_polymer_accounts` → `load_proof_chunk*` → `validate_event` →
+  `receive_attest`) for proofs too large for one transaction
+  (`oracle_polymer/src/lib.rs:14`).
+- **`finalise` takes one attestation per output in `order.outputs` order** as
+  remaining accounts. The program indexes them positionally, so a reordering
+  settles the wrong output.
+- **`filler_data` must be exactly 32 non-zero bytes** (`resolve_output.rs`).
+- **No `orderStatus` enum.** `finalise` and `refund` both close
+  `order_context`, so "context gone, `consumed_order` present" means terminal,
+  not specifically claimed. The app already folds Claimed and Refunded together
+  on EVM and Tron, so this matches.
+- **The mint's owning program is part of the ATA seed.** SPL and Token-2022
+  produce different ATAs for the same mint, so the owner is read on chain, not
+  guessed.
+
+---
+
+## Stale references — do not copy from these
+
+The reference TypeScript in `catalyst-intent-svm/tests/end-to-end/` predates
+several changes and will mislead:
+
+- `shared.ts` `computeOracleAttestationPda` **omits the `"attestation"` seed
+  prefix**. The correct 6-seed derivation is in
+  `base-solana/receive-and-finalise/00-receive.test.ts:213`.
+- `base-solana/receive-and-finalise/00-receive.test.ts:300` calls `.receive()`,
+  an instruction that no longer exists.
+- `open-order/00-open-order.test.ts:226` omits the `consumed_order` account.
+- `chains.json` / `default_orders.json` carry pre-rotation addresses.
+
+---
+
+## Toolchain
+
+`@solana/web3.js` and `@coral-xyz/anchor` **do** import cleanly under
+`bun test` — unlike `tronweb`, which cannot load under bun and is the reason
+the Tron tests mock `TronWebLike`. The Solana facade still uses a DI seam
+(`src/lib/solana/types.ts`), but for a different reason: isolating the signer
+so write paths can be asserted without a network or a wallet.
+
+The wallet adapters require a global `Buffer`, installed in
+`src/hooks.client.ts`. Without it the failure is a bare "Buffer is not defined"
+from inside a dependency at signing time.
+
+---
+
+## NOT YET VERIFIED ON CHAIN
+
+Everything above is derived from source. The following must be confirmed
+against live RPCs **before mainnet is enabled**, and nothing here should be
+treated as fact until it is. All reads at `finalized` commitment.
+
+- [ ] **`ChainId` PDA contents on each cluster.** The programs enforce
+      `output.chain_id == chain_id`, so a wrong value silently invalidates
+      every fill. Expect `1151111081099710` (mainnet) / `1151111081099712`
+      (devnet). **If this is wrong, stop.**
+- [ ] **Genesis hashes**, which back the network guard in
+      `src/lib/solana/client.ts`. Currently the widely published values,
+      marked UNVERIFIED in code:
+      mainnet `5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d`,
+      devnet `EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG`.
+- [ ] **Deployed binary matches the audited source** — program accounts
+      executable, program-data address resolved, binary hash recorded, upgrade
+      authority recorded (or immutability confirmed). Matching a PDA and a
+      chain id does not prove this.
+- [ ] **Settler PDAs initialised** with the expected account owner and
+      discriminator.
+- [ ] **`OraclePolymer.polymer_prover_id` and `owner`.** The prover's
+      `cache`/`result`/`internal` PDA seeds currently come from a stale test
+      and must be confirmed against the prover's published IDL.
+- [ ] **`chain_mapping` PDAs** exist for every EVM chain offered as a
+      counterpart.
+- [ ] **Polymer's proof-request API shape for a Solana source.** The
+      `{srcChainId, txSignature, programID}` body is inferred from a previous
+      attempt (PR #47), not from Polymer documentation.
+- [ ] **SPL mints and decimals** for the tokens listed in `config.ts`.
+- [ ] One real devnet fill, with its full log dump saved beside this file as
+      `tx-fill-devnet.json` (the analogue of Tron's
+      `txinfo-fill-old-settler.json`).
+- [ ] **`finalise` transaction-size headroom.** `validate_finalise_tx_size_fits`
+      caps the finalise transaction, so orders above roughly three outputs are
+      rejected at `open`. Measure the real limit and surface it at issuance.

--- a/tests/fixtures/solana/PREFLIGHT.md
+++ b/tests/fixtures/solana/PREFLIGHT.md
@@ -250,6 +250,21 @@ Two traps worth restating, because both cost a debugging session:
   `.result` blindly yields `undefined`, which then queries as `not_found` and is
   indistinguishable from "not ready yet".
 
+## Read commitment
+
+Fill details (solver + timestamp, decoded from `OutputFilledEvent`) are read at
+**`confirmed`**, not `finalized`. `finalized` added roughly 13 seconds — about
+32 slots — to every fill before the proof could even be built, and `signAndSend`
+has already waited for `confirmed` and read the transaction back, so this read
+costs nothing.
+
+Accepted risk, decided deliberately: a confirmed slot can in principle still be
+dropped, and `getFillDetails` memoises for the session, so a dropped slot would
+leave a stale timestamp that fails every retry with
+`InvalidLocalAttestationTimestamp` until a page reload. It cannot produce a
+false proof — `oracle_base::validate_payload` compares the payload against the
+on-chain `LocalAttestation` — so the failure mode is loud, not silent.
+
 ## STILL NOT VERIFIED
 
 The remaining unknowns. Nothing below should be treated as fact until checked.

--- a/tests/fixtures/solana/PREFLIGHT.md
+++ b/tests/fixtures/solana/PREFLIGHT.md
@@ -304,6 +304,54 @@ unmapped id; read from chain:
 Note `SOLANA_POLYMER_CHAIN_ID = 2` is hardcoded in `PolymerOracle`, matching what
 Polymer's API demands — the same `2` documented above.
 
+## The quote API's Solana notation (verified against order.li.fi 2026-08-14)
+
+`POST /api/v1/integrator/quote/request` identifies every party as a CAIP-2
+`namespace:chainId` chain, and reads that party's sibling `asset`, `receiver`
+and `user` fields **in that namespace's own notation**. The two must agree.
+
+| Field               | Solana form                                    |
+| ------------------- | ---------------------------------------------- |
+| `chain`             | `solana:1151111081099710` — **not** `eip155:…` |
+| `asset`             | base58 mint (`EPjFWdd5…`), not 32-byte hex     |
+| `receiver` / `user` | base58 pubkey                                  |
+
+Declaring a Solana output under `eip155:` fails with
+
+```
+400 intent.outputs.0.asset: bytes32 value has non-zero upper bytes: 0xc6fa7af3…
+```
+
+because the API reads an `eip155` asset as a left-padded 20-byte EVM address,
+and a full 32-byte Solana key never fits. The same error appears for a correct
+`solana:` chain still carrying the hex form, so **a wrong namespace and a wrong
+encoding are indistinguishable from the response** — check both.
+
+`@lifi/intent`'s `getQuotes` converts hex to base58 from the `namespace` on each
+input/output, so callers keep the internal hex form; the namespace is what must
+be supplied. lintent derives it with `namespaceForChain`.
+
+One further API rule, learned from a rejection rather than from docs:
+
+```
+400 intent.outputs.0.receiver: Invalid address format:
+    expected on-curve wallet pubkey (not a PDA), got: 4wBqpZM9…
+```
+
+The receiver must be an **on-curve** pubkey. This is not currently checked
+client-side; a PDA recipient is rejected only at quote time.
+
+Confirmed accepted (HTTP 200) with the corrected notation:
+
+```json
+{
+  "chain": "solana:1151111081099710",
+  "receiver": "DQVzbZe8bKqrNxk37udwnYMWag8u2mDBTbFbPUZiGWFM",
+  "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  "amount": "0"
+}
+```
+
 ## STILL NOT VERIFIED
 
 The remaining unknowns. Nothing below should be treated as fact until checked.

--- a/tests/fixtures/solana/PREFLIGHT.md
+++ b/tests/fixtures/solana/PREFLIGHT.md
@@ -228,6 +228,28 @@ opaque CPI error mid-proof.
 
 ---
 
+## Polymer's Solana proof API (verified on chain 2026-08-14)
+
+Confirmed end to end against the live **mainnet** API with a real `submit`
+transaction; the returned proof was 534 bytes.
+
+| Thing                   | Value                                                                           | How we know                                                                                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Request body            | `{srcChainId, txSignature, programID}`                                          | Accepted by `polymer_requestProof`                                                                                                             |
+| `srcChainId` for Solana | **`2`** — Polymer's own registry id, NOT the OIF chain id                       | Rejected `1151111081099710` with `srcChainId is required for Solana and must be 2` (code -32000)                                               |
+| `txSignature`           | the **`submit`** signature, not the fill's                                      | Posting the fill signature returns `transaction does not contain a Polymer Prove log`; the `Prove:` log is emitted by `oracle_polymer::submit` |
+| `programID`             | the Polymer oracle **program id** `LiFiBtfyPT1DnTHTAeZ2rwr5RgMrThwA5kt7KGT5nBV` | Pinned and re-checked by the route                                                                                                             |
+| Statuses observed       | `pending`, `initialized`, `complete`, `error`, `not_found`                      | Only `complete` and `error` are terminal                                                                                                       |
+
+Two traps worth restating, because both cost a debugging session:
+
+- **The cluster is chosen by the API host** (`api.polymer.zone` vs
+  `api.testnet.polymer.zone`), not by `srcChainId`. The same id `2` is sent to
+  both. Only mainnet has been confirmed — devnet is assumed to match.
+- **A rejection arrives as a JSON-RPC `error`, with HTTP 200.** Reading
+  `.result` blindly yields `undefined`, which then queries as `not_found` and is
+  indistinguishable from "not ready yet".
+
 ## STILL NOT VERIFIED
 
 The remaining unknowns. Nothing below should be treated as fact until checked.
@@ -238,9 +260,9 @@ The remaining unknowns. Nothing below should be treated as fact until checked.
       chain id does not prove this.
 - [ ] **`chain_mapping` PDAs** exist for every EVM chain offered as a
       counterpart.
-- [ ] **Polymer's proof-request API shape for a Solana source.** The
-      `{srcChainId, txSignature, programID}` body is inferred from a previous
-      attempt (PR #47), not from Polymer documentation.
+- [ ] **Polymer's Solana chain id on the TESTNET API.** Mainnet is confirmed as
+      `2`; devnet is assumed to be the same because the host selects the
+      cluster, but has not been exercised.
 - [ ] One real devnet fill, with its full log dump saved beside this file as
       `tx-fill-devnet.json` (the analogue of Tron's
       `txinfo-fill-old-settler.json`).

--- a/tests/unit/polymerReceive.test.ts
+++ b/tests/unit/polymerReceive.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { encodeFunctionData, toFunctionSelector } from "viem";
+import {
+  SOLANA_DEVNET_CHAIN_ID,
+  SOLANA_MAINNET_CHAIN_ID,
+  TRON_MAINNET_CHAIN_ID
+} from "@lifi/intent";
+import { POLYMER_ORACLE_ABI } from "../../src/lib/abi/polymeroracle";
+import { polymerReceiveFunction } from "../../src/lib/libraries/polymerReceive";
+
+// A Solana proof sent to `receiveMessage` reverts with no reason string on the
+// deployed Base oracle (0x008C3800F3Ad9b3B662d002E90Cc00000000eE17), because
+// that entry point runs ICrossL2ProverV2.validateEvent and tries to parse the
+// blob as an EVM event log. `receiveSolanaMessage` runs validateSolLogs and
+// succeeds. Confirmed by simulating a real proof against both, on chain.
+describe("which PolymerOracle entry point receives a proof", () => {
+  test("a Solana output goes to receiveSolanaMessage", () => {
+    expect(polymerReceiveFunction(SOLANA_MAINNET_CHAIN_ID)).toBe("receiveSolanaMessage");
+    expect(polymerReceiveFunction(SOLANA_DEVNET_CHAIN_ID)).toBe("receiveSolanaMessage");
+  });
+
+  test("an EVM or Tron output goes to receiveMessage", () => {
+    expect(polymerReceiveFunction(1)).toBe("receiveMessage");
+    expect(polymerReceiveFunction(8453)).toBe("receiveMessage");
+    expect(polymerReceiveFunction(TRON_MAINNET_CHAIN_ID)).toBe("receiveMessage");
+  });
+
+  // The argument is the chain the proof came FROM. A Solana fill of an
+  // EVM-input order still needs the Solana entry point, even though the call
+  // itself is made on the EVM input chain.
+  test("selects on the output chain, not the chain being called", () => {
+    const solanaOutputEvmInput = polymerReceiveFunction(SOLANA_MAINNET_CHAIN_ID);
+    expect(solanaOutputEvmInput).toBe("receiveSolanaMessage");
+  });
+
+  test("the ABI carries both entry points, and they are different functions", () => {
+    // 0xf953cec7 is what reverted in the field — pinned so a regression to it
+    // is unmistakable.
+    expect(toFunctionSelector("receiveMessage(bytes)")).toBe("0xf953cec7");
+    expect(toFunctionSelector("receiveSolanaMessage(bytes)")).not.toBe("0xf953cec7");
+
+    const proof = `0x${"ab".repeat(64)}` as const;
+    const evm = encodeFunctionData({
+      abi: POLYMER_ORACLE_ABI,
+      functionName: "receiveMessage",
+      args: [proof]
+    });
+    const solana = encodeFunctionData({
+      abi: POLYMER_ORACLE_ABI,
+      functionName: "receiveSolanaMessage",
+      args: [proof]
+    });
+
+    expect(evm.slice(0, 10)).toBe("0xf953cec7");
+    expect(solana.slice(0, 10)).toBe(toFunctionSelector("receiveSolanaMessage(bytes)"));
+    expect(solana.slice(0, 10)).not.toBe(evm.slice(0, 10));
+  });
+});

--- a/tests/unit/polymerRoute.test.ts
+++ b/tests/unit/polymerRoute.test.ts
@@ -9,6 +9,9 @@ mock.module("$env/static/private", () => ({
   PRIVATE_ROUTEMESH_API_KEY: "routemesh-key"
 }));
 
+// The Solana source path reads its optional RPC URL from `$env/dynamic/private`.
+mock.module("$env/dynamic/private", () => ({ env: {} }));
+
 type PolymerCall = { url: string; method: string; params: unknown[]; auth: string };
 
 const polymerCalls: PolymerCall[] = [];

--- a/tests/unit/polymerRoute.test.ts
+++ b/tests/unit/polymerRoute.test.ts
@@ -18,6 +18,10 @@ const polymerCalls: PolymerCall[] = [];
 let verifyCalls = 0;
 let verifyResult: "match" | "mismatch" | "unknown" = "match";
 let queryProofResult: unknown = { jobID: 1, createdAt: 0, updatedAt: 0, status: "initialized" };
+// The whole `polymer_requestProof` envelope, so a test can return a JSON-RPC
+// `error` instead of a `result` — that is how Polymer reports a rejection, and
+// axios resolves happily either way.
+let requestProofResponse: unknown = { jsonrpc: "2.0", id: 1, result: 7777 };
 
 // Drive the real `verifyProvableLog` through its RPC instead of `mock.module`-ing it: bun runs
 // every test file in one process and module mocks are global, so stubbing that path clobbered
@@ -82,7 +86,7 @@ mock.module("axios", () => ({
         auth: headers.Authorization
       });
       if (payload.method === "polymer_requestProof") {
-        return { data: { jsonrpc: "2.0", id: 1, result: 7777 } };
+        return { data: requestProofResponse };
       }
       return { data: { jsonrpc: "2.0", id: 1, result: queryProofResult } };
     }
@@ -108,6 +112,7 @@ beforeEach(() => {
   verifyCalls = 0;
   verifyResult = "match";
   queryProofResult = { jobID: 1, createdAt: 0, updatedAt: 0, status: "initialized" };
+  requestProofResponse = { jsonrpc: "2.0", id: 1, result: 7777 };
 });
 
 describe("POST /polymer — poll by polymerIndex", () => {
@@ -297,5 +302,76 @@ describe("POST /polymer — network selection", () => {
 
     expect(res.status).toBe(400);
     expect(polymerCalls).toHaveLength(0);
+  });
+});
+
+describe("POST /polymer — what the live Polymer API actually demands", () => {
+  const SOLANA_SUBMIT_SIG =
+    "2YunasnHmEatJwn3273q4QMsJAPSJrZXLVtXr1soF3gjQ73DFYFqE6cdTbJxSe6YB3zHD9EvGUCfVEbpjzSVZvE9";
+  const POLYMER_ORACLE_PROGRAM = "LiFiBtfyPT1DnTHTAeZ2rwr5RgMrThwA5kt7KGT5nBV";
+  const OIF_SOLANA_MAINNET = 1151111081099710;
+
+  const solanaBody = {
+    srcChainId: OIF_SOLANA_MAINNET,
+    txSignature: SOLANA_SUBMIT_SIG,
+    programID: POLYMER_ORACLE_PROGRAM,
+    mainnet: true
+  };
+
+  // Polymer keys Solana by its own registry id, NOT the OIF chain id. Sending
+  // the OIF one is rejected with "srcChainId is required for Solana and must
+  // be 2" — observed against the live API, and the reason every Solana proof
+  // request silently failed.
+  it("sends Polymer's Solana chain id, not the OIF one", async () => {
+    const res = await post(solanaBody);
+
+    expect(res.status).toBe(200);
+    const request = polymerCalls.find((c) => c.method === "polymer_requestProof");
+    expect(request?.params).toEqual([
+      {
+        srcChainId: 2,
+        txSignature: SOLANA_SUBMIT_SIG,
+        programID: POLYMER_ORACLE_PROGRAM
+      }
+    ]);
+  });
+
+  // Regression: `requestProof.data.result` was read blindly. On rejection there
+  // is no `result`, so the index became undefined, was passed to queryProof,
+  // and came back as a bare `not_found` — indistinguishable to the caller from
+  // "not ready yet", so the UI polled forever for a request never accepted.
+  it("surfaces a JSON-RPC rejection instead of polling a nonexistent index", async () => {
+    requestProofResponse = {
+      jsonrpc: "2.0",
+      id: 1,
+      error: { code: -32000, message: "srcChainId is required for Solana and must be 2" }
+    };
+
+    const res = await post(solanaBody);
+
+    expect(res.status).toBe(502);
+    // The failure must stop here: querying an index we never got is what
+    // produced the misleading "not_found".
+    expect(methods()).toEqual(["polymer_requestProof"]);
+  });
+
+  it("rejects a request index that is not a number", async () => {
+    requestProofResponse = { jsonrpc: "2.0", id: 1, result: null };
+
+    const res = await post(solanaBody);
+
+    expect(res.status).toBe(502);
+    expect(methods()).toEqual(["polymer_requestProof"]);
+  });
+
+  it("treats an in-progress status as pollable rather than terminal", async () => {
+    // "pending" and "not_found" are both live-observed statuses that were
+    // absent from the typed union; neither is terminal.
+    queryProofResult = { jobID: 1, createdAt: 0, updatedAt: 0, status: "pending" };
+
+    const res = await post({ polymerIndex: 1877308, mainnet: true });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ status: "pending" });
   });
 });

--- a/tests/unit/provableSolanaLogVerify.test.ts
+++ b/tests/unit/provableSolanaLogVerify.test.ts
@@ -1,0 +1,167 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { SOLANA_DEVNET_CHAIN_ID, SOLANA_MAINNET_CHAIN_ID } from "@lifi/intent";
+
+// `$env/static/private` is a Vite virtual module with no file behind it, so the real one can
+// never resolve under `bun test`. Stub it before importing the module under test.
+mock.module("$env/static/private", () => ({
+  PRIVATE_POLYMER_MAINNET_ZONE_API_KEY: "mainnet-key",
+  PRIVATE_POLYMER_TESTNET_ZONE_API_KEY: "testnet-key",
+  PRIVATE_ROUTEMESH_API_KEY: "routemesh-key"
+}));
+
+// PRIVATE_SOLANA_RPC_URL is optional, so it is read through `$env/dynamic/private`
+// — the static form would fail the import outright when the key is absent.
+// Left empty here so the public-endpoint fallback is what gets exercised.
+mock.module("$env/dynamic/private", () => ({ env: {} }));
+
+type Verify =
+  typeof import("../../src/lib/libraries/provableSolanaLogVerify").verifyProvableSolanaLog;
+
+let verifyProvableSolanaLog: Verify;
+let POLYMER_SOLANA_PROGRAM_ID: string;
+
+type RpcCall = { url: string; method: string; params: unknown[] };
+
+const calls: RpcCall[] = [];
+let reply: (call: RpcCall) => Response;
+const realFetch = global.fetch;
+
+const SIGNATURE = "5".repeat(87);
+
+beforeAll(async () => {
+  global.fetch = (async (url: string, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body)) as { method: string; params: unknown[] };
+    calls.push({ url: String(url), method: body.method, params: body.params });
+    return reply(calls[calls.length - 1]);
+  }) as unknown as typeof fetch;
+
+  ({ verifyProvableSolanaLog, POLYMER_SOLANA_PROGRAM_ID } = await import(
+    "../../src/lib/libraries/provableSolanaLogVerify"
+  ));
+});
+
+// bun runs every test file in one process, so an unrestored stub would silently serve the next
+// file that happens to use fetch.
+afterAll(() => {
+  global.fetch = realFetch;
+});
+
+beforeEach(() => {
+  calls.length = 0;
+});
+
+/** A getTransaction result carrying the given program logs. */
+function rpcOk(logMessages: string[] | null, result: "present" | "null" = "present") {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: result === "null" ? null : { meta: { logMessages } }
+    }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+}
+
+/** The literal line `oracle_polymer::submit` emits: `Prove: program: {id}, {base64}`. */
+function proveLog(programId: string) {
+  return `Program log: Prove: program: ${programId}, YWJjZA==`;
+}
+
+describe("verifyProvableSolanaLog", () => {
+  it("asks the RPC for the transaction with a version-tolerant getTransaction", async () => {
+    reply = () => rpcOk([proveLog(POLYMER_SOLANA_PROGRAM_ID)]);
+    await verifyProvableSolanaLog(Number(SOLANA_MAINNET_CHAIN_ID), SIGNATURE, "prog");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe("getTransaction");
+    expect(calls[0].params[0]).toBe(SIGNATURE);
+    // Without maxSupportedTransactionVersion the RPC errors on every v0 transaction, which is
+    // most of them — the gate would then be permanently inconclusive.
+    expect(calls[0].params[1]).toMatchObject({ maxSupportedTransactionVersion: 0 });
+  });
+
+  it("matches the Prove log of the pinned program", async () => {
+    reply = () =>
+      rpcOk([
+        "Program LiFiBtfyPT1DnTHTAeZ2rwr5RgMrThwA5kt7KGT5nBV invoke [1]",
+        proveLog(POLYMER_SOLANA_PROGRAM_ID),
+        "Program LiFiBtfyPT1DnTHTAeZ2rwr5RgMrThwA5kt7KGT5nBV success"
+      ]);
+
+    expect(
+      await verifyProvableSolanaLog(
+        Number(SOLANA_MAINNET_CHAIN_ID),
+        SIGNATURE,
+        POLYMER_SOLANA_PROGRAM_ID
+      )
+    ).toBe("match");
+  });
+
+  it("rejects a Prove log emitted by a different program", async () => {
+    // The whole point of carrying the program id into the marker: Polymer keys attestations by
+    // `returnedProgramId`, so another program's Prove log must not pass as ours.
+    reply = () => rpcOk([proveLog("11111111111111111111111111111111")]);
+
+    expect(
+      await verifyProvableSolanaLog(
+        Number(SOLANA_MAINNET_CHAIN_ID),
+        SIGNATURE,
+        POLYMER_SOLANA_PROGRAM_ID
+      )
+    ).toBe("mismatch");
+  });
+
+  it("rejects a transaction with no Prove log at all", async () => {
+    reply = () => rpcOk(["Program log: Instruction: Fill", "Program log: success"]);
+
+    expect(
+      await verifyProvableSolanaLog(
+        Number(SOLANA_MAINNET_CHAIN_ID),
+        SIGNATURE,
+        POLYMER_SOLANA_PROGRAM_ID
+      )
+    ).toBe("mismatch");
+  });
+
+  it.each([
+    ["a null result (not indexed yet)", () => rpcOk(null, "null")],
+    ["missing logMessages", () => rpcOk(null)],
+    [
+      "a JSON-RPC error",
+      () =>
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, error: { message: "boom" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        })
+    ],
+    ["a non-200 response", () => new Response("nope", { status: 503 })],
+    [
+      "a thrown transport error",
+      () => {
+        throw new Error("rpc down");
+      }
+    ]
+  ])("degrades to unknown on %s", async (_label, r) => {
+    // Deliberately fail-open (the route only rejects "mismatch"), so an infra blip does not block
+    // the happy path. Pinned so the trade-off is a decision, not an accident.
+    reply = r as (call: RpcCall) => Response;
+
+    expect(
+      await verifyProvableSolanaLog(
+        Number(SOLANA_MAINNET_CHAIN_ID),
+        SIGNATURE,
+        POLYMER_SOLANA_PROGRAM_ID
+      )
+    ).toBe("unknown");
+  });
+
+  it("picks the public endpoint matching the network when no private RPC is configured", async () => {
+    reply = () => rpcOk([]);
+
+    await verifyProvableSolanaLog(Number(SOLANA_MAINNET_CHAIN_ID), SIGNATURE, "prog");
+    await verifyProvableSolanaLog(Number(SOLANA_DEVNET_CHAIN_ID), SIGNATURE, "prog");
+
+    expect(calls[0].url).toBe("https://api.mainnet-beta.solana.com");
+    expect(calls[1].url).toBe("https://api.devnet.solana.com");
+  });
+});

--- a/tests/unit/recipientField.test.ts
+++ b/tests/unit/recipientField.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { resolveAddress as resolveRecipient } from "../../src/lib/utils/address";
+import {
+  resolveAddress as resolveRecipient,
+  resolveAddressForChainType
+} from "../../src/lib/utils/address";
 
 describe("resolveRecipient", () => {
   it("returns the address for a valid checksummed EVM address", () => {
@@ -46,6 +49,45 @@ describe("outputRecipient in AppCreateIntentOptions", () => {
     const recipient = "not-an-address";
     const outputRecipient = resolveRecipient(recipient);
     expect(outputRecipient).toBeUndefined();
+  });
+});
+
+describe("resolveAddressForChainType", () => {
+  const EVM_ADDR = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+  const TRON_ADDR = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+  // devnet USDC mint — any valid 32-byte base58 key works here
+  const SOLANA_ADDR = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+
+  it("accepts only base58 for a Solana output — a 0x address would be zero-padded into an uncontrolled pubkey", () => {
+    expect(resolveAddressForChainType(SOLANA_ADDR, "solana")).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(resolveAddressForChainType(EVM_ADDR, "solana")).toBeUndefined();
+    expect(resolveAddressForChainType(TRON_ADDR, "solana")).toBeUndefined();
+  });
+
+  it("rejects a 32-byte Solana key for an EVM output — it would be truncated to 20 bytes on payout", () => {
+    expect(resolveAddressForChainType(EVM_ADDR, "evm")).toBe(EVM_ADDR);
+    expect(resolveAddressForChainType(SOLANA_ADDR, "evm")).toBeUndefined();
+  });
+
+  it("accepts a Tron Base58Check address for an EVM output — same 20-byte identity, and a mixed Tron+EVM order needs one recipient valid for both", () => {
+    expect(resolveAddressForChainType(TRON_ADDR, "evm")).toBe(
+      "0xa614f803b6fd780986a42c78ec9c7f77e6ded13c"
+    );
+  });
+
+  it("accepts Base58Check or the raw hex form for a Tron output, never a Solana key", () => {
+    expect(resolveAddressForChainType(TRON_ADDR, "tron")).toBe(
+      "0xa614f803b6fd780986a42c78ec9c7f77e6ded13c"
+    );
+    expect(resolveAddressForChainType(EVM_ADDR, "tron")).toBe(EVM_ADDR);
+    expect(resolveAddressForChainType(SOLANA_ADDR, "tron")).toBeUndefined();
+  });
+
+  it("returns undefined for empty and junk input on every chain type", () => {
+    for (const chainType of ["evm", "tron", "solana"] as const) {
+      expect(resolveAddressForChainType("", chainType)).toBeUndefined();
+      expect(resolveAddressForChainType("alice.eth", chainType)).toBeUndefined();
+    }
   });
 });
 

--- a/tests/unit/reviveOrderBigInts.test.ts
+++ b/tests/unit/reviveOrderBigInts.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import type { MultichainOrder, StandardOrder } from "@lifi/intent";
+import { reviveOrderBigInts } from "../../src/lib/utils/intent";
+
+// Both ingestion paths that motivated the reviver deliver orders as parsed
+// JSON: the local DB round-trip (BigInt.prototype.toJSON → JSON.parse) and the
+// order-server websocket push. In both, every bigint-typed field is a decimal
+// string at runtime.
+const parsedStandard = {
+  user: "0x1111111111111111111111111111111111111111111111111111111111111111",
+  nonce: "42",
+  originChainId: "1151111081099710",
+  expires: 1755600000,
+  fillDeadline: 1755600000,
+  inputOracle: "0x2222222222222222222222222222222222222222222222222222222222222222",
+  inputs: [["123456789", "1496250"]],
+  outputs: [
+    {
+      oracle: "0x3333333333333333333333333333333333333333333333333333333333333333",
+      settler: "0x4444444444444444444444444444444444444444444444444444444444444444",
+      chainId: "8453",
+      token: "0x5555555555555555555555555555555555555555555555555555555555555555",
+      amount: "1496250",
+      recipient: "0x6666666666666666666666666666666666666666666666666666666666666666",
+      callbackData: "0x",
+      context: "0x"
+    }
+  ]
+} as unknown as StandardOrder;
+
+describe("reviveOrderBigInts", () => {
+  test("restores bigints on a JSON round-tripped standard order", () => {
+    const order = reviveOrderBigInts(parsedStandard) as StandardOrder;
+    expect(order.nonce).toBe(42n);
+    expect(order.originChainId).toBe(1151111081099710n);
+    expect(order.inputs[0]).toEqual([123456789n, 1496250n]);
+    expect(order.outputs[0]!.chainId).toBe(8453n);
+    expect(order.outputs[0]!.amount).toBe(1496250n);
+    // Untouched fields survive: number timestamps and hex strings.
+    expect(order.expires).toBe(1755600000);
+    expect(order.outputs[0]!.oracle).toBe(parsedStandard.outputs[0]!.oracle);
+  });
+
+  test("is a no-op on an order that is already bigint-typed", () => {
+    const revived = reviveOrderBigInts(parsedStandard);
+    expect(reviveOrderBigInts(revived)).toEqual(revived);
+  });
+
+  test("restores the nested inputs of a multichain order", () => {
+    const parsedMultichain = {
+      user: parsedStandard.user,
+      nonce: "7",
+      expires: 1755600000,
+      fillDeadline: 1755600000,
+      inputOracle: parsedStandard.inputOracle,
+      inputs: [{ chainId: "8453", inputs: [["1", "2"]] }],
+      outputs: parsedStandard.outputs
+    } as unknown as MultichainOrder;
+    const order = reviveOrderBigInts(parsedMultichain) as MultichainOrder;
+    expect(order.nonce).toBe(7n);
+    expect(order.inputs[0]!.chainId).toBe(8453n);
+    expect(order.inputs[0]!.inputs[0]).toEqual([1n, 2n]);
+    expect(order.outputs[0]!.chainId).toBe(8453n);
+  });
+});

--- a/tests/unit/solanaConfig.test.ts
+++ b/tests/unit/solanaConfig.test.ts
@@ -7,6 +7,8 @@ import {
   SOLANA_POLYMER_ORACLE_PROGRAM
 } from "@lifi/intent";
 import {
+  chainIdList,
+  coinList,
   SOLANA_OUTPUT_SETTLER,
   SOLANA_POLYMER_OUTPUT_ORACLE,
   chainMetaById,
@@ -75,5 +77,41 @@ describe("config (solana)", () => {
       expect(chainMetaById[Number(chainId)]).toBeDefined();
       expect(() => getClient(chainId)).toThrow();
     }
+  });
+});
+
+describe("solana tokens", () => {
+  test("mainnet lists USDC, USDT and wSOL as 32-byte mints", () => {
+    // Decimals and owning program read from mainnet-beta on 2026-08-13; all
+    // three are legacy SPL Token, so the default ATA derivation applies.
+    const solana = coinList(true).filter((t) => t.chainId === Number(SOLANA_MAINNET_CHAIN_ID));
+    expect(solana.map((t) => t.name).sort()).toEqual(["usdc", "usdt", "wsol"]);
+    for (const token of solana) {
+      // 0x + 64 hex: a truncated 20-byte address would match the wrong token.
+      expect(token.address).toHaveLength(66);
+    }
+    expect(solana.find((t) => t.name === "wsol")?.decimals).toBe(9);
+    expect(solana.find((t) => t.name === "usdc")?.decimals).toBe(6);
+  });
+
+  test("devnet lists its own USDC and wSOL", () => {
+    const solana = coinList(false).filter((t) => t.chainId === Number(SOLANA_DEVNET_CHAIN_ID));
+    expect(solana.map((t) => t.name).sort()).toEqual(["usdc", "wsol"]);
+  });
+
+  test("no Solana token is the zero mint", () => {
+    // Native SOL is a valid output but never an input, so it is not listed —
+    // `open` has no native path and would fail at signing time.
+    const all = [...coinList(true), ...coinList(false)].filter((t) =>
+      [Number(SOLANA_MAINNET_CHAIN_ID), Number(SOLANA_DEVNET_CHAIN_ID)].includes(t.chainId)
+    );
+    for (const token of all) expect(BigInt(token.address)).not.toBe(0n);
+  });
+
+  test("chainIdList offers the matching cluster per network", () => {
+    expect(chainIdList(true)).toContain(Number(SOLANA_MAINNET_CHAIN_ID));
+    expect(chainIdList(true)).not.toContain(Number(SOLANA_DEVNET_CHAIN_ID));
+    expect(chainIdList(false)).toContain(Number(SOLANA_DEVNET_CHAIN_ID));
+    expect(chainIdList(false)).not.toContain(Number(SOLANA_MAINNET_CHAIN_ID));
   });
 });

--- a/tests/unit/solanaConfig.test.ts
+++ b/tests/unit/solanaConfig.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SOLANA_DEVNET_CHAIN_ID,
+  SOLANA_MAINNET_CHAIN_ID,
+  SOLANA_OUTPUT_SETTLER_PDA,
+  SOLANA_POLYMER_ORACLE_PDA,
+  SOLANA_POLYMER_ORACLE_PROGRAM
+} from "@lifi/intent";
+import {
+  SOLANA_OUTPUT_SETTLER,
+  SOLANA_POLYMER_OUTPUT_ORACLE,
+  chainMetaById,
+  getChain,
+  getChainName,
+  getClient,
+  getOracle,
+  isChainIdTestnet
+} from "../../src/lib/config";
+
+const SOLANA_IDS = [SOLANA_MAINNET_CHAIN_ID, SOLANA_DEVNET_CHAIN_ID];
+
+describe("config (solana)", () => {
+  test("getChainName no longer throws for solana chains", () => {
+    // Before the ChainMeta registry these read chainNameById, which is derived
+    // from chainMap (viem chains only) and threw — blowing up every screen
+    // that renders a chain name for a Solana order.
+    expect(getChainName(SOLANA_MAINNET_CHAIN_ID)).toBe("solana");
+    expect(getChainName(SOLANA_DEVNET_CHAIN_ID)).toBe("solanaDevnet");
+  });
+
+  test("isChainIdTestnet classifies solana clusters", () => {
+    expect(isChainIdTestnet(SOLANA_MAINNET_CHAIN_ID)).toBe(false);
+    expect(isChainIdTestnet(SOLANA_DEVNET_CHAIN_ID)).toBe(true);
+  });
+
+  test("chainMetaById covers both EVM and solana chains", () => {
+    expect(chainMetaById[1]?.type).toBe("evm");
+    expect(chainMetaById[Number(SOLANA_MAINNET_CHAIN_ID)]?.type).toBe("solana");
+    expect(chainMetaById[728126428]?.type).toBe("tron");
+  });
+
+  test("getChain and getClient still refuse solana, with a chain-type message", () => {
+    // These return viem values with no Solana analogue. The message must name
+    // the chain type so a missing branch is obvious at the call site.
+    for (const chainId of SOLANA_IDS) {
+      expect(() => getChain(chainId)).toThrow(/is a solana chain, not an EVM chain/);
+      expect(() => getClient(chainId)).toThrow(/is a solana chain, not an EVM chain/);
+    }
+  });
+
+  test("getOracle returns the polymer PDA for a solana input chain", () => {
+    for (const chainId of SOLANA_IDS) {
+      expect(getOracle("polymer", chainId)).toBe(SOLANA_POLYMER_ORACLE_PDA);
+    }
+  });
+
+  test("the input oracle and the output oracle are different values", () => {
+    // The single most likely silent failure: an order that fills and can then
+    // never be proven. Input side wants the PDA, output side the program id.
+    expect(SOLANA_POLYMER_OUTPUT_ORACLE).toBe(SOLANA_POLYMER_ORACLE_PROGRAM);
+    expect(SOLANA_POLYMER_OUTPUT_ORACLE).not.toBe(SOLANA_POLYMER_ORACLE_PDA);
+    expect(getOracle("polymer", SOLANA_MAINNET_CHAIN_ID)).not.toBe(SOLANA_POLYMER_OUTPUT_ORACLE);
+  });
+
+  test("the solana output settler is the settler PDA", () => {
+    expect(SOLANA_OUTPUT_SETTLER).toBe(SOLANA_OUTPUT_SETTLER_PDA);
+    expect(SOLANA_OUTPUT_SETTLER).not.toBe(SOLANA_POLYMER_OUTPUT_ORACLE);
+  });
+
+  test("solana chains are absent from the viem chain map", () => {
+    // Keeping them out of chainMap is deliberate: it feeds wagmiChains and
+    // clientsById. A Solana entry would appear in wallet switch-chain menus
+    // and produce a viem client aimed at a Solana RPC.
+    for (const chainId of SOLANA_IDS) {
+      expect(chainMetaById[Number(chainId)]).toBeDefined();
+      expect(() => getClient(chainId)).toThrow();
+    }
+  });
+});

--- a/tests/unit/solanaEncode.test.ts
+++ b/tests/unit/solanaEncode.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "bun:test";
+import { BYTES32_ZERO, FILL_MAGIC, encodeFillDescription, getOutputHash } from "@lifi/intent";
+import type { MandateOutput } from "@lifi/intent";
+import { concat, encodePacked, keccak256, numberToHex, toHex } from "viem";
+import {
+  U64_MAX,
+  assertSolanaAmountFitsU64,
+  commonPayload,
+  fillDescriptionWithoutTimestamp,
+  fillPayloadHash,
+  isNativeSolanaOutput,
+  localAttestationDataHash,
+  solverToFillerData
+} from "../../src/lib/solana/encode";
+
+const b32 = (nibble: string) => `0x${nibble.repeat(64)}` as `0x${string}`;
+
+const SOLVER = b32("5");
+const ORDER_ID = b32("6");
+
+function makeOutput(overrides: Partial<MandateOutput> = {}): MandateOutput {
+  return {
+    oracle: b32("1"),
+    settler: b32("2"),
+    chainId: 1151111081099712n,
+    token: b32("3"),
+    amount: 1_000_000n,
+    recipient: b32("4"),
+    callbackData: "0x",
+    context: "0x",
+    ...overrides
+  } as MandateOutput;
+}
+
+describe("commonPayload", () => {
+  test("matches the Rust encode_common_payload layout byte for byte", () => {
+    // token(32) | amount(32) | recipient(32) | u16be(cbLen) | cb | u16be(ctxLen) | ctx
+    // Built here independently of the implementation so a change to either
+    // side has to be deliberate.
+    const output = makeOutput({ callbackData: "0xdeadbeef", context: "0xc0ffee" });
+    const expected = concat([
+      output.token,
+      numberToHex(output.amount, { size: 32 }),
+      output.recipient,
+      numberToHex(4, { size: 2 }),
+      "0xdeadbeef",
+      numberToHex(3, { size: 2 }),
+      "0xc0ffee"
+    ]);
+    expect(commonPayload(output)).toBe(expected);
+  });
+
+  test("encodes empty callbackData and context as zero lengths", () => {
+    const payload = commonPayload(makeOutput());
+    // 32 + 32 + 32 + 2 + 0 + 2 + 0 = 100 bytes
+    expect((payload.length - 2) / 2).toBe(100);
+    expect(payload.endsWith("00000000")).toBe(true);
+  });
+});
+
+describe("fill descriptions", () => {
+  test("the without-timestamp variant is the with-timestamp one minus 4 bytes", () => {
+    // The only structural difference is the uint32 timestamp at offset 68.
+    const output = makeOutput();
+    const withTs = encodeFillDescription({
+      solver: SOLVER,
+      orderId: ORDER_ID,
+      timestamp: 1_700_000_000,
+      output
+    });
+    const withoutTs = fillDescriptionWithoutTimestamp({
+      solver: SOLVER,
+      orderId: ORDER_ID,
+      output
+    });
+    expect((withTs.length - withoutTs.length) / 2).toBe(4);
+    // Same prefix up to the timestamp slot (4 + 32 + 32 = 68 bytes).
+    expect(withTs.slice(0, 2 + 68 * 2)).toBe(withoutTs.slice(0, 2 + 68 * 2));
+    // And the same tail after it.
+    expect(withTs.slice(2 + 72 * 2)).toBe(withoutTs.slice(2 + 68 * 2));
+  });
+
+  test("the without-timestamp variant leads with FILL_MAGIC", () => {
+    // The magic is what keeps the fill and not-filled proof domains from being
+    // cross-consumed; dropping it was the v0.3.0 bug.
+    const encoded = fillDescriptionWithoutTimestamp({
+      solver: SOLVER,
+      orderId: ORDER_ID,
+      output: makeOutput()
+    });
+    expect(encoded.slice(0, 10)).toBe(FILL_MAGIC);
+  });
+
+  test("matches an independently built Rust-layout encoding", () => {
+    const output = makeOutput();
+    const expected = encodePacked(
+      ["bytes4", "bytes32", "bytes32", "bytes"],
+      [FILL_MAGIC, SOLVER, ORDER_ID, commonPayload(output)]
+    );
+    expect(fillDescriptionWithoutTimestamp({ solver: SOLVER, orderId: ORDER_ID, output })).toBe(
+      expected
+    );
+  });
+
+  test("localAttestationDataHash and fillPayloadHash are different hashes", () => {
+    // Conflating them derives an attestation account that does not exist —
+    // the failure is silent until finalise cannot find its account.
+    const output = makeOutput();
+    const local = localAttestationDataHash({ solver: SOLVER, orderId: ORDER_ID, output });
+    const remote = fillPayloadHash({
+      solver: SOLVER,
+      orderId: ORDER_ID,
+      timestamp: 1_700_000_000,
+      output
+    });
+    expect(local).not.toBe(remote);
+    expect(local).toBe(
+      keccak256(fillDescriptionWithoutTimestamp({ solver: SOLVER, orderId: ORDER_ID, output }))
+    );
+  });
+
+  test("localAttestationDataHash is independent of the timestamp", () => {
+    // This is the whole reason the variant exists: the hash is a PDA seed, so
+    // it must be derivable before the fill lands.
+    const output = makeOutput();
+    const hash = localAttestationDataHash({ solver: SOLVER, orderId: ORDER_ID, output });
+    expect(localAttestationDataHash({ solver: SOLVER, orderId: ORDER_ID, output })).toBe(hash);
+  });
+
+  test("the hashes change with solver, orderId and output", () => {
+    const base = localAttestationDataHash({
+      solver: SOLVER,
+      orderId: ORDER_ID,
+      output: makeOutput()
+    });
+    expect(
+      localAttestationDataHash({ solver: b32("7"), orderId: ORDER_ID, output: makeOutput() })
+    ).not.toBe(base);
+    expect(
+      localAttestationDataHash({ solver: SOLVER, orderId: b32("8"), output: makeOutput() })
+    ).not.toBe(base);
+    expect(
+      localAttestationDataHash({
+        solver: SOLVER,
+        orderId: ORDER_ID,
+        output: makeOutput({ amount: 2n })
+      })
+    ).not.toBe(base);
+  });
+});
+
+describe("getOutputHash as the FillId seed", () => {
+  test("hashes the oracle/settler/chainId prefix followed by the common payload", () => {
+    // The Rust mandate_output_hash is
+    // keccak(oracle | settler | chainId_be32 | commonPayload). Rebuilding it
+    // here proves the library's getOutputHash is the same function, which is
+    // why this module re-exports it instead of defining a second one.
+    const output = makeOutput({ callbackData: "0xbeef", context: "0x" });
+    const expected = keccak256(
+      concat([
+        output.oracle,
+        output.settler,
+        numberToHex(output.chainId, { size: 32 }),
+        commonPayload(output)
+      ])
+    );
+    expect(getOutputHash(output)).toBe(expected);
+  });
+});
+
+describe("solverToFillerData", () => {
+  test("returns the 32 solver bytes", () => {
+    const data = solverToFillerData(SOLVER);
+    expect(data).toHaveLength(32);
+    expect(toHex(data)).toBe(SOLVER);
+  });
+
+  test("rejects the zero pubkey", () => {
+    // resolve_output rejects it on chain; catching it here avoids a signed
+    // transaction that cannot succeed.
+    expect(() => solverToFillerData(BYTES32_ZERO)).toThrow("zero pubkey");
+  });
+
+  test("rejects a 20-byte EVM address", () => {
+    expect(() => solverToFillerData("0x75220B7600c300005038432a0000f308e0000068")).toThrow(
+      "32-byte solver identity"
+    );
+  });
+});
+
+describe("native outputs and u64 bounds", () => {
+  test("isNativeSolanaOutput detects the zero token", () => {
+    expect(isNativeSolanaOutput(makeOutput({ token: BYTES32_ZERO }))).toBe(true);
+    expect(isNativeSolanaOutput(makeOutput())).toBe(false);
+  });
+
+  test("assertSolanaAmountFitsU64 accepts u64 max and rejects one above", () => {
+    expect(() => assertSolanaAmountFitsU64(makeOutput({ amount: U64_MAX }))).not.toThrow();
+    expect(() => assertSolanaAmountFitsU64(makeOutput({ amount: U64_MAX + 1n }))).toThrow(
+      "exceeds u64"
+    );
+  });
+});

--- a/tests/unit/solanaEvents.test.ts
+++ b/tests/unit/solanaEvents.test.ts
@@ -128,6 +128,29 @@ describe("decodeOutputFilledEvent", () => {
     expect(decoded.finalAmount).toBe(1_000_000n);
   });
 
+  test("decodes a timestamp with bit 31 set as unsigned (post-2038)", () => {
+    // `|` re-coerces to signed int32; a decoder that lets that through hands
+    // back a negative timestamp and the fill becomes unprovable.
+    const decoded = decodeOutputFilledEvent(
+      toBytes(
+        `0x${Buffer.from(encodeOutputFilledEvent({ timestamp: 0x80000000 }), "base64").toString("hex")}`
+      )
+    );
+    expect(decoded.timestamp).toBe(2_147_483_648);
+  });
+
+  test("rejects a high-bit vec length instead of reading backwards", () => {
+    const base = new Uint8Array(Buffer.from(encodeOutputFilledEvent({}), "base64"));
+    // callbackData's u32 length sits after discriminator (8) + settler/orderId/
+    // solver (3*32) + timestamp (4) + the six 32-byte output fields.
+    const lengthOffset = 8 + 3 * 32 + 4 + 6 * 32;
+    base.set([0xff, 0xff, 0xff, 0xff], lengthOffset);
+    // A signed decode would make this length -1: take(-1) passes the
+    // upper-bound check, returns an empty slice, and moves the offset
+    // BACKWARDS. It must fail as an out-of-bounds read instead.
+    expect(() => decodeOutputFilledEvent(base)).toThrow("Truncated");
+  });
+
   test("rejects a payload with trailing bytes", () => {
     // A prefix parse that "works" is how a layout drift goes unnoticed.
     const base = Buffer.from(encodeOutputFilledEvent({}), "base64");

--- a/tests/unit/solanaEvents.test.ts
+++ b/tests/unit/solanaEvents.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, test } from "bun:test";
+import type { MandateOutput } from "@lifi/intent";
+import { concat, hexToBytes, numberToHex, sha256, stringToBytes, toBytes } from "viem";
+import {
+  FINALISED_DISCRIMINATOR,
+  OPEN_DISCRIMINATOR,
+  OUTPUT_FILLED_DISCRIMINATOR,
+  OUTPUT_NOT_FILLED_DISCRIMINATOR,
+  OUTPUT_PROVEN_DISCRIMINATOR,
+  decodeOutputFilledEvent,
+  findOutputFilledLog,
+  findProveLogs,
+  programDataLogs
+} from "../../src/lib/solana/events";
+
+const SETTLER_PROGRAM = "LiFiEDFjz5x1jJe9gSXNDHQW4dWt4yLXdp2VN4EiQUt";
+const POLYMER_PROGRAM = "LiFiBtfyPT1DnTHTAeZ2rwr5RgMrThwA5kt7KGT5nBV";
+const OTHER_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+
+const b32 = (nibble: string) => `0x${nibble.repeat(64)}` as `0x${string}`;
+
+const ORDER_ID = b32("6");
+const SOLVER = b32("5");
+
+function makeOutput(overrides: Partial<MandateOutput> = {}): MandateOutput {
+  return {
+    oracle: b32("1"),
+    settler: b32("2"),
+    chainId: 1151111081099712n,
+    token: b32("3"),
+    amount: 1_000_000n,
+    recipient: b32("4"),
+    callbackData: "0x",
+    context: "0x",
+    ...overrides
+  } as MandateOutput;
+}
+
+function u32le(value: number): Uint8Array {
+  return new Uint8Array([
+    value & 0xff,
+    (value >> 8) & 0xff,
+    (value >> 16) & 0xff,
+    (value >> 24) & 0xff
+  ]);
+}
+
+function u64le(value: bigint): Uint8Array {
+  const out = new Uint8Array(8);
+  let v = value;
+  for (let i = 0; i < 8; i++) {
+    out[i] = Number(v & 0xffn);
+    v >>= 8n;
+  }
+  return out;
+}
+
+/** Builds the exact bytes the on-chain `emit!(OutputFilledEvent{..})` produces. */
+function encodeOutputFilledEvent(args: {
+  settler?: `0x${string}`;
+  orderId?: `0x${string}`;
+  solver?: `0x${string}`;
+  timestamp?: number;
+  output?: MandateOutput;
+  finalAmount?: bigint;
+}): string {
+  const output = args.output ?? makeOutput();
+  const callbackData = toBytes(output.callbackData);
+  const context = toBytes(output.context);
+  const bytes = concat([
+    OUTPUT_FILLED_DISCRIMINATOR,
+    hexToBytes(args.settler ?? b32("2")),
+    hexToBytes(args.orderId ?? ORDER_ID),
+    hexToBytes(args.solver ?? SOLVER),
+    u32le(args.timestamp ?? 1_700_000_000),
+    hexToBytes(output.oracle),
+    hexToBytes(output.settler),
+    hexToBytes(numberToHex(output.chainId, { size: 32 })),
+    hexToBytes(output.token),
+    hexToBytes(numberToHex(output.amount, { size: 32 })),
+    hexToBytes(output.recipient),
+    u32le(callbackData.length),
+    callbackData,
+    u32le(context.length),
+    context,
+    u64le(args.finalAmount ?? 1_000_000n)
+  ]);
+  return Buffer.from(bytes).toString("base64");
+}
+
+function fillLogs(payloadBase64: string, programId = SETTLER_PROGRAM): string[] {
+  return [
+    `Program ${programId} invoke [1]`,
+    `Program data: ${payloadBase64}`,
+    `Program ${programId} success`
+  ];
+}
+
+describe("event discriminators", () => {
+  test.each([
+    ["OutputFilledEvent", OUTPUT_FILLED_DISCRIMINATOR],
+    ["OutputNotFilledEvent", OUTPUT_NOT_FILLED_DISCRIMINATOR],
+    ["OpenEvent", OPEN_DISCRIMINATOR],
+    ["FinalisedEvent", FINALISED_DISCRIMINATOR],
+    ["OutputProvenEvent", OUTPUT_PROVEN_DISCRIMINATOR]
+  ])("%s equals sha256('event:<Name>')[..8]", (name, discriminator) => {
+    // These events are absent from the generated IDLs, so nothing else pins
+    // them. If Anchor's scheme or an event name ever changes, this fails
+    // rather than the decoder silently matching nothing.
+    const expected = hexToBytes(sha256(stringToBytes(`event:${name}`))).slice(0, 8);
+    expect(Array.from(discriminator)).toEqual(Array.from(expected));
+  });
+});
+
+describe("decodeOutputFilledEvent", () => {
+  test("round-trips a full event including callbackData and context", () => {
+    const output = makeOutput({ callbackData: "0xdeadbeef", context: "0xc0ffee" });
+    const decoded = decodeOutputFilledEvent(
+      toBytes(`0x${Buffer.from(encodeOutputFilledEvent({ output }), "base64").toString("hex")}`)
+    );
+    expect(decoded.orderId).toBe(ORDER_ID);
+    expect(decoded.solver).toBe(SOLVER);
+    expect(decoded.timestamp).toBe(1_700_000_000);
+    expect(decoded.output.callbackData).toBe("0xdeadbeef");
+    expect(decoded.output.context).toBe("0xc0ffee");
+    expect(decoded.output.chainId).toBe(output.chainId);
+    expect(decoded.output.amount).toBe(output.amount);
+    expect(decoded.finalAmount).toBe(1_000_000n);
+  });
+
+  test("rejects a payload with trailing bytes", () => {
+    // A prefix parse that "works" is how a layout drift goes unnoticed.
+    const base = Buffer.from(encodeOutputFilledEvent({}), "base64");
+    const padded = new Uint8Array(base.length + 3);
+    padded.set(base);
+    expect(() => decodeOutputFilledEvent(padded)).toThrow("trailing bytes");
+  });
+
+  test("rejects a truncated payload", () => {
+    const base = Buffer.from(encodeOutputFilledEvent({}), "base64");
+    expect(() => decodeOutputFilledEvent(base.subarray(0, base.length - 4))).toThrow("Truncated");
+  });
+});
+
+describe("programDataLogs frame attribution", () => {
+  test("ignores a Program data line printed by another program", () => {
+    const payload = encodeOutputFilledEvent({});
+    const logs = [
+      `Program ${OTHER_PROGRAM} invoke [1]`,
+      `Program data: ${payload}`,
+      `Program ${OTHER_PROGRAM} success`
+    ];
+    expect(programDataLogs(logs, SETTLER_PROGRAM)).toHaveLength(0);
+  });
+
+  test("attributes a line inside a CPI to the inner program, not the outer", () => {
+    const payload = encodeOutputFilledEvent({});
+    const logs = [
+      `Program ${SETTLER_PROGRAM} invoke [1]`,
+      `Program ${OTHER_PROGRAM} invoke [2]`,
+      `Program data: ${payload}`,
+      `Program ${OTHER_PROGRAM} success`,
+      `Program ${SETTLER_PROGRAM} success`
+    ];
+    expect(programDataLogs(logs, SETTLER_PROGRAM)).toHaveLength(0);
+    expect(programDataLogs(logs, OTHER_PROGRAM)).toHaveLength(1);
+  });
+
+  test("collects lines emitted after an inner CPI returns", () => {
+    const payload = encodeOutputFilledEvent({});
+    const logs = [
+      `Program ${SETTLER_PROGRAM} invoke [1]`,
+      `Program ${OTHER_PROGRAM} invoke [2]`,
+      `Program ${OTHER_PROGRAM} success`,
+      `Program data: ${payload}`,
+      `Program ${SETTLER_PROGRAM} success`
+    ];
+    expect(programDataLogs(logs, SETTLER_PROGRAM)).toHaveLength(1);
+  });
+});
+
+describe("findOutputFilledLog", () => {
+  const output = makeOutput();
+
+  test("finds the matching event", () => {
+    const decoded = findOutputFilledLog(fillLogs(encodeOutputFilledEvent({ output })), {
+      programId: SETTLER_PROGRAM,
+      orderId: ORDER_ID,
+      output
+    });
+    expect(decoded.solver).toBe(SOLVER);
+    expect(decoded.timestamp).toBe(1_700_000_000);
+  });
+
+  test("rejects an event spoofed by an unrelated program", () => {
+    // The anti-spoof: the payload is byte-identical and would decode fine, but
+    // it was not printed inside the settler's frame.
+    const logs = [
+      `Program ${OTHER_PROGRAM} invoke [1]`,
+      `Program data: ${encodeOutputFilledEvent({ output })}`,
+      `Program ${OTHER_PROGRAM} success`
+    ];
+    expect(() =>
+      findOutputFilledLog(logs, { programId: SETTLER_PROGRAM, orderId: ORDER_ID, output })
+    ).toThrow("No matching OutputFilled event");
+  });
+
+  test("rejects a different orderId", () => {
+    const logs = fillLogs(encodeOutputFilledEvent({ orderId: b32("9"), output }));
+    expect(() =>
+      findOutputFilledLog(logs, { programId: SETTLER_PROGRAM, orderId: ORDER_ID, output })
+    ).toThrow("No matching OutputFilled event");
+  });
+
+  test("rejects a different output", () => {
+    const logs = fillLogs(encodeOutputFilledEvent({ output }));
+    expect(() =>
+      findOutputFilledLog(logs, {
+        programId: SETTLER_PROGRAM,
+        orderId: ORDER_ID,
+        output: makeOutput({ amount: 999n })
+      })
+    ).toThrow("No matching OutputFilled event");
+  });
+
+  test("throws on two events matching the same order and output", () => {
+    // Never silently pick the first: both cannot be the fill being settled.
+    const payload = encodeOutputFilledEvent({ output });
+    const logs = [
+      `Program ${SETTLER_PROGRAM} invoke [1]`,
+      `Program data: ${payload}`,
+      `Program data: ${payload}`,
+      `Program ${SETTLER_PROGRAM} success`
+    ];
+    expect(() =>
+      findOutputFilledLog(logs, { programId: SETTLER_PROGRAM, orderId: ORDER_ID, output })
+    ).toThrow("Ambiguous fill");
+  });
+
+  test("throws on a zero solver", () => {
+    const logs = fillLogs(
+      encodeOutputFilledEvent({ solver: `0x${"00".repeat(32)}` as `0x${string}`, output })
+    );
+    expect(() =>
+      findOutputFilledLog(logs, { programId: SETTLER_PROGRAM, orderId: ORDER_ID, output })
+    ).toThrow("zero solver");
+  });
+
+  test("skips an undecodable payload instead of aborting the scan", () => {
+    // A malformed line must not hide a valid event later in the same tx.
+    const logs = [
+      `Program ${SETTLER_PROGRAM} invoke [1]`,
+      `Program data: ${Buffer.from(OUTPUT_FILLED_DISCRIMINATOR).toString("base64")}`,
+      `Program data: ${encodeOutputFilledEvent({ output })}`,
+      `Program ${SETTLER_PROGRAM} success`
+    ];
+    expect(
+      findOutputFilledLog(logs, { programId: SETTLER_PROGRAM, orderId: ORDER_ID, output }).solver
+    ).toBe(SOLVER);
+  });
+
+  test("ignores non-OutputFilled events in the same frame", () => {
+    const logs = [
+      `Program ${SETTLER_PROGRAM} invoke [1]`,
+      `Program data: ${Buffer.from(OPEN_DISCRIMINATOR).toString("base64")}`,
+      `Program data: ${encodeOutputFilledEvent({ output })}`,
+      `Program ${SETTLER_PROGRAM} success`
+    ];
+    expect(
+      findOutputFilledLog(logs, { programId: SETTLER_PROGRAM, orderId: ORDER_ID, output }).timestamp
+    ).toBe(1_700_000_000);
+  });
+});
+
+describe("findProveLogs", () => {
+  test("matches the msg! line oracle_polymer::submit emits", () => {
+    const logs = [
+      `Program ${POLYMER_PROGRAM} invoke [1]`,
+      `Program log: Prove: program: ${POLYMER_PROGRAM}, AAAA`,
+      `Program ${POLYMER_PROGRAM} success`
+    ];
+    expect(findProveLogs(logs, POLYMER_PROGRAM)).toHaveLength(1);
+  });
+
+  test("ignores a Prove line naming a different program", () => {
+    const logs = [`Program log: Prove: program: ${OTHER_PROGRAM}, AAAA`];
+    expect(findProveLogs(logs, POLYMER_PROGRAM)).toHaveLength(0);
+  });
+});

--- a/tests/unit/solanaPda.test.ts
+++ b/tests/unit/solanaPda.test.ts
@@ -110,6 +110,16 @@ describe("encoding helpers", () => {
     expect(u128ToLeBytes(0n)).toEqual(new Uint8Array(16));
   });
 
+  test("u128ToLeBytes accepts the decimal strings a DB round-trip produces", () => {
+    // Containers rehydrated with a plain JSON.parse carry chain ids as decimal
+    // strings despite the bigint type; the unguarded version threw "Cannot mix
+    // BigInt and other types" from every attestationPda derivation.
+    expect(u128ToLeBytes("1151111081099710" as unknown as bigint)).toEqual(
+      u128ToLeBytes(1151111081099710n)
+    );
+    expect(() => u128ToLeBytes("not a number" as unknown as bigint)).toThrow();
+  });
+
   test("pubkeyToBytes32 and bytes32ToPubkey round-trip", () => {
     const pda = polymerOraclePda();
     expect(bytes32ToPubkey(pubkeyToBytes32(pda)).toBase58()).toBe(pda.toBase58());

--- a/tests/unit/solanaPda.test.ts
+++ b/tests/unit/solanaPda.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SOLANA_CHAIN_ID_PDA,
+  SOLANA_INPUT_SETTLER_ESCROW_PDA,
+  SOLANA_OUTPUT_SETTLER_PDA,
+  SOLANA_POLYMER_ORACLE_PDA
+} from "@lifi/intent";
+import {
+  INPUT_SETTLER_ESCROW_PROGRAM_ID,
+  INTENTS_PROTOCOL_PROGRAM_ID,
+  OUTPUT_SETTLER_SIMPLE_PROGRAM_ID,
+  POLYMER_PROGRAM_ID
+} from "../../src/lib/idl";
+import {
+  bytes32ToPubkey,
+  chainIdPda,
+  consumedOrderPda,
+  fillIdPda,
+  inputSettlerEscrowPda,
+  outputSettlerSimplePda,
+  polymerOraclePda,
+  orderContextPda,
+  pubkeyToBytes32,
+  u128ToLeBytes
+} from "../../src/lib/solana/pda";
+
+const ORDER_ID = `0x${"11".repeat(32)}` as const;
+const OUTPUT_HASH = `0x${"22".repeat(32)}` as const;
+
+describe("solana program ids", () => {
+  test("come from the IDLs' top-level address field", () => {
+    // Anchor >= 0.30 moved the program id out of `metadata`. Reading
+    // `metadata.address` yields undefined and silently derives every PDA under
+    // a garbage program id, so pin the values here.
+    expect(INTENTS_PROTOCOL_PROGRAM_ID).toBe("LiFixdGLT5CMdLsHBvaijTXpPy4Uux9Y53SXkuR4HaK");
+    expect(INPUT_SETTLER_ESCROW_PROGRAM_ID).toBe("LiFiRp8RM7nJUZyUYC9FPPpDr7sAy5XPfBN6ABzBgT7");
+    expect(OUTPUT_SETTLER_SIMPLE_PROGRAM_ID).toBe("LiFiEDFjz5x1jJe9gSXNDHQW4dWt4yLXdp2VN4EiQUt");
+    expect(POLYMER_PROGRAM_ID).toBe("LiFiBtfyPT1DnTHTAeZ2rwr5RgMrThwA5kt7KGT5nBV");
+  });
+});
+
+describe("static PDAs", () => {
+  // Golden vectors: these four accounts are initialised on chain, so a change
+  // here means the app would read and write the wrong accounts entirely.
+  test.each([
+    ["chain_id", chainIdPda(), "BkEw3WHFvJR9a5deUcwPLJ79yK3r9YGdQ61TehFXzAQ", SOLANA_CHAIN_ID_PDA],
+    [
+      "input_settler_escrow",
+      inputSettlerEscrowPda(),
+      "Cj3mSoPJtgi5bubC9rLz8oM1DuXoJj97RMw1uC6ev9zm",
+      SOLANA_INPUT_SETTLER_ESCROW_PDA
+    ],
+    [
+      "output_settler_simple",
+      outputSettlerSimplePda(),
+      "DHShHmVkTwCzUzAQbCu4GDqJmursuDscNR6o4hTBgeRy",
+      SOLANA_OUTPUT_SETTLER_PDA
+    ],
+    [
+      "polymer",
+      polymerOraclePda(),
+      "49zLKETMq34CUC2E2wL1xvv6uN2AUgyhjVX221mjE3Rw",
+      SOLANA_POLYMER_ORACLE_PDA
+    ]
+  ])("%s derives to the deployed account", (_seed, pda, base58, bytes32) => {
+    expect(pda.toBase58()).toBe(base58);
+    // The app-side derivation and the library constant must agree; they are
+    // independent code paths that both feed order construction.
+    expect(pubkeyToBytes32(pda)).toBe(bytes32);
+  });
+});
+
+describe("order-scoped PDAs", () => {
+  test("order_context and consumed_order are distinct for the same order", () => {
+    // Different seed prefixes, same order id — conflating them would make
+    // `open` collide with its own replay guard.
+    expect(orderContextPda(ORDER_ID).toBase58()).not.toBe(consumedOrderPda(ORDER_ID).toBase58());
+  });
+
+  test("order-scoped PDAs vary with the order id", () => {
+    const other = `0x${"33".repeat(32)}` as const;
+    expect(orderContextPda(ORDER_ID).toBase58()).not.toBe(orderContextPda(other).toBase58());
+    expect(consumedOrderPda(ORDER_ID).toBase58()).not.toBe(consumedOrderPda(other).toBase58());
+  });
+
+  test("fill_id varies with both of its seeds", () => {
+    // fill_id = [orderId, mandateOutputHash] with NO string prefix.
+    const base = fillIdPda(ORDER_ID, OUTPUT_HASH).toBase58();
+    expect(fillIdPda(`0x${"33".repeat(32)}`, OUTPUT_HASH).toBase58()).not.toBe(base);
+    expect(fillIdPda(ORDER_ID, `0x${"44".repeat(32)}`).toBase58()).not.toBe(base);
+  });
+
+  test("fill_id is not order_context under a different prefix", () => {
+    expect(fillIdPda(ORDER_ID, OUTPUT_HASH).toBase58()).not.toBe(
+      orderContextPda(ORDER_ID).toBase58()
+    );
+  });
+});
+
+describe("encoding helpers", () => {
+  test("u128ToLeBytes is 16 bytes, little-endian", () => {
+    // The attestation seed uses chain_id as u128 LE; big-endian here would
+    // derive an attestation account that never exists.
+    expect(u128ToLeBytes(1n)).toEqual(
+      new Uint8Array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    );
+    expect(u128ToLeBytes(1151111081099710n)).toHaveLength(16);
+    expect(u128ToLeBytes(0n)).toEqual(new Uint8Array(16));
+  });
+
+  test("pubkeyToBytes32 and bytes32ToPubkey round-trip", () => {
+    const pda = polymerOraclePda();
+    expect(bytes32ToPubkey(pubkeyToBytes32(pda)).toBase58()).toBe(pda.toBase58());
+  });
+});

--- a/tests/unit/solanaPda.test.ts
+++ b/tests/unit/solanaPda.test.ts
@@ -12,6 +12,7 @@ import {
   POLYMER_PROGRAM_ID
 } from "../../src/lib/idl";
 import {
+  POLYMER_PROVER_PROGRAM_ID,
   bytes32ToPubkey,
   chainIdPda,
   consumedOrderPda,
@@ -20,6 +21,7 @@ import {
   outputSettlerSimplePda,
   polymerOraclePda,
   orderContextPda,
+  polymerScratchPdas,
   pubkeyToBytes32,
   u128ToLeBytes
 } from "../../src/lib/solana/pda";
@@ -111,5 +113,32 @@ describe("encoding helpers", () => {
   test("pubkeyToBytes32 and bytes32ToPubkey round-trip", () => {
     const pda = polymerOraclePda();
     expect(bytes32ToPubkey(pubkeyToBytes32(pda)).toBase58()).toBe(pda.toBase58());
+  });
+});
+
+describe("polymer prover", () => {
+  test("pins the program id read from both clusters", () => {
+    // Read from OraclePolymer.polymer_prover_id on mainnet AND devnet
+    // (identical). readPolymerProverId re-checks this against the account, so
+    // a rotation on Polymer's side fails loudly instead of as a CPI error.
+    expect(POLYMER_PROVER_PROGRAM_ID).toBe("CdvSq48QUukYuMczgZAVNZrwcHNshBdtqrjW26sQiGPs");
+  });
+
+  test("derives the singleton internal PDA that exists on chain", () => {
+    // This exact address exists on mainnet and devnet owned by the prover
+    // program — which is what confirms the seed scheme for cache/result too,
+    // since those are per-authority and only exist mid-proof.
+    const { internal } = polymerScratchPdas("BkEw3WHFvJR9a5deUcwPLJ79yK3r9YGdQ61TehFXzAQ");
+    expect(internal).toBe("4w6Lac3Yc8ZdJ7H4Nt9FS98VMt8w6DwkGRJL1h4Ww5z1");
+  });
+
+  test("cache and result are per-authority, internal is not", () => {
+    // Two solvers proving at once must not share scratch accounts.
+    const a = polymerScratchPdas("BkEw3WHFvJR9a5deUcwPLJ79yK3r9YGdQ61TehFXzAQ");
+    const b = polymerScratchPdas("49zLKETMq34CUC2E2wL1xvv6uN2AUgyhjVX221mjE3Rw");
+    expect(a.cache).not.toBe(b.cache);
+    expect(a.result).not.toBe(b.result);
+    expect(a.internal).toBe(b.internal);
+    expect(a.cache).not.toBe(a.result);
   });
 });

--- a/tests/unit/solanaReads.test.ts
+++ b/tests/unit/solanaReads.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "bun:test";
+import { getOutputHash } from "@lifi/intent";
+import type { MandateOutput } from "@lifi/intent";
+import {
+  INPUT_SETTLER_ESCROW_PROGRAM_ID,
+  INTENTS_PROTOCOL_PROGRAM_ID,
+  OUTPUT_SETTLER_SIMPLE_PROGRAM_ID
+} from "../../src/lib/idl";
+import { localAttestationDataHash } from "../../src/lib/solana/encode";
+import {
+  attestationPda,
+  bytes32ToPubkey,
+  consumedOrderPda,
+  fillIdPda,
+  localAttestationPda,
+  orderContextPda,
+  outputSettlerSimplePda
+} from "../../src/lib/solana/pda";
+import {
+  readIsLocallyAttested,
+  readIsOrderFinalised,
+  readIsOrderOpen,
+  readIsOutputFilled,
+  readIsProvenOnSolana,
+  readSplBalance
+} from "../../src/lib/solana/reads";
+import type { SolanaAccountInfoLike, SolanaConnectionLike } from "../../src/lib/solana/types";
+
+const b32 = (nibble: string) => `0x${nibble.repeat(64)}` as `0x${string}`;
+const ORDER_ID = b32("6");
+const SOLVER = b32("5");
+
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+
+function makeOutput(overrides: Partial<MandateOutput> = {}): MandateOutput {
+  return {
+    oracle: b32("1"),
+    settler: b32("2"),
+    chainId: 1151111081099712n,
+    token: b32("3"),
+    amount: 1_000_000n,
+    recipient: b32("4"),
+    callbackData: "0x",
+    context: "0x",
+    ...overrides
+  } as MandateOutput;
+}
+
+/**
+ * A connection whose accounts are whatever the test says they are. Built by
+ * hand against SolanaConnectionLike — no @solana/web3.js in the test process,
+ * which is the point of the DI seam.
+ */
+function makeReads(accounts: Record<string, { owner: string }> = {}) {
+  const requested: string[] = [];
+  const reads: SolanaConnectionLike = {
+    rpcEndpoint: "https://test.invalid",
+    getGenesisHash: async () => "genesis",
+    getAccountInfo: async (address) => {
+      requested.push(address);
+      const account = accounts[address];
+      return account
+        ? ({ owner: account.owner, lamports: 1, data: new Uint8Array() } as SolanaAccountInfoLike)
+        : null;
+    },
+    getMultipleAccountsInfo: async (addresses) => {
+      requested.push(...addresses);
+      return addresses.map((address) => {
+        const account = accounts[address];
+        return account
+          ? ({ owner: account.owner, lamports: 1, data: new Uint8Array() } as SolanaAccountInfoLike)
+          : null;
+      });
+    },
+    getTransaction: async () => null,
+    getBalance: async () => 0n,
+    getTokenAccountBalance: async () => 0n,
+    getLatestBlockhash: async () => ({ blockhash: "hash", lastValidBlockHeight: 1 })
+  };
+  return { reads, requested };
+}
+
+describe("readIsOutputFilled", () => {
+  const output = makeOutput();
+  const fillId = fillIdPda(ORDER_ID, getOutputHash(output)).toBase58();
+
+  test("true when the FillId account is owned by the output settler", () => {
+    const { reads } = makeReads({ [fillId]: { owner: OUTPUT_SETTLER_SIMPLE_PROGRAM_ID } });
+    return expect(readIsOutputFilled(reads, { orderId: ORDER_ID, output })).resolves.toBe(true);
+  });
+
+  test("false when the account is absent", () => {
+    const { reads } = makeReads();
+    return expect(readIsOutputFilled(reads, { orderId: ORDER_ID, output })).resolves.toBe(false);
+  });
+
+  test("false when the account exists but is not owned by the settler", async () => {
+    // Anyone can create a system-owned account at a known PDA address by
+    // sending it rent. Without the owner check that would read as a fill.
+    const { reads } = makeReads({ [fillId]: { owner: SYSTEM_PROGRAM } });
+    expect(await readIsOutputFilled(reads, { orderId: ORDER_ID, output })).toBe(false);
+  });
+
+  test("queries the FillId PDA for the given order and output", async () => {
+    const { reads, requested } = makeReads();
+    await readIsOutputFilled(reads, { orderId: ORDER_ID, output });
+    expect(requested).toEqual([fillId]);
+  });
+});
+
+describe("readIsLocallyAttested", () => {
+  const output = makeOutput();
+  const dataHash = localAttestationDataHash({ solver: SOLVER, orderId: ORDER_ID, output });
+  const pda = localAttestationPda(outputSettlerSimplePda(), output.oracle, dataHash).toBase58();
+
+  test("true when the protocol owns the LocalAttestation account", async () => {
+    const { reads } = makeReads({ [pda]: { owner: INTENTS_PROTOCOL_PROGRAM_ID } });
+    expect(await readIsLocallyAttested(reads, { orderId: ORDER_ID, output, solver: SOLVER })).toBe(
+      true
+    );
+  });
+
+  test("false for a different solver", async () => {
+    // The solver is inside the data hash, so a different one derives a
+    // different account entirely.
+    const { reads } = makeReads({ [pda]: { owner: INTENTS_PROTOCOL_PROGRAM_ID } });
+    expect(
+      await readIsLocallyAttested(reads, { orderId: ORDER_ID, output, solver: b32("7") })
+    ).toBe(false);
+  });
+});
+
+describe("readIsProvenOnSolana", () => {
+  const output = makeOutput();
+  const inputOracle = b32("8");
+  const payloadHash = b32("9");
+  const pda = attestationPda(
+    bytes32ToPubkey(inputOracle),
+    output.chainId,
+    output.oracle,
+    output.settler,
+    payloadHash
+  ).toBase58();
+
+  test("true when the attestation account exists", async () => {
+    const { reads } = makeReads({ [pda]: { owner: INTENTS_PROTOCOL_PROGRAM_ID } });
+    expect(await readIsProvenOnSolana(reads, { inputOracle, output, payloadHash })).toBe(true);
+  });
+
+  test("false when the payload hash differs", async () => {
+    const { reads } = makeReads({ [pda]: { owner: INTENTS_PROTOCOL_PROGRAM_ID } });
+    expect(await readIsProvenOnSolana(reads, { inputOracle, output, payloadHash: b32("a") })).toBe(
+      false
+    );
+  });
+});
+
+describe("order lifecycle", () => {
+  const context = orderContextPda(ORDER_ID).toBase58();
+  const consumed = consumedOrderPda(ORDER_ID).toBase58();
+  const owner = INPUT_SETTLER_ESCROW_PROGRAM_ID;
+
+  test("open while the order context exists", async () => {
+    const { reads } = makeReads({ [context]: { owner }, [consumed]: { owner } });
+    expect(await readIsOrderOpen(reads, ORDER_ID)).toBe(true);
+    expect(await readIsOrderFinalised(reads, ORDER_ID)).toBe(false);
+  });
+
+  test("terminal once the context is closed but consumed_order remains", async () => {
+    // finalise and refund both close order_context; consumed_order is never
+    // closed, so this pair is the only signal that the order ran to an end.
+    const { reads } = makeReads({ [consumed]: { owner } });
+    expect(await readIsOrderOpen(reads, ORDER_ID)).toBe(false);
+    expect(await readIsOrderFinalised(reads, ORDER_ID)).toBe(true);
+  });
+
+  test("not finalised when the order was never opened", async () => {
+    // Both accounts absent means "unknown order", not "already settled" —
+    // otherwise a typo'd order id would render as complete.
+    const { reads } = makeReads();
+    expect(await readIsOrderFinalised(reads, ORDER_ID)).toBe(false);
+  });
+});
+
+describe("readSplBalance", () => {
+  test("returns zero when the associated token account does not exist", async () => {
+    // An unfunded ATA is a zero balance, not a failure.
+    const { reads } = makeReads();
+    expect(
+      await readSplBalance(reads, { mintBytes32: b32("3"), ownerBase58: SYSTEM_PROGRAM })
+    ).toBe(0n);
+  });
+});

--- a/tests/unit/solanaReads.test.ts
+++ b/tests/unit/solanaReads.test.ts
@@ -8,15 +8,18 @@ import {
 } from "../../src/lib/idl";
 import { localAttestationDataHash } from "../../src/lib/solana/encode";
 import {
+  POLYMER_PROVER_PROGRAM_ID,
   attestationPda,
   bytes32ToPubkey,
   consumedOrderPda,
   fillIdPda,
   localAttestationPda,
   orderContextPda,
-  outputSettlerSimplePda
+  outputSettlerSimplePda,
+  polymerOraclePda
 } from "../../src/lib/solana/pda";
 import {
+  readPolymerProverId,
   readIsLocallyAttested,
   readIsOrderFinalised,
   readIsOrderOpen,
@@ -25,6 +28,7 @@ import {
   readSplBalance
 } from "../../src/lib/solana/reads";
 import type { SolanaAccountInfoLike, SolanaConnectionLike } from "../../src/lib/solana/types";
+import { PublicKey } from "@solana/web3.js";
 
 const b32 = (nibble: string) => `0x${nibble.repeat(64)}` as `0x${string}`;
 const ORDER_ID = b32("6");
@@ -51,7 +55,7 @@ function makeOutput(overrides: Partial<MandateOutput> = {}): MandateOutput {
  * hand against SolanaConnectionLike — no @solana/web3.js in the test process,
  * which is the point of the DI seam.
  */
-function makeReads(accounts: Record<string, { owner: string }> = {}) {
+function makeReads(accounts: Record<string, { owner: string; data?: Uint8Array }> = {}) {
   const requested: string[] = [];
   const reads: SolanaConnectionLike = {
     rpcEndpoint: "https://test.invalid",
@@ -60,7 +64,11 @@ function makeReads(accounts: Record<string, { owner: string }> = {}) {
       requested.push(address);
       const account = accounts[address];
       return account
-        ? ({ owner: account.owner, lamports: 1, data: new Uint8Array() } as SolanaAccountInfoLike)
+        ? ({
+            owner: account.owner,
+            lamports: 1,
+            data: account.data ?? new Uint8Array()
+          } as SolanaAccountInfoLike)
         : null;
     },
     getMultipleAccountsInfo: async (addresses) => {
@@ -68,7 +76,11 @@ function makeReads(accounts: Record<string, { owner: string }> = {}) {
       return addresses.map((address) => {
         const account = accounts[address];
         return account
-          ? ({ owner: account.owner, lamports: 1, data: new Uint8Array() } as SolanaAccountInfoLike)
+          ? ({
+              owner: account.owner,
+              lamports: 1,
+              data: account.data ?? new Uint8Array()
+            } as SolanaAccountInfoLike)
           : null;
       });
     },
@@ -189,5 +201,46 @@ describe("readSplBalance", () => {
     expect(
       await readSplBalance(reads, { mintBytes32: b32("3"), ownerBase58: SYSTEM_PROGRAM })
     ).toBe(0n);
+  });
+});
+
+describe("readPolymerProverId", () => {
+  const oracle = polymerOraclePda().toBase58();
+
+  /**
+   * A raw OraclePolymer account:
+   *   discriminator[8] | polymer_prover_id | owner | chain_id u128 | bump
+   */
+  function oracleAccount(proverBase58: string): Uint8Array {
+    const data = new Uint8Array(8 + 32 + 32 + 16 + 1);
+    data.set(new PublicKey(proverBase58).toBytes(), 8);
+    return data;
+  }
+
+  test("returns the pinned id when the account agrees", async () => {
+    const { reads } = makeReads({
+      [oracle]: {
+        owner: INTENTS_PROTOCOL_PROGRAM_ID,
+        data: oracleAccount(POLYMER_PROVER_PROGRAM_ID)
+      }
+    });
+    expect(await readPolymerProverId(reads)).toBe(POLYMER_PROVER_PROGRAM_ID);
+  });
+
+  test("throws when Polymer has rotated its prover", async () => {
+    // An external program: a rotation must be loud here rather than surfacing
+    // as an opaque CPI failure part-way through proving.
+    const { reads } = makeReads({
+      [oracle]: {
+        owner: INTENTS_PROTOCOL_PROGRAM_ID,
+        data: oracleAccount("BkEw3WHFvJR9a5deUcwPLJ79yK3r9YGdQ61TehFXzAQ")
+      }
+    });
+    await expect(readPolymerProverId(reads)).rejects.toThrow("rotated its prover program");
+  });
+
+  test("throws when the oracle account is missing", async () => {
+    const { reads } = makeReads();
+    await expect(readPolymerProverId(reads)).rejects.toThrow("does not exist");
   });
 });

--- a/tests/unit/solanaSupport.test.ts
+++ b/tests/unit/solanaSupport.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SOLANA_DEVNET_CHAIN_ID,
+  SOLANA_MAINNET_CHAIN_ID,
+  SOLANA_TESTNET_CHAIN_ID,
+  TRON_MAINNET_CHAIN_ID
+} from "@lifi/intent";
+import {
+  SOLANA_CHAIN_IDS,
+  getChainType,
+  isEvmChain,
+  isSolanaChain,
+  isSolanaMainnet,
+  isTronChain
+} from "../../src/lib/utils/chainType";
+
+describe("chainType (solana)", () => {
+  test("isSolanaChain accepts every solana chain id, as number and bigint", () => {
+    for (const chainId of [
+      SOLANA_MAINNET_CHAIN_ID,
+      SOLANA_TESTNET_CHAIN_ID,
+      SOLANA_DEVNET_CHAIN_ID
+    ]) {
+      expect(isSolanaChain(chainId)).toBe(true);
+      expect(isSolanaChain(Number(chainId))).toBe(true);
+    }
+  });
+
+  test("isSolanaChain rejects evm and tron chains", () => {
+    for (const chainId of [1, 8453, 42161, Number(TRON_MAINNET_CHAIN_ID)]) {
+      expect(isSolanaChain(chainId)).toBe(false);
+    }
+  });
+
+  test("getChainType classifies all three namespaces", () => {
+    expect(getChainType(1)).toBe("evm");
+    expect(getChainType(TRON_MAINNET_CHAIN_ID)).toBe("tron");
+    expect(getChainType(SOLANA_MAINNET_CHAIN_ID)).toBe("solana");
+  });
+
+  test("isEvmChain is false for solana", () => {
+    // Regression guard: isEvmChain used to be `!isTronChain`, which reported
+    // every Solana chain as EVM and silently routed it down the viem path.
+    expect(isEvmChain(SOLANA_MAINNET_CHAIN_ID)).toBe(false);
+    expect(isEvmChain(SOLANA_DEVNET_CHAIN_ID)).toBe(false);
+    expect(isEvmChain(TRON_MAINNET_CHAIN_ID)).toBe(false);
+    expect(isEvmChain(1)).toBe(true);
+  });
+
+  test("the three chain-type predicates are mutually exclusive", () => {
+    for (const chainId of [
+      1,
+      8453,
+      Number(TRON_MAINNET_CHAIN_ID),
+      Number(SOLANA_MAINNET_CHAIN_ID),
+      Number(SOLANA_DEVNET_CHAIN_ID)
+    ]) {
+      const matches = [isEvmChain(chainId), isTronChain(chainId), isSolanaChain(chainId)].filter(
+        Boolean
+      );
+      expect(matches).toHaveLength(1);
+    }
+  });
+
+  test("solana chain ids survive the Number() round trip exactly", () => {
+    // The Set<number> lookup in chainType.ts is only sound while these stay
+    // inside Number.MAX_SAFE_INTEGER (~9.0e15). They are ~1.15e15 today.
+    for (const chainId of SOLANA_CHAIN_IDS) {
+      expect(Number.isSafeInteger(Number(chainId))).toBe(true);
+      expect(BigInt(Number(chainId))).toBe(chainId);
+    }
+  });
+
+  test("isSolanaMainnet distinguishes mainnet from devnet", () => {
+    expect(isSolanaMainnet(SOLANA_MAINNET_CHAIN_ID)).toBe(true);
+    expect(isSolanaMainnet(SOLANA_DEVNET_CHAIN_ID)).toBe(false);
+    expect(isSolanaMainnet(1)).toBe(false);
+  });
+
+  test("SOLANA_CHAIN_IDS is the single source of truth", () => {
+    expect(SOLANA_CHAIN_IDS.size).toBe(3);
+    for (const chainId of SOLANA_CHAIN_IDS) {
+      expect(isSolanaChain(chainId)).toBe(true);
+    }
+  });
+});

--- a/tests/unit/solanaSupport.test.ts
+++ b/tests/unit/solanaSupport.test.ts
@@ -11,7 +11,8 @@ import {
   isEvmChain,
   isSolanaChain,
   isSolanaMainnet,
-  isTronChain
+  isTronChain,
+  namespaceForChain
 } from "../../src/lib/utils/chainType";
 
 describe("chainType (solana)", () => {
@@ -75,6 +76,24 @@ describe("chainType (solana)", () => {
     expect(isSolanaMainnet(SOLANA_MAINNET_CHAIN_ID)).toBe(true);
     expect(isSolanaMainnet(SOLANA_DEVNET_CHAIN_ID)).toBe(false);
     expect(isSolanaMainnet(1)).toBe(false);
+  });
+
+  test("namespaceForChain names each chain type on the wire", () => {
+    expect(namespaceForChain(1)).toBe("eip155");
+    expect(namespaceForChain(8453)).toBe("eip155");
+    expect(namespaceForChain(TRON_MAINNET_CHAIN_ID)).toBe("tron");
+    for (const chainId of SOLANA_CHAIN_IDS) {
+      expect(namespaceForChain(chainId)).toBe("solana");
+      expect(namespaceForChain(Number(chainId))).toBe("solana");
+    }
+  });
+
+  test("namespaceForChain never labels a solana chain eip155", () => {
+    // The regression this pins: a Solana output sent as
+    // `eip155:1151111081099710` makes the order service read its 32-byte mint
+    // as a left-padded 20-byte EVM address and reject the quote with
+    // "bytes32 value has non-zero upper bytes".
+    expect(namespaceForChain(SOLANA_MAINNET_CHAIN_ID)).not.toBe("eip155");
   });
 
   test("SOLANA_CHAIN_IDS is the single source of truth", () => {

--- a/tests/unit/solanaWrites.test.ts
+++ b/tests/unit/solanaWrites.test.ts
@@ -27,7 +27,14 @@ import type {
   SolanaProgramLike,
   SolanaProgramsLike
 } from "../../src/lib/solana/types";
-import { fillOutput, finalise, openEscrow, submitFillProof } from "../../src/lib/solana/writes";
+import {
+  fillOutput,
+  fillOutputs,
+  finalise,
+  openEscrow,
+  submitFillProof
+} from "../../src/lib/solana/writes";
+import { PublicKey } from "@solana/web3.js";
 
 const CHAIN_ID = SOLANA_DEVNET_CHAIN_ID;
 const DEVNET_GENESIS = SOLANA_GENESIS_HASHES[CHAIN_ID.toString()]!;
@@ -145,6 +152,21 @@ function makeDeps(
   };
 
   return { deps, calls, sent };
+}
+
+/**
+ * A raw OrderContext account.
+ *
+ * Layout (input_settler_escrow/src/state/input_settler_escrow.rs):
+ *   discriminator[8] | input_token: Pubkey | user: Pubkey | sponsor: Pubkey | bump
+ * The sponsor is at byte 72 — reading it from byte 8 yields `input_token`.
+ */
+function orderContextData(opts: { inputToken: string; user: string; sponsor: string }): Uint8Array {
+  const data = new Uint8Array(8 + 32 + 32 + 32 + 1);
+  data.set(new PublicKey(opts.inputToken).toBytes(), 8);
+  data.set(new PublicKey(opts.user).toBytes(), 40);
+  data.set(new PublicKey(opts.sponsor).toBytes(), 72);
+  return data;
 }
 
 function makeOutput(overrides: Partial<MandateOutput> = {}): MandateOutput {
@@ -427,5 +449,102 @@ describe("finalise", () => {
       ).toBase58()
     );
     expect(call.remaining?.[1]?.pubkey).not.toBe(call.remaining?.[0]?.pubkey);
+  });
+});
+
+describe("finalise sponsor resolution", () => {
+  const solver = pubkeyToBytes32(bytes32ToPubkey(b32("5")));
+  const solverBase58 = bytes32ToPubkey(solver).toBase58();
+  const SPONSOR = "49zLKETMq34CUC2E2wL1xvv6uN2AUgyhjVX221mjE3Rw";
+
+  test("reads sponsor from byte 72, not from the discriminator", async () => {
+    // The bug this pins: reading bytes 8..40 yields `input_token` (the mint).
+    // finalise has `has_one = sponsor`, so passing the mint there makes every
+    // claim fail on chain — invisible to a zero-filled fixture.
+    const order = makeOrder();
+    const context = orderContextPda(ORDER_ID).toBase58();
+    const user = bytes32ToPubkey(order.user as `0x${string}`).toBase58();
+    const { deps, calls } = makeDeps({
+      signerPublicKey: solverBase58,
+      accounts: {
+        [MINT]: { owner: TOKEN_PROGRAM_ID },
+        [context]: {
+          owner: INPUT_SETTLER_ESCROW_PROGRAM_ID,
+          data: orderContextData({ inputToken: MINT, user, sponsor: SPONSOR })
+        }
+      }
+    });
+
+    await finalise(deps, {
+      order,
+      orderId: ORDER_ID,
+      solveParams: [{ solver, timestamp: 1_700_000_000 }],
+      destinationBytes32: solver
+    });
+
+    const call = calls.find((c) => c.method === "finalise")!;
+    expect(call.accounts?.sponsor).toBe(SPONSOR);
+    expect(call.accounts?.sponsor).not.toBe(MINT);
+    expect(call.accounts?.user).toBe(user);
+  });
+});
+
+describe("fillOutputs batching", () => {
+  test("sends every output in ONE transaction", async () => {
+    // Each output needs its own instruction, but they must share a
+    // transaction: the caller stores one reference per output and later
+    // searches that transaction's logs for each output's OutputFilledEvent.
+    // Separate transactions leave outputs 2..N filled but unprovable.
+    const outputs = [makeOutput(), makeOutput({ amount: 2_000_000n })];
+    const { deps, calls, sent } = makeDeps();
+
+    const signature = await fillOutputs(deps, {
+      orderId: ORDER_ID,
+      outputs,
+      fillDeadline: 1_700_000_900,
+      solverBytes32: b32("5")
+    });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toHaveLength(2);
+    expect(signature).toBe("sig1");
+    expect(calls.filter((c) => c.method === "fill")).toHaveLength(2);
+  });
+
+  test("derives a distinct fill_id per output", async () => {
+    const outputs = [makeOutput(), makeOutput({ amount: 2_000_000n })];
+    const { deps, calls } = makeDeps();
+    await fillOutputs(deps, {
+      orderId: ORDER_ID,
+      outputs,
+      fillDeadline: 1,
+      solverBytes32: b32("5")
+    });
+    const fills = calls.filter((c) => c.method === "fill");
+    expect(fills[0]!.accounts?.fillId).not.toBe(fills[1]!.accounts?.fillId);
+  });
+
+  test("rejects an empty output list", async () => {
+    const { deps } = makeDeps();
+    await expect(
+      fillOutputs(deps, {
+        orderId: ORDER_ID,
+        outputs: [],
+        fillDeadline: 1,
+        solverBytes32: b32("5")
+      })
+    ).rejects.toThrow("at least one output");
+  });
+
+  test("fillOutput is the single-output case of fillOutputs", async () => {
+    const { deps, sent } = makeDeps();
+    await fillOutput(deps, {
+      orderId: ORDER_ID,
+      output: makeOutput(),
+      fillDeadline: 1,
+      solverBytes32: b32("5")
+    });
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toHaveLength(1);
   });
 });

--- a/tests/unit/solanaWrites.test.ts
+++ b/tests/unit/solanaWrites.test.ts
@@ -1,0 +1,431 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { SOLANA_DEVNET_CHAIN_ID, getOutputHash } from "@lifi/intent";
+import type { MandateOutput, StandardSolana } from "@lifi/intent";
+import {
+  INPUT_SETTLER_ESCROW_PROGRAM_ID,
+  INTENTS_PROTOCOL_PROGRAM_ID,
+  OUTPUT_SETTLER_SIMPLE_PROGRAM_ID,
+  POLYMER_PROGRAM_ID
+} from "../../src/lib/idl";
+import { SOLANA_GENESIS_HASHES, invalidateSolanaClusterGuard } from "../../src/lib/solana/client";
+import { localAttestationDataHash } from "../../src/lib/solana/encode";
+import {
+  TOKEN_PROGRAM_ID,
+  bytes32ToPubkey,
+  consumedOrderPda,
+  fillIdPda,
+  localAttestationPda,
+  orderContextPda,
+  outputSettlerSimplePda,
+  pubkeyToBytes32
+} from "../../src/lib/solana/pda";
+import type {
+  SolanaAccountInfoLike,
+  SolanaAccountMeta,
+  SolanaDeps,
+  SolanaInstructionLike,
+  SolanaProgramLike,
+  SolanaProgramsLike
+} from "../../src/lib/solana/types";
+import { fillOutput, finalise, openEscrow, submitFillProof } from "../../src/lib/solana/writes";
+
+const CHAIN_ID = SOLANA_DEVNET_CHAIN_ID;
+const DEVNET_GENESIS = SOLANA_GENESIS_HASHES[CHAIN_ID.toString()]!;
+
+const b32 = (nibble: string) => `0x${nibble.repeat(64)}` as `0x${string}`;
+const ORDER_ID = b32("6");
+
+// A real, on-curve key so PublicKey accepts it; its bytes32 form is the
+// identity the order carries.
+const USER = "BkEw3WHFvJR9a5deUcwPLJ79yK3r9YGdQ61TehFXzAQ";
+const USER_B32 = pubkeyToBytes32(bytes32ToPubkey(b32("0")));
+const MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const MINT_B32 = "0xc6fa7af3bedbad3a3d65f36aabc97431b1bbe4c2d2f6e0e47ca60203452f5d61" as const;
+
+type RecordedCall = {
+  program: string;
+  method: string;
+  args: unknown[];
+  accounts?: Record<string, string>;
+  remaining?: SolanaAccountMeta[];
+};
+
+/**
+ * Programs whose every instruction is synthesised on demand and recorded.
+ *
+ * Mirrors the Tron mock in tronWrites.test.ts, including the `then` guard: a
+ * Proxy that answers `then` is a thenable, and awaiting it never settles.
+ */
+function makePrograms(calls: RecordedCall[]): SolanaProgramsLike {
+  const make = (program: string, programId: string): SolanaProgramLike => ({
+    programId,
+    methods: new Proxy({} as SolanaProgramLike["methods"], {
+      get(_target, method) {
+        if (typeof method !== "string" || method === "then") return undefined;
+        return (...args: unknown[]) => {
+          const call: RecordedCall = { program, method, args };
+          calls.push(call);
+          const builder = {
+            accounts(accounts: Record<string, string>) {
+              call.accounts = accounts;
+              return builder;
+            },
+            remainingAccounts(remaining: SolanaAccountMeta[]) {
+              call.remaining = remaining;
+              return builder;
+            },
+            async instruction(): Promise<SolanaInstructionLike> {
+              return { programId, keys: [], data: new Uint8Array() };
+            }
+          };
+          return builder;
+        };
+      }
+    })
+  });
+
+  return {
+    inputSettlerEscrow: make("inputSettlerEscrow", INPUT_SETTLER_ESCROW_PROGRAM_ID),
+    outputSettlerSimple: make("outputSettlerSimple", OUTPUT_SETTLER_SIMPLE_PROGRAM_ID),
+    polymer: make("polymer", POLYMER_PROGRAM_ID),
+    intentsProtocol: make("intentsProtocol", INTENTS_PROTOCOL_PROGRAM_ID)
+  };
+}
+
+function makeDeps(
+  opts: {
+    accounts?: Record<string, { owner: string; data?: Uint8Array }>;
+    signerPublicKey?: string;
+    genesis?: string;
+  } = {}
+) {
+  const calls: RecordedCall[] = [];
+  const sent: SolanaInstructionLike[][] = [];
+  const accounts = opts.accounts ?? { [MINT]: { owner: TOKEN_PROGRAM_ID } };
+
+  const deps: SolanaDeps = {
+    chainId: CHAIN_ID,
+    reads: {
+      rpcEndpoint: "https://test.invalid",
+      getGenesisHash: async () => opts.genesis ?? DEVNET_GENESIS,
+      getAccountInfo: async (address) => {
+        const account = accounts[address];
+        return account
+          ? ({
+              owner: account.owner,
+              lamports: 1,
+              data: account.data ?? new Uint8Array()
+            } as SolanaAccountInfoLike)
+          : null;
+      },
+      getMultipleAccountsInfo: async (addresses) =>
+        addresses.map((address) => {
+          const account = accounts[address];
+          return account
+            ? ({
+                owner: account.owner,
+                lamports: 1,
+                data: account.data ?? new Uint8Array()
+              } as SolanaAccountInfoLike)
+            : null;
+        }),
+      getTransaction: async () => null,
+      getBalance: async () => 0n,
+      getTokenAccountBalance: async () => 0n,
+      getLatestBlockhash: async () => ({ blockhash: "hash", lastValidBlockHeight: 1 })
+    },
+    signer: {
+      publicKey: opts.signerPublicKey ?? USER,
+      signAndSend: async (instructions) => {
+        sent.push(instructions);
+        return `sig${sent.length}`;
+      }
+    },
+    programs: makePrograms(calls)
+  };
+
+  return { deps, calls, sent };
+}
+
+function makeOutput(overrides: Partial<MandateOutput> = {}): MandateOutput {
+  return {
+    oracle: pubkeyToBytes32(bytes32ToPubkey(b32("1"))),
+    settler: pubkeyToBytes32(outputSettlerSimplePda()),
+    chainId: CHAIN_ID,
+    token: MINT_B32,
+    amount: 1_000_000n,
+    recipient: pubkeyToBytes32(bytes32ToPubkey(b32("4"))),
+    callbackData: "0x",
+    context: "0x",
+    ...overrides
+  } as MandateOutput;
+}
+
+function makeOrder(overrides: Partial<StandardSolana> = {}): StandardSolana {
+  return {
+    user: pubkeyToBytes32(bytes32ToPubkey(USER_B32)),
+    nonce: 1n,
+    originChainId: CHAIN_ID,
+    expires: 1_700_001_000,
+    fillDeadline: 1_700_000_900,
+    inputOracle: pubkeyToBytes32(bytes32ToPubkey(b32("8"))),
+    inputs: [[BigInt(MINT_B32), 1_000_000n]],
+    outputs: [makeOutput()],
+    ...overrides
+  } as StandardSolana;
+}
+
+beforeEach(() => {
+  invalidateSolanaClusterGuard();
+});
+
+describe("cluster guard", () => {
+  test("refuses to sign against a wrong-cluster RPC", async () => {
+    // The wallet can be pointed anywhere; only the genesis hash identifies the
+    // cluster actually being written to.
+    const order = makeOrder();
+    const { deps } = makeDeps({
+      genesis: "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+      signerPublicKey: bytes32ToPubkey(order.user as `0x${string}`).toBase58()
+    });
+    await expect(openEscrow(deps, { order, orderId: ORDER_ID })).rejects.toThrow(
+      /Refusing to sign against the wrong cluster/
+    );
+  });
+});
+
+describe("openEscrow", () => {
+  test("passes the full account set including consumed_order and the vault", async () => {
+    const order = makeOrder();
+    const user = bytes32ToPubkey(order.user as `0x${string}`).toBase58();
+    const { deps, calls, sent } = makeDeps({
+      signerPublicKey: user,
+      accounts: { [MINT]: { owner: TOKEN_PROGRAM_ID } }
+    });
+
+    const signature = await openEscrow(deps, { order, orderId: ORDER_ID });
+
+    expect(signature).toBe("sig1");
+    expect(sent).toHaveLength(1);
+    const call = calls.find((c) => c.method === "open")!;
+    expect(call.program).toBe("inputSettlerEscrow");
+    // consumed_order is the replay guard and is easy to omit — the reference
+    // test in catalyst-intent-svm predates it and does exactly that.
+    expect(call.accounts?.consumedOrder).toBe(consumedOrderPda(ORDER_ID).toBase58());
+    expect(call.accounts?.orderContext).toBe(orderContextPda(ORDER_ID).toBase58());
+    expect(call.accounts?.tokenProgram).toBe(TOKEN_PROGRAM_ID);
+    // The vault is the order context's OWN ata, not the user's.
+    expect(call.accounts?.orderPdaTokenAccount).not.toBe(call.accounts?.userTokenAccount);
+  });
+
+  test("rejects when the connected wallet is not the order's user", async () => {
+    // `open` debits the user's ATA under the user's signature, so a different
+    // wallet builds a transaction that cannot succeed.
+    const order = makeOrder();
+    const { deps } = makeDeps({ signerPublicKey: USER });
+    await expect(openEscrow(deps, { order, orderId: ORDER_ID })).rejects.toThrow(
+      /is not the order's user/
+    );
+  });
+
+  test("rejects a native-SOL input with an explanation", async () => {
+    const order = makeOrder({ inputs: [[0n, 1_000_000n]] });
+    const user = bytes32ToPubkey(order.user as `0x${string}`).toBase58();
+    const { deps } = makeDeps({ signerPublicKey: user });
+    await expect(openEscrow(deps, { order, orderId: ORDER_ID })).rejects.toThrow(
+      /no native-SOL input path/
+    );
+  });
+
+  test("rejects a mint owned by something that is not a token program", async () => {
+    const order = makeOrder();
+    const user = bytes32ToPubkey(order.user as `0x${string}`).toBase58();
+    const { deps } = makeDeps({
+      signerPublicKey: user,
+      accounts: { [MINT]: { owner: INTENTS_PROTOCOL_PROGRAM_ID } }
+    });
+    await expect(openEscrow(deps, { order, orderId: ORDER_ID })).rejects.toThrow(
+      /not a token program/
+    );
+  });
+});
+
+describe("fillOutput", () => {
+  test("passes fill_id and local_attestation explicitly", async () => {
+    // Anchor cannot resolve either: fill_id's second seed is a hash of an
+    // instruction argument, and local_attestation is created by CPI.
+    const output = makeOutput();
+    const { deps, calls } = makeDeps();
+    await fillOutput(deps, {
+      orderId: ORDER_ID,
+      output,
+      fillDeadline: 1_700_000_900,
+      solverBytes32: b32("5")
+    });
+
+    const call = calls.find((c) => c.method === "fill")!;
+    expect(call.accounts?.fillId).toBe(fillIdPda(ORDER_ID, getOutputHash(output)).toBase58());
+    expect(call.accounts?.localAttestation).toBe(
+      localAttestationPda(
+        outputSettlerSimplePda(),
+        output.oracle,
+        localAttestationDataHash({ solver: b32("5"), orderId: ORDER_ID, output })
+      ).toBase58()
+    );
+  });
+
+  test("uses native_fill for a zero token and omits the token accounts", async () => {
+    const output = makeOutput({ token: `0x${"00".repeat(32)}` as `0x${string}` });
+    const { deps, calls } = makeDeps();
+    await fillOutput(deps, {
+      orderId: ORDER_ID,
+      output,
+      fillDeadline: 1_700_000_900,
+      solverBytes32: b32("5")
+    });
+
+    const call = calls.find((c) => c.method === "nativeFill")!;
+    expect(call).toBeDefined();
+    expect(call.accounts?.mint).toBeUndefined();
+    expect(calls.find((c) => c.method === "fill")).toBeUndefined();
+  });
+
+  test("rejects a zero solver before signing", async () => {
+    const { deps, sent } = makeDeps();
+    await expect(
+      fillOutput(deps, {
+        orderId: ORDER_ID,
+        output: makeOutput(),
+        fillDeadline: 1,
+        solverBytes32: `0x${"00".repeat(32)}` as `0x${string}`
+      })
+    ).rejects.toThrow(/zero pubkey/);
+    expect(sent).toHaveLength(0);
+  });
+
+  test("rejects an amount above u64 before signing", async () => {
+    const { deps, sent } = makeDeps();
+    await expect(
+      fillOutput(deps, {
+        orderId: ORDER_ID,
+        output: makeOutput({ amount: 1n << 64n }),
+        fillDeadline: 1,
+        solverBytes32: b32("5")
+      })
+    ).rejects.toThrow(/exceeds u64/);
+    expect(sent).toHaveLength(0);
+  });
+});
+
+describe("submitFillProof", () => {
+  test("rejects an output whose oracle is not the polymer program", async () => {
+    // This is the failure the whole PR exists to prevent: the fill succeeds,
+    // then proving is impossible. Surface it as a sentence.
+    const { deps, sent } = makeDeps();
+    await expect(
+      submitFillProof(deps, {
+        orderId: ORDER_ID,
+        output: makeOutput(),
+        solverBytes32: b32("5"),
+        timestamp: 1_700_000_000
+      })
+    ).rejects.toThrow(/Polymer can only prove outputs whose oracle is the Polymer program/);
+    expect(sent).toHaveLength(0);
+  });
+
+  test("submits with the attestation as a remaining account", async () => {
+    const withPolymerOracle = makeOutput({
+      oracle: "0x050cae5588f8d907500199177ab1239f61b8557af2ffacd5defed0070b858ad4"
+    });
+    const { deps, calls } = makeDeps();
+    await submitFillProof(deps, {
+      orderId: ORDER_ID,
+      output: withPolymerOracle,
+      solverBytes32: b32("5"),
+      timestamp: 1_700_000_000
+    });
+
+    const call = calls.find((c) => c.method === "submit")!;
+    expect(call.remaining).toHaveLength(1);
+    expect(call.remaining?.[0]?.pubkey).toBe(
+      localAttestationPda(
+        outputSettlerSimplePda(),
+        withPolymerOracle.oracle,
+        localAttestationDataHash({
+          solver: b32("5"),
+          orderId: ORDER_ID,
+          output: withPolymerOracle
+        })
+      ).toBase58()
+    );
+  });
+});
+
+describe("finalise", () => {
+  const solver = pubkeyToBytes32(bytes32ToPubkey(b32("5")));
+  const solverBase58 = bytes32ToPubkey(solver).toBase58();
+
+  test("refuses when the connected wallet is not the first solver", async () => {
+    const order = makeOrder();
+    const { deps, sent } = makeDeps({ signerPublicKey: USER });
+    await expect(
+      finalise(deps, {
+        order,
+        orderId: ORDER_ID,
+        solveParams: [{ solver, timestamp: 1_700_000_000 }],
+        destinationBytes32: solver
+      })
+    ).rejects.toThrow(/must be signed by the first solver/);
+    expect(sent).toHaveLength(0);
+  });
+
+  test("refuses when the escrow is already settled", async () => {
+    const order = makeOrder();
+    const { deps } = makeDeps({ signerPublicKey: solverBase58 });
+    await expect(
+      finalise(deps, {
+        order,
+        orderId: ORDER_ID,
+        solveParams: [{ solver, timestamp: 1_700_000_000 }],
+        destinationBytes32: solver
+      })
+    ).rejects.toThrow(/no open escrow/);
+  });
+
+  test("passes one attestation per output, in order.outputs order", async () => {
+    // The program indexes remainingAccounts positionally, so a reordering
+    // settles the wrong output.
+    const outputs = [makeOutput(), makeOutput({ amount: 2_000_000n })];
+    const order = makeOrder({ outputs });
+    const context = orderContextPda(ORDER_ID).toBase58();
+    const { deps, calls } = makeDeps({
+      signerPublicKey: solverBase58,
+      accounts: {
+        [MINT]: { owner: TOKEN_PROGRAM_ID },
+        [context]: { owner: INPUT_SETTLER_ESCROW_PROGRAM_ID, data: new Uint8Array(40) }
+      }
+    });
+
+    await finalise(deps, {
+      order,
+      orderId: ORDER_ID,
+      solveParams: [
+        { solver, timestamp: 1_700_000_000 },
+        { solver, timestamp: 1_700_000_001 }
+      ],
+      destinationBytes32: solver
+    });
+
+    const call = calls.find((c) => c.method === "finalise")!;
+    expect(call.remaining).toHaveLength(2);
+    // Both outputs are same-chain here, so both are LocalAttestations.
+    expect(call.remaining?.[0]?.pubkey).toBe(
+      localAttestationPda(
+        outputSettlerSimplePda(),
+        outputs[0]!.oracle,
+        localAttestationDataHash({ solver, orderId: ORDER_ID, output: outputs[0]! })
+      ).toBase58()
+    );
+    expect(call.remaining?.[1]?.pubkey).not.toBe(call.remaining?.[0]?.pubkey);
+  });
+});

--- a/tests/unit/solanaWrites.test.ts
+++ b/tests/unit/solanaWrites.test.ts
@@ -312,6 +312,64 @@ describe("fillOutput", () => {
     expect(calls.find((c) => c.method === "fill")).toBeUndefined();
   });
 
+  test("encodes a JSON-round-tripped output identically to a bigint one", async () => {
+    // Orders reloaded from the local DB carry `amount`/`chainId` as decimal
+    // STRINGS (BigInt.prototype.toJSON on the way in, plain JSON.parse on the
+    // way out). `toBytes32` used to format those with `String.prototype
+    // .toString(16)`, which ignores the radix, so the decimal digits were
+    // re-read as hex: amount 1000000 went out as 0x…01000000. The PDAs come
+    // from `getOutputHash`, which coerces through viem and stayed correct, so
+    // the program derived fill_id from a different hash than the client and the
+    // fill died with ConstraintSeeds (2006) — after which the transfer would
+    // have moved the wrong number of tokens.
+    const output = makeOutput();
+    const roundTripped = JSON.parse(
+      JSON.stringify(output, (_key, value) =>
+        typeof value === "bigint" ? value.toString() : value
+      )
+    ) as MandateOutput;
+    expect(typeof (roundTripped as unknown as { amount: unknown }).amount).toBe("string");
+
+    const bigintRun = makeDeps();
+    await fillOutput(bigintRun.deps, {
+      orderId: ORDER_ID,
+      output,
+      fillDeadline: 1_700_000_900,
+      solverBytes32: b32("5")
+    });
+    const stringRun = makeDeps();
+    await fillOutput(stringRun.deps, {
+      orderId: ORDER_ID,
+      output: roundTripped,
+      fillDeadline: 1_700_000_900,
+      solverBytes32: b32("5")
+    });
+
+    const encoded = (run: { calls: RecordedCall[] }) => {
+      const call = run.calls.find((c) => c.method === "fill")!;
+      return JSON.stringify({ args: call.args, accounts: call.accounts });
+    };
+    expect(encoded(stringRun)).toBe(encoded(bigintRun));
+  });
+
+  test("rejects a field that is not 32-byte hex before signing", async () => {
+    // A base58 address reaching the instruction encoder must never be padded
+    // into NaN bytes (borsh-encodes as zeroes) — that ships an argument the
+    // client's own PDAs disagree with, i.e. another opaque ConstraintSeeds.
+    // viem's hex parsing in `getOutputHash` is the first line of defence and
+    // wins here; `bytes32Array` backstops any path that skips it.
+    const { deps, sent } = makeDeps();
+    await expect(
+      fillOutput(deps, {
+        orderId: ORDER_ID,
+        output: makeOutput({ recipient: MINT as unknown as `0x${string}` }),
+        fillDeadline: 1_700_000_900,
+        solverBytes32: b32("5")
+      })
+    ).rejects.toThrow(/Invalid byte sequence|32-byte hex/);
+    expect(sent).toHaveLength(0);
+  });
+
   test("rejects a zero solver before signing", async () => {
     const { deps, sent } = makeDeps();
     await expect(

--- a/tests/unit/tronWrites.test.ts
+++ b/tests/unit/tronWrites.test.ts
@@ -8,7 +8,7 @@ import {
   invalidateNetworkGuardCache,
   waitForTronTransaction
 } from "../../src/lib/tron/signer";
-import { fillOutputs, finalise, openEscrow } from "../../src/lib/tron/writes";
+import { fillOutputs, finalise, openEscrow, submitReceiveMessage } from "../../src/lib/tron/writes";
 import type { TronTxInfo, TronWebLike } from "../../src/lib/tron/types";
 
 const USDT = "0xa614f803b6fd780986a42c78ec9c7f77e6ded13c" as const;
@@ -268,6 +268,35 @@ describe("fillOutputs", () => {
         }
       )
     ).rejects.toThrow("non-mainnet");
+  });
+});
+
+describe("submitReceiveMessage", () => {
+  const ORACLE = "0x94b0c01e26aff5a6a0fd767afe0e3ca0f8b34e3d" as const;
+
+  it("defaults to receiveMessage for EVM/Tron proofs", async () => {
+    invalidateNetworkGuardCache();
+    const { tw, calls } = makeMock({});
+    await submitReceiveMessage({ reads: tw, signer: tw }, ORACLE, "0xdeadbeef");
+    const receive = calls.find((c) => c.method === "receiveMessage");
+    expect(receive).toBeDefined();
+    expect(receive!.args[0]).toBe("0xdeadbeef");
+    expect(calls.some((c) => c.method === "receiveSolanaMessage")).toBe(false);
+  });
+
+  it("uses receiveSolanaMessage when asked — a Solana proof reverts in receiveMessage", async () => {
+    invalidateNetworkGuardCache();
+    const { tw, calls } = makeMock({});
+    await submitReceiveMessage(
+      { reads: tw, signer: tw },
+      ORACLE,
+      "deadbeef",
+      "receiveSolanaMessage"
+    );
+    const receive = calls.find((c) => c.method === "receiveSolanaMessage");
+    expect(receive).toBeDefined();
+    expect(receive!.args[0]).toBe("0xdeadbeef");
+    expect(calls.some((c) => c.method === "receiveMessage")).toBe(false);
   });
 });
 

--- a/tests/unit/txRef.test.ts
+++ b/tests/unit/txRef.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SOLANA_DEVNET_CHAIN_ID,
+  SOLANA_MAINNET_CHAIN_ID,
+  TRON_MAINNET_CHAIN_ID
+} from "@lifi/intent";
+import { base58 } from "@scure/base";
+import {
+  isValidTxRef,
+  normalizeTxRef,
+  txRefError,
+  txRefPlaceholder
+} from "../../src/lib/utils/txRef";
+
+const EVM_HASH = `0x${"ab".repeat(32)}`;
+const BARE_HASH = "ab".repeat(32);
+const SOLANA_SIG = base58.encode(new Uint8Array(64).fill(7));
+const SOLANA_PUBKEY = base58.encode(new Uint8Array(32).fill(7));
+
+describe("isValidTxRef", () => {
+  test("accepts a 0x hash on EVM chains", () => {
+    expect(isValidTxRef(EVM_HASH, 1)).toBe(true);
+    expect(isValidTxRef(BARE_HASH, 1)).toBe(false);
+  });
+
+  test("accepts both prefixed and bare hashes on Tron", () => {
+    // Tron reports transaction ids without the 0x prefix.
+    expect(isValidTxRef(EVM_HASH, TRON_MAINNET_CHAIN_ID)).toBe(true);
+    expect(isValidTxRef(BARE_HASH, TRON_MAINNET_CHAIN_ID)).toBe(true);
+  });
+
+  test("accepts a 64-byte base58 signature on Solana", () => {
+    expect(isValidTxRef(SOLANA_SIG, SOLANA_MAINNET_CHAIN_ID)).toBe(true);
+    expect(isValidTxRef(SOLANA_SIG, SOLANA_DEVNET_CHAIN_ID)).toBe(true);
+  });
+
+  test("rejects a 32-byte base58 value on Solana", () => {
+    // Valid base58 that decodes to a pubkey, not a signature — a length-only
+    // check would wave this through.
+    expect(isValidTxRef(SOLANA_PUBKEY, SOLANA_MAINNET_CHAIN_ID)).toBe(false);
+  });
+
+  test("rejects an EVM hash on Solana and a Solana signature on EVM", () => {
+    // The trap this type exists to prevent: a fill reference belongs to the
+    // OUTPUT chain, so validating it against the wrong chain silently accepts
+    // or rejects the wrong thing.
+    expect(isValidTxRef(EVM_HASH, SOLANA_MAINNET_CHAIN_ID)).toBe(false);
+    expect(isValidTxRef(SOLANA_SIG, 1)).toBe(false);
+  });
+
+  test("rejects empty and undefined", () => {
+    expect(isValidTxRef(undefined, 1)).toBe(false);
+    expect(isValidTxRef("", SOLANA_MAINNET_CHAIN_ID)).toBe(false);
+  });
+});
+
+describe("normalizeTxRef", () => {
+  test("prefixes a bare Tron hash", () => {
+    expect(normalizeTxRef(BARE_HASH, TRON_MAINNET_CHAIN_ID)).toBe(EVM_HASH);
+  });
+
+  test("leaves a Solana signature untouched", () => {
+    // base58 is case-sensitive and has no prefix; touching it corrupts it.
+    expect(normalizeTxRef(SOLANA_SIG, SOLANA_MAINNET_CHAIN_ID)).toBe(SOLANA_SIG);
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(normalizeTxRef(`  ${EVM_HASH}  `, 1)).toBe(EVM_HASH);
+  });
+});
+
+describe("messages", () => {
+  test("placeholder and error text are chain-appropriate", () => {
+    expect(txRefPlaceholder(SOLANA_MAINNET_CHAIN_ID)).toContain("base58");
+    expect(txRefPlaceholder(1)).toBe("0x...");
+    expect(txRefError(SOLANA_MAINNET_CHAIN_ID)).toContain("base58");
+    expect(txRefError(1)).toContain("32-byte");
+  });
+});

--- a/tests/unit/txRef.test.ts
+++ b/tests/unit/txRef.test.ts
@@ -77,3 +77,32 @@ describe("messages", () => {
     expect(txRefError(1)).toContain("32-byte");
   });
 });
+
+describe("the signature the claim path rejected", () => {
+  // Regression: Solver.claim validated fill hashes with a hardcoded
+  // `startsWith("0x") && length === 66`, which the txRef refactor missed. A
+  // real devnet fill signature was rejected as "Invalid fill tx hash at index
+  // 0" even though the fill had landed, stranding the order before finalise.
+  const REAL_FILL_SIGNATURE =
+    "5B72eWR4yk58nkmJFcGDXtRi3KS9EHNuZgQSSwXnYQPJnuCtrC4U6aV3wPTopQAATkxkmDcxBqwxPyJ6CVpMRfkQ";
+
+  test("is a well-formed 64-byte Solana signature", () => {
+    expect(base58.decode(REAL_FILL_SIGNATURE).length).toBe(64);
+  });
+
+  test("is accepted for a Solana output chain", () => {
+    expect(isValidTxRef(REAL_FILL_SIGNATURE, SOLANA_DEVNET_CHAIN_ID)).toBe(true);
+    expect(isValidTxRef(REAL_FILL_SIGNATURE, SOLANA_MAINNET_CHAIN_ID)).toBe(true);
+  });
+
+  test("fails the old hardcoded EVM check, which is why the bug existed", () => {
+    const oldCheck = (h: string) => h.startsWith("0x") && h.length === 66;
+    expect(oldCheck(REAL_FILL_SIGNATURE)).toBe(false);
+  });
+
+  test("is still rejected when the output chain is EVM", () => {
+    // The fill hash belongs to output.chainId, so passing an EVM chain here
+    // must reject — a base58 signature on an EVM output is genuinely wrong.
+    expect(isValidTxRef(REAL_FILL_SIGNATURE, 8453)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds application-side Solana support to lintent for the complete escrow intent lifecycle: issuing, opening, filling, proving, tracking, and finalising.

The branch supports:

- EVM → Solana
- Solana → EVM
- Solana → Solana

It includes chain classification and metadata, Phantom and Solflare wallet integration, Anchor IDLs, PDA derivation, payload and event handling, read/write facades, Polymer proof routing, chain-aware transaction references, and mainnet/devnet token configuration.

`@lifi/intent@0.4.0` now provides the canonical Solana constants and encoding helpers; the earlier temporary local dependency has been removed.

## What works

- Solana is treated as a first-class chain type rather than falling through to EVM/viem paths.
- Phantom and Solflare can connect from the wallet picker and status bar.
- Solana-input escrow orders can be issued and opened with SPL or Token-2022 inputs.
- Solana outputs can be filled with SPL/Token-2022 tokens or native SOL.
- Multi-output fills are submitted as one transaction so every output has a valid shared fill reference.
- Same-chain Solana fills use local attestations without a Polymer round trip.
- Cross-chain Solana outputs submit a `Prove:` log to Polymer and deliver the resulting proof to the input chain.
- Solana-input orders can receive Polymer proofs and finalise against ordered attestation accounts.
- Fill, proof, and terminal progress is read from program-owned marker PDAs.
- Base58 Solana signatures and hex EVM/Tron transaction hashes are validated against the output chain that produced them.
- Each write verifies the RPC cluster genesis hash before asking the wallet to sign.

## Important protocol distinction

Three different values are commonly called the “Solana Polymer oracle” and are not interchangeable:

| Order field | Required value | Canonical deployment value |
| --- | --- | --- |
| `MandateOutput.settler` for a Solana output | Output settler **PDA** | `DHShHmVkTwCzUzAQbCu4GDqJmursuDscNR6o4hTBgeRy` |
| `MandateOutput.oracle` for a cross-chain Solana output | Polymer **program ID** | `LiFiBtfyPT1DnTHTAeZ2rwr5RgMrThwA5kt7KGT5nBV` |
| `StandardSolana.inputOracle` for a cross-chain Solana input | Polymer oracle **PDA** | `49zLKETMq34CUC2E2wL1xvv6uN2AUgyhjVX221mjE3Rw` |

For Solana → Solana orders, both oracle fields use the output settler PDA because validation follows the local-attestation path.

## Current limitations

- Solana supports escrow orders only. Compact and multichain Solana orders reject explicitly.
- Native SOL cannot be an input because the escrow program has no native `open` path; use wSOL. Native SOL outputs are supported.
- Mainnet Solana is currently selectable with USDC, USDT, and wSOL, but a small-value end-to-end mainnet canary has not yet been recorded.
- A complete real devnet flow and finalized fill-log fixture are still outstanding.
- The safe multi-output ceiling still needs to be measured against the finalise transaction-size limit.
- Quote-time validation, rather than the client, currently rejects off-curve Solana recipient addresses.

## Review hotspots

- Solana intentionally stays out of `chainMap`, which feeds wagmi and viem. It uses parallel chain metadata and Solana-specific clients instead.
- Solana identities remain full 32-byte values internally and display as base58; they must never pass through 20-byte EVM address helpers.
- Fill references must be validated using each output’s chain, not the order’s input chain.
- Marker-account reads assert the expected program owner rather than treating account existence alone as proof of state.
- Finalisation passes one attestation account per output in the original output order.
- Anchor event parsing tracks invoke frames so a forged `Program data:` log emitted by another program is rejected.

## Validation

- GitHub `unit`: passing
- GitHub `e2e`: passing
- Cloudflare preview deployment: passing
- `bun run check`: 0 errors and 0 warnings
- `bun run build`: passing
- Targeted Solana unit suite: 117 passing, 0 failing

Deployment facts and live RPC observations are recorded in `tests/fixtures/solana/PREFLIGHT.md`.

## Remaining production validation

- [ ] Record deployed program binary hashes and upgrade authorities, or confirm immutability, against the audited source.
- [ ] Confirm Solana-side `chain_mapping` PDAs for every offered EVM counterpart. Base ↔ Solana is already confirmed on the EVM side.
- [ ] Exercise Polymer’s Solana chain ID against the testnet API; mainnet is confirmed as `2`.
- [ ] Execute and save a finalized real devnet fill as `tests/fixtures/solana/tx-fill-devnet.json`.
- [ ] Exercise EVM → Solana, Solana → Solana, and Solana → EVM end to end, including negative and replay cases.
- [ ] Measure fill/finalise transaction-size headroom and enforce a safe issuance limit for multi-output orders.
- [ ] Complete a small-value mainnet canary before treating mainnet support as production-ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Solana support across wallet connection, quoting, order creation, filling, proof handling, and finalisation.
  * Added Phantom and Solflare wallet detection and connection flows.
  * Added support for SOL, SPL tokens, Solana balances, transactions, and Base58 references.
  * Added Solana transaction validation, event detection, proof verification, and status tracking.
  * Improved multi-chain quotes with chain-specific accounts and optional recipients.
* **Bug Fixes**
  * Prevented stale quote responses from updating the interface.
  * Added clearer validation and connection errors for unsupported or mismatched networks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->